### PR TITLE
Pages#show throws error when the body of the page object is blank.

### DIFF
--- a/app/views/spotlight/pages/show.html.erb
+++ b/app/views/spotlight/pages/show.html.erb
@@ -4,6 +4,6 @@
 </h1>
 
 <div>
-  <%= render_sir_trevor @page.content %>
+  <%= render_sir_trevor(@page.content) unless @page.content.blank? %>
 </div>
 

--- a/spec/integration/create_page_spec.rb
+++ b/spec/integration/create_page_spec.rb
@@ -1,0 +1,10 @@
+require "spec_helper"
+
+describe "Creating a page", :type => :feature do
+  it "should be possible with only a title" do
+    visit spotlight.new_page_path
+    fill_in "page_title", :with => "New Page Title!"
+    click_button "Create Page"
+    expect(page).to have_content "Page was successfully created."
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,4 +22,5 @@ RSpec.configure do |config|
   config.include Devise::TestHelpers, type: :controller
   config.include Devise::TestHelpers, type: :view
   config.include Controllers::EngineHelpers, type: :controller
+  config.include Capybara::DSL
 end


### PR DESCRIPTION
The error comes from sir-trevor attempting to render empty json.

This change just checks if the page body is blank and doesn't attempt to pass it to sir-trevor for rendering.

Fixes #45 
