### PR TITLE
convert other solr-field backed blacklight configuration fields to serialize as hashes with an enabled flag

### DIFF
--- a/app/controllers/spotlight/exhibits_controller.rb
+++ b/app/controllers/spotlight/exhibits_controller.rb
@@ -35,19 +35,20 @@ class Spotlight::ExhibitsController < Spotlight::ApplicationController
       :description,
       contact_emails_attributes: [:email],
       blacklight_configuration_attributes: [
-        facet_fields: [exhibit_configuration_facet_params(@exhibit.blacklight_configuration.default_blacklight_config.facet_fields.keys)],
-        index_fields: [exhibit_configuration_index_params(@exhibit.blacklight_configuration.default_blacklight_config.view.keys)], 
-        show_fields: []
+        facet_fields: [exhibit_configuration_facet_params],
+        index_fields: [exhibit_configuration_index_params]
       ]
     )
   end
 
-  def exhibit_configuration_index_params arr
-    arr.inject({}) { |result, element| result[element] = []; result }
+  def exhibit_configuration_index_params
+    views = @exhibit.blacklight_configuration.default_blacklight_config.view.keys | [:show]
+
+    @exhibit.blacklight_configuration.default_blacklight_config.index_fields.keys.inject({}) { |result, element| result[element] = ([:enabled] | views); result }
   end
 
-  def exhibit_configuration_facet_params arr
-    arr.inject({}) { |result, element| result[element] = [:enabled, :label]; result }
+  def exhibit_configuration_facet_params
+    @exhibit.blacklight_configuration.default_blacklight_config.facet_fields.keys.inject({}) { |result, element| result[element] = [:enabled, :label]; result }
   end
 
   def default_exhibit

--- a/app/models/spotlight/blacklight_configuration.rb
+++ b/app/models/spotlight/blacklight_configuration.rb
@@ -5,8 +5,7 @@ module Spotlight
     has_one :exhibit
     serialize :facet_fields, Hash
     serialize :index_fields, Hash
-    serialize :show_fields, Array
-    serialize :sort_fields, Array
+    serialize :sort_fields, Hash
     serialize :default_solr_params, Hash
     serialize :show, Hash
     serialize :index, Hash
@@ -15,17 +14,27 @@ module Spotlight
 
     # get rid of empty values
     before_validation do |model|
-      model.facet_fields.each do |k,v|
-        v[:enabled] = (v[:enabled] == "1")
-        v.reject! { |k, v1| v1.blank? and !v1 === false }
-      end if model.facet_fields
 
-      model.index_fields.each do |k, v|
-        v.reject!(&:blank?)
+      model.index_fields.each do |k,v|
+        v[:enabled] ||= v.any? { |k1, v1| !v1.blank? }
+
+        default_blacklight_config.view.keys.each do |view|
+          v[view] &&= (v[view] == "1")
+        end
+
+        v[:show] &&= (v[:show] == "1")
+
+        v.reject! { |k, v1| v1.blank? and !v1 === false }
       end if model.index_fields
 
-      model.show_fields.reject!(&:blank?) if model.show_fields
-      model.sort_fields.reject!(&:blank?) if model.sort_fields
+      [:facet_fields, :sort_fields].each do |field|
+        model.send(field).each do |k,v|
+          v[:enabled] &&= (v[:enabled] == "1")
+          v[:enabled] ||= true if v[:enabled].nil?
+          v.reject! { |k, v1| v1.blank? and !v1 === false }
+        end if model.send(field)
+      end
+
       model.per_page.reject!(&:blank?) if model.per_page
       model.document_index_view_types.reject!(&:blank?) if model.document_index_view_types
     end
@@ -35,7 +44,7 @@ module Spotlight
     # appropriate to the current view. If a value isn't set in this record,
     # it will use the configuration set upstream (in default_blacklight_config)
     # @param [String] view the configuration may be different depending on the index view selected
-    def blacklight_config view = nil
+    def blacklight_config view = :list
       config = default_blacklight_config.inheritable_copy
 
       config.show.merge! show unless show.blank?
@@ -43,15 +52,55 @@ module Spotlight
 
       config.default_solr_params = config.default_solr_params.merge(default_solr_params)
 
-      config.index_fields = config.index_fields.slice *index_fields_for_view(view) unless index_fields_for_view(view).blank?
-      config.show_fields = config.show_fields.slice *show_fields unless show_fields.blank?
-      config.sort_fields = config.sort_fields.slice *sort_fields unless sort_fields.blank?
       
+      show_fields = index_fields_for_view(:show)
+      unless show_fields.blank?
+        active_show_fields = show_fields.select { |k,v| v[:enabled] == true }
+        config.show_fields = config.index_fields.slice *active_show_fields.keys
+        config.show_fields = Hash[config.show_fields.sort_by { |k,v| active_show_fields.keys.index k }]
+
+        config.index_fields.each do |k, v|
+          next if show_fields[k].blank?
+
+          v.merge! show_fields[k].symbolize_keys
+          v.normalize! config
+          v.validate!
+        end
+      end
+
+      unless index_fields_for_view(view).blank?
+        active_index_fields = index_fields_for_view(view).select { |k,v| v[:enabled] == true }
+        config.index_fields.slice! *active_index_fields.keys
+        config.index_fields = Hash[config.index_fields.sort_by { |k,v| active_index_fields.keys.index k }]
+
+        config.index_fields.each do |k, v|
+          next if index_fields[k].blank?
+
+          v.merge! index_fields[k].symbolize_keys
+          v.normalize! config
+          v.validate!
+        end
+      end
+
+      unless sort_fields.blank?
+        active_sort_fields = sort_fields.select { |k,v| v[:enabled] == true }
+        config.sort_fields.slice! *active_sort_fields.keys
+        config.sort_fields = Hash[config.sort_fields.sort_by { |k,v| active_sort_fields.keys.index k }]
+
+        config.sort_fields.each do |k, v|
+          next if sort_fields[k].blank?
+
+          v.merge! sort_fields[k].symbolize_keys
+          v.normalize! config
+          v.validate!
+        end
+      end
+
       unless facet_fields.blank?
         active_facet_fields = facet_fields.select { |k,v| v[:enabled] == true }
         config.facet_fields.slice! *active_facet_fields.keys
         config.facet_fields = Hash[config.facet_fields.sort_by { |k,v| active_facet_fields.keys.index k }]
-        
+
         config.facet_fields.each do |k, v|
           next if facet_fields[k].blank?
 
@@ -69,16 +118,21 @@ module Spotlight
 
     def all_facet_fields
       default_blacklight_config.facet_fields.sort_by { |k,v| facet_fields.keys.index k }
+    end
 
-
+    def all_index_fields
+      default_blacklight_config.index_fields.sort_by { |k,v| index_fields.keys.index k }
     end
 
     ##
     # Get the index fields that should be visible for the given view; if the view is
     # not found, just use the list view.
     # @param [String] view 
-    def index_fields_for_view view
-      index_fields.fetch(view, index_fields[:list])
+    def index_fields_for_view view = :list
+      index_fields.select do |key, config|
+        config.with_indifferent_access[:enabled] &&
+          config.with_indifferent_access[view]
+      end
     end
 
     ##

--- a/app/views/spotlight/exhibits/edit_metadata_fields.html.erb
+++ b/app/views/spotlight/exhibits/edit_metadata_fields.html.erb
@@ -13,20 +13,34 @@
       </div>
     </div>
 
-   <%= f.fields_for :blacklight_configuration, @exhibit.blacklight_configuration do |c| %>
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th><%= t :'spotlight.curation.metadata_fields.label' %></th>
+          <th><%= t :'spotlight.curation.metadata_fields.view.show', default: t(:'blacklight.search.view.show') %></th>
+          <% @exhibit.blacklight_configuration.default_blacklight_config.view.keys.each do |type| %>
 
-      <div class="row">
-        <%= c.select :show_fields, options_for_select(Spotlight::CatalogController.blacklight_config.show_fields.map { |k,v| [v.label,k] }, @exhibit.blacklight_configuration.show_fields), { }, multiple: true %> 
-      </div>
-
-      <%= c.fields_for :index_fields do |idxf| %>
-        <% @exhibit.blacklight_configuration.default_blacklight_config.view.keys.each do |type| %>
-          <div class="row">
-            <%= idxf.select type, options_for_select(Spotlight::CatalogController.blacklight_config.index_fields.map { |k,v| [v.label,k] }, @exhibit.blacklight_configuration.index_fields_for_view(type)), { }, multiple: true %> 
-          </div>
+          <th><%= t "spotlight.curation.metadata_fields.view.#{type}", default: t("blacklight.search.view.#{type}") %></th>
+          <% end %>
+        </tr>
+      </thead>
+      <tbody>
+     <%= f.fields_for :blacklight_configuration, @exhibit.blacklight_configuration do |c| %>
+        <%= c.fields_for :index_fields do |idxf| %>
+          <% @exhibit.blacklight_configuration.all_index_fields.each do |key, config| %>
+              <tr>
+                <%= idxf.fields_for key do |field| %>
+                  <td><%= config.label %></td>
+                  <td><%= field.check_box :show, checked: (@exhibit.blacklight_configuration.index_fields[key] || {})[:show], label: "" %></td>
+                  <% @exhibit.blacklight_configuration.default_blacklight_config.view.keys.each do |type| %>
+                  <td><%= field.check_box type, checked: (@exhibit.blacklight_configuration.index_fields[key] || {})[type], label: "" %></td>
+                  <% end %>
+                <% end %>
+              </tr>
+          <% end %>
         <% end %>
-      <% end %>
-
-   <% end %>
+     <% end %>
+     </tbody>
+   </table>
 <% end %>
 </div>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -34,6 +34,9 @@ en:
       header: "Curation"
       metadata_fields:
         header: "Metadata Fields"
+        label: "Field name"
+        view:
+          show: "Item Details"
       facet_fields:
         header: "Search Facets"
         options:

--- a/db/migrate/20140130215634_create_spotlight_blacklight_configurations.rb
+++ b/db/migrate/20140130215634_create_spotlight_blacklight_configurations.rb
@@ -3,7 +3,6 @@ class CreateSpotlightBlacklightConfigurations < ActiveRecord::Migration
     create_table :spotlight_blacklight_configurations do |t|
       t.text :facet_fields
       t.text :index_fields
-      t.text :show_fields
       t.text :search_fields
       t.text :sort_fields
       t.text :default_solr_params

--- a/spec/controllers/spotlight/exhibits_controller_spec.rb
+++ b/spec/controllers/spotlight/exhibits_controller_spec.rb
@@ -48,6 +48,7 @@ describe Spotlight::ExhibitsController do
 
     describe "#edit_facet_fields" do
       it "should be successful" do
+        controller.stub_chain(:blacklight_solr, :get).and_return({})
         get :edit_facet_fields, id: exhibit
         expect(response).to be_successful
       end
@@ -68,12 +69,21 @@ describe Spotlight::ExhibitsController do
       end
 
       it "should update metadata fields" do
-        patch :update, id: exhibit, exhibit: { blacklight_configuration_attributes: { show_fields: ['c', 'd'], index_fields: { list: ['e', 'f']} }}
+        exhibit.blacklight_configuration.default_blacklight_config.stub(index_fields: { 'a' => {},  'b' => {},  'c' => {}, 'd' => {},  'e' => {}, 'f' => {} })
+        patch :update, id: exhibit, exhibit: { blacklight_configuration_attributes: {
+          index_fields: {
+            c: { enabled: true, show: true},
+            d: { enabled: true, show: true},
+            e: { enabled: true, list: true},
+            f: { enabled: true, list: true}
+          }
+          }
+        }
+
         expect(flash[:notice]).to eq "The exhibit was saved."
         expect(response).to redirect_to main_app.root_path
         assigns[:exhibit].tap do |saved|
-          expect(saved.blacklight_configuration.show_fields).to eq ['c', 'd']
-          expect(saved.blacklight_configuration.index_fields['list']).to eq ['e', 'f']
+          expect(saved.blacklight_configuration.index_fields).to include 'c', 'd', 'e', 'f'
         end
       end
 

--- a/spec/features/exhibits/edit_metadata_fields_spec.rb
+++ b/spec/features/exhibits/edit_metadata_fields_spec.rb
@@ -15,12 +15,16 @@ describe "Editing metadata fields", type: :feature do
     expect(page).to have_content "Curation Metadata Fields"
     expect(page).to have_button "Save"
 
-    select "Language", from: "List"
-    select "Type", from: "List"
+    check :exhibit_blacklight_configuration_attributes_index_fields_language_ssm_show
+    check :exhibit_blacklight_configuration_attributes_index_fields_language_ssm_list
+
+    check :exhibit_blacklight_configuration_attributes_index_fields_abstract_tesim_show
+    check :exhibit_blacklight_configuration_attributes_index_fields_note_mapuse_tesim_list
 
     click_on "Save changes"
 
     expect(Spotlight::Exhibit.default.blacklight_config('list').index_fields).to include("language_ssm", "note_mapuse_tesim")
     expect(Spotlight::Exhibit.default.blacklight_config('list').index_fields).to have(2).fields
+    expect(Spotlight::Exhibit.default.blacklight_config.show_fields).to include("language_ssm", "abstract_tesim")
   end
 end

--- a/spec/models/spotlight/blacklight_configuration_spec.rb
+++ b/spec/models/spotlight/blacklight_configuration_spec.rb
@@ -17,7 +17,7 @@ describe Spotlight::BlacklightConfiguration do
     end
 
     it "should filter blank values" do
-      subject.facet_fields["title_facet"] = { :something => ""}
+      subject.facet_fields["title_facet"] = { something: "" }
       subject.valid?
       expect(subject.facet_fields["title_facet"].keys).to_not include :something
     end
@@ -26,7 +26,7 @@ describe Spotlight::BlacklightConfiguration do
       subject.facet_fields['a'] = { enabled: true }
       subject.facet_fields['b'] = { enabled: false }
       subject.facet_fields['d'] = { enabled: true }
-      
+
       blacklight_config.add_facet_field 'a'
       blacklight_config.add_facet_field 'b'
       blacklight_config.add_facet_field 'c'
@@ -37,68 +37,67 @@ describe Spotlight::BlacklightConfiguration do
     end
   end
 
-  describe "show fields" do
-    it "should have show fields" do
-      expect(subject.show_fields).to be_empty
-      subject.show_fields << 'title' << 'author'
-      expect(subject.show_fields).to eq ['title', 'author']
-    end
-
-    it "should filter blank values" do
-      subject.show_fields << ""
-      subject.valid?
-      expect(subject.show_fields).to_not include ""
-    end
-
-    it "should filter the upstream blacklight config" do
-      subject.show_fields = ['a', 'c', 'd']
-      blacklight_config.add_show_field 'a'
-      blacklight_config.add_show_field 'b'
-      blacklight_config.add_show_field 'c'
-
-      expect(subject.blacklight_config.show_fields).to include('a', 'c')
-      expect(subject.blacklight_config.show_fields).to_not include('b')
-      expect(subject.blacklight_config.show_fields).to have(2).fields
-    end
-  end
-
   describe "index fields" do
+
     it "should have index fields" do
       expect(subject.index_fields).to be_empty
-      subject.index_fields = { list: ['title', 'author'] }
-      expect(subject.index_fields[:list]).to eq ['title', 'author']
+      subject.index_fields['title'] = {}
+      subject.index_fields['author'] = {}
+      expect(subject.index_fields.keys).to eq ['title', 'author']
     end
 
     it "should filter blank values" do
-      subject.index_fields = { list: ['title', 'author'] }
+      subject.index_fields['title'] = { something: "" }
       subject.valid?
-      expect(subject.index_fields[:list]).to_not include ""
+      expect(subject.index_fields["title"].keys).to_not include :something
     end
 
     it "should filter the upstream blacklight config" do
-      subject.index_fields = { list: ['a', 'c', 'd'] }
+      subject.index_fields['a'] = { enabled: true, list: true }
+      subject.index_fields['c'] = { enabled: false, list: false }
+      subject.index_fields['d'] = { enabled: true, list: true }
+
       blacklight_config.add_index_field 'a'
       blacklight_config.add_index_field 'b'
       blacklight_config.add_index_field 'c'
 
-      expect(subject.blacklight_config.index_fields).to include('a', 'c')
-      expect(subject.blacklight_config.index_fields).to_not include('b')
-      expect(subject.blacklight_config.index_fields).to have(2).fields
+      expect(subject.blacklight_config.index_fields).to include('a')
+      expect(subject.blacklight_config.index_fields).to_not include('b', 'd')
+      expect(subject.blacklight_config.index_fields).to have(1).fields
     end
 
-    it "should filter the upstream blacklight config with the correct view type" do
-      subject.index_fields = { list: ['a', 'c', 'e'], gallery: ['b', 'd'] }
+    it "should filter the upstream blacklight config" do
+      subject.index_fields['a'] = { enabled: true, list: true, gallery: false }
+      subject.index_fields['b'] = { enabled: true, list: false, gallery: true }
+      subject.index_fields['c'] = { enabled: false, list: true, gallery: false }
+      subject.index_fields['d'] = { enabled: true, list: false, gallery: true }
+      subject.index_fields['e'] = { enabled: true, list: true, gallery: false }
+
       blacklight_config.add_index_field 'a'
       blacklight_config.add_index_field 'b'
       blacklight_config.add_index_field 'c'
       blacklight_config.add_index_field 'd'
 
-      expect(subject.blacklight_config(:list).index_fields).to include('a', 'c')
+      expect(subject.blacklight_config(:list).index_fields).to include('a')
       expect(subject.blacklight_config(:gallery).index_fields).to include('b', 'd')
       expect(subject.blacklight_config(:list).index_fields).to_not include('b', 'd')
       expect(subject.blacklight_config(:gallery).index_fields).to_not include('a', 'c')
-      expect(subject.blacklight_config(:list).index_fields).to have(2).fields
+      expect(subject.blacklight_config(:list).index_fields).to have(1).fields
       expect(subject.blacklight_config(:gallery).index_fields).to have(2).fields
+    end
+
+    it "should filter the upstream blacklight config for show fields" do
+      subject.index_fields['a'] = { enabled: true, show: true }
+      subject.index_fields['c'] = { enabled: false, show: false }
+      subject.index_fields['d'] = { enabled: true, show: false }
+
+      blacklight_config.add_index_field 'a'
+      blacklight_config.add_index_field 'b'
+      blacklight_config.add_index_field 'c'
+
+      expect(subject.blacklight_config.show_fields).to include('a')
+      expect(subject.blacklight_config.show_fields).to_not include('b', 'd')
+      expect(subject.blacklight_config.show_fields).to have(1).fields
     end
   end
 
@@ -106,18 +105,22 @@ describe Spotlight::BlacklightConfiguration do
   describe "sort fields" do
     it "should have sort fields" do
       expect(subject.sort_fields).to be_empty
-      subject.sort_fields << 'title' << 'author'
-      expect(subject.sort_fields).to eq ['title', 'author']
+      subject.sort_fields['title'] = {}
+      subject.sort_fields['author'] = {}
+      expect(subject.sort_fields.keys).to eq ['title', 'author']
     end
 
     it "should filter blank values" do
-      subject.sort_fields << ""
+      subject.sort_fields['title'] = { something: "" }
       subject.valid?
-      expect(subject.sort_fields).to_not include ""
+      expect(subject.sort_fields['title'].keys).to_not include :something
     end
 
     it "should filter the upstream blacklight config" do
-      subject.sort_fields = ['a', 'c', 'd']
+      subject.sort_fields['a'] = { enabled: true }
+      subject.sort_fields['c'] = { enabled: true }
+      subject.sort_fields['d'] = { enabled: true }
+
       blacklight_config.add_sort_field 'a'
       blacklight_config.add_sort_field 'b'
       blacklight_config.add_sort_field 'c'


### PR DESCRIPTION
In the process:
- remove the blacklight configuration show_fields; use a flag on the
  index_fields instead
- update the metadata fields edit form to use checkboxes for the different
  results views (fixes #69)
