### PR TITLE
Add a simple sir-trevor widget to include an image and title for a document.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ group :test do
   gem 'devise-guests'
   gem "bootstrap-sass"
   gem 'turbolinks'
+  gem 'jquery-rails'
 end
 
 if File.exists?('spec/test_app_templates/Gemfile.extra')

--- a/app/assets/javascripts/spotlight/application.js
+++ b/app/assets/javascripts/spotlight/application.js
@@ -12,6 +12,5 @@
 //
 //= require jquery
 //= require sir-trevor
-//= require spotlight/spotlight 
-//= require spotlight/search_result_block
-//= require spotlight/exhibits
+//= require spotlight/spotlight
+//= require_tree .

--- a/app/assets/javascripts/spotlight/record_thumbnail_block.js
+++ b/app/assets/javascripts/spotlight/record_thumbnail_block.js
@@ -1,0 +1,53 @@
+/*
+  Sir Trevor Records Block.
+  This block takes an array of record IDs,
+  fetches them from solr, and displays them.
+*/
+
+SirTrevor.Blocks.RecordThumbnail =  (function(){
+
+  var id_key = "record-thumbnail-id";
+  var title_key = "show-title";
+
+  var type = "record-thumbnail";
+
+  var template = _.template([
+    '<div class="form-inline">',
+      '<label for="' + id_key + '">Record ID:</label>',
+      '<input name="' + id_key + '"',
+      ' class="st-input-string form-control st-required ' + type + '" type="text" id="' + id_key + '" />',
+      '<label for"' + title_key + '">',
+        '<input name="' + title_key + '" type="hidden" value="false" />',
+        '<input name="' + title_key + '" id="' + title_key + '" type="checkbox" value="true" />',
+        'Show title?',
+      '</label>',
+      '<span class="help-block">The record ID of a document in this collection.',
+      'If you choose to show the title it will be displayed as a caption beneath the image.</span>',
+    '</div>'
+  ].join("\n"));
+
+  return SirTrevor.Block.extend({
+
+    type: type,
+
+    title: function() { return "Record Thumbnail"; },
+
+    editorHTML: function() {
+      return template(this);
+    },
+
+    icon_name: type,
+
+    toData: function() {
+      var data = {};
+      data[id_key] = this.$('#' + id_key).val();
+      data[title_key] = this.$('#' + title_key).is(':checked');
+      this.setData(data);
+    },
+
+    loadData: function(data){
+      this.$('#' + id_key).val(data[id_key]);
+      this.$('#' + title_key).prop('checked', data[title_key]);
+    }
+  });
+})();

--- a/app/assets/stylesheets/spotlight/record_thumbnail_block.css.scss
+++ b/app/assets/stylesheets/spotlight/record_thumbnail_block.css.scss
@@ -1,0 +1,4 @@
+.record-thumbnail {
+  &.form-control { width: auto; }
+  &.panel { display: inline-block; }
+}

--- a/app/controllers/spotlight/application_controller.rb
+++ b/app/controllers/spotlight/application_controller.rb
@@ -4,7 +4,7 @@ module Spotlight
   # Inherit from the host app's ApplicationController
   # This will configure e.g. the layout used by the host
   class ApplicationController < ::ApplicationController
+    include Blacklight::Catalog::SearchContext
     layout 'spotlight/spotlight'
-
   end
 end

--- a/app/controllers/spotlight/pages_controller.rb
+++ b/app/controllers/spotlight/pages_controller.rb
@@ -6,7 +6,7 @@ module Spotlight
 
     copy_blacklight_config_from(CatalogController)
 
-    helper_method :get_search_results
+    helper_method :get_search_results, :get_solr_response_for_doc_id
 
     before_action :set_page, only: [:show, :edit, :update, :destroy]
 

--- a/app/helpers/spotlight/pages_helper.rb
+++ b/app/helpers/spotlight/pages_helper.rb
@@ -1,4 +1,10 @@
 module Spotlight
   module PagesHelper
+    def has_title? document
+      document_heading(document) != document.id
+    end
+    def should_render_record_thumbnail_title? document, block
+      has_title?(document) && block["show-title"]
+    end
   end
 end

--- a/app/views/sir-trevor/blocks/_record_thumbnail_block.html.erb
+++ b/app/views/sir-trevor/blocks/_record_thumbnail_block.html.erb
@@ -1,0 +1,15 @@
+<%- document = get_solr_response_for_doc_id(block.values).last -%>
+<div>
+  <div class="record-thumbnail panel panel-default">
+    <%- if has_thumbnail? document -%>
+      <div class="panel-body">
+        <%= render_thumbnail_tag(document) %>
+      </div>
+    <%- end -%>
+    <%- if should_render_record_thumbnail_title?(document, block) -%>
+      <div class="panel-footer">
+        <%= document_heading(document).try(:join) %>
+      </div>
+    <%- end -%>
+  </div>
+</div>

--- a/spec/features/javascript/record_thumbnail_block_spec.rb
+++ b/spec/features/javascript/record_thumbnail_block_spec.rb
@@ -1,0 +1,55 @@
+require "spec_helper"
+
+feature "Record Thumbnail Block" do
+  scenario "should allow you to add a thumbnail to a page within an exhibit", :js => true do
+    # create page
+    visit spotlight.new_page_path
+    # fill in title
+    fill_in "page_title", :with => "Exhibit Title"
+    # click to add widget
+    find("[data-icon='add']").click
+    # click the Record Thumbnail widget
+    expect(page).to have_css("a[data-type='record-thumbnail']")
+    find("a[data-type='record-thumbnail']").click
+    # fill in the record ID field
+    expect(page).to have_css("input#record-thumbnail-id")
+    fill_in "record-thumbnail-id", :with => "dq287tq6352"
+    # create the page
+    click_button("Create Page")
+    # veryify that the page was created
+    expect(page).to have_content("Page was successfully created.")
+    # veryify that the record thumbnail widget is displaying an image from the document.
+    within(:css, ".panel.record-thumbnail") do
+      expect(page).to have_css(".panel-body")
+      expect(page).to have_css(".panel-body a img")
+      expect(page).not_to have_css(".panel-footer")
+    end
+  end
+  scenario "should allow you to optionally display the title with the image", :js => true do
+    # create page
+    visit spotlight.new_page_path
+    # fill in title
+    fill_in "page_title", :with => "Exhibit Title"
+    # click to add widget
+    find("[data-icon='add']").click
+    # click the Record Thumbnail widget
+    expect(page).to have_css("a[data-type='record-thumbnail']")
+    find("a[data-type='record-thumbnail']").click
+    # fill in the record ID field
+    expect(page).to have_css("input#record-thumbnail-id")
+    fill_in "record-thumbnail-id", :with => "dq287tq6352"
+    # display the title
+    check("Show title?")
+    # create the page
+    click_button("Create Page")
+    # veryify that the page was created
+    expect(page).to have_content("Page was successfully created.")
+    # veryify that the record thumbnail widget is displaying image and title from the requested document.
+    within(:css, ".panel.record-thumbnail") do
+      expect(page).to have_css(".panel-body")
+      expect(page).to have_css(".panel-body a img")
+      expect(page).to have_css(".panel-footer")
+      expect(page).to have_content("L'AMERIQUE")
+    end
+  end
+end

--- a/spec/helpers/spotlight/pages_helper_spec.rb
+++ b/spec/helpers/spotlight/pages_helper_spec.rb
@@ -1,17 +1,30 @@
 require 'spec_helper'
 
-# Specs in this file have access to a helper object that includes
-# the PagesHelper. For example:
-#
-# describe PagesHelper do
-#   describe "string concat" do
-#     it "concats two strings with spaces" do
-#       expect(helper.concat_strings("this","that")).to eq("this that")
-#     end
-#   end
-# end
 module Spotlight
   describe PagesHelper do
-    pending "add some examples to (or delete) #{__FILE__}"
+    let(:blacklight_config) { OpenStruct.new( :show => OpenStruct.new( :heading => :abc ) ) }
+    let(:titled_document)   { SolrDocument.new( :abc => "value" ) }
+    let(:untitled_document) { SolrDocument.new( :id  => "1234"  ) }
+    before(:each) { helper.stub(:blacklight_config => blacklight_config) }
+
+    describe "has_title?" do
+      it "should return true if the title is not the same as the ID" do
+        expect(helper.has_title? titled_document).to be_true
+      end
+      it "should return false if the document heading returned is the same as the ID (indicating there is no title)" do
+        expect(helper.has_title? untitled_document).to be_false
+      end
+    end
+    describe "should_render_record_thumbnail_title?" do
+      it "should return true if there is a title" do
+        expect(helper.should_render_record_thumbnail_title?(titled_document, {'show-title' => true})).to be_true
+      end
+      it "should return false there is no title" do
+        expect(helper.should_render_record_thumbnail_title?(untitled_document, {'show-title' => true})).to be_false
+      end
+      it "should return false if the block configuration is hiding the title" do
+        expect(helper.should_render_record_thumbnail_title?(titled_document, {'show-title' => false})).to be_false
+      end
+    end
   end
 end


### PR DESCRIPTION
This widget currently will just take a known ID of a document in the local
index and display the configured title and image thumbnail.

There is a checkbox to configure weather to show the title or not in
case the user just wants the image for a document that has a title.

Fixes #33 

![screen shot 2014-01-29 at 3 32 31 pm](https://f.cloud.github.com/assets/96776/2035753/b100978c-893e-11e3-8319-55273741065b.png)

![screen shot 2014-01-29 at 3 32 23 pm](https://f.cloud.github.com/assets/96776/2035754/b51df5c6-893e-11e3-9cdb-5d54c9ce934b.png)
