### PR TITLE
Scope 'Curated Feature' links in exhibit nav to published pages only.

### DIFF
--- a/app/models/spotlight/exhibit.rb
+++ b/app/models/spotlight/exhibit.rb
@@ -36,7 +36,7 @@ class Spotlight::Exhibit < ActiveRecord::Base
   end
 
   def main_about_page
-    about_pages.first
+    about_pages.published.first
   end
 
   def home_page

--- a/app/views/shared/_exhibit_navbar.html.erb
+++ b/app/views/shared/_exhibit_navbar.html.erb
@@ -1,5 +1,5 @@
 <% if current_exhibit -%>
-<% top_level_feature_pages = current_exhibit.feature_pages.at_top_level -%>
+<% published_top_level_feature_pages = current_exhibit.feature_pages.published.at_top_level -%>
 <div id="exhibit-navbar" class="navbar navbar-default navbar-static-top" role="navigation">
   <div class="container">
     <ul class="nav navbar-nav">
@@ -8,12 +8,12 @@
       <% else %>
         <li class="<%= "active" if current_page?(root_url) %>"><%= link_to t(:'spotlight.curation.home.nav_catalog_link'), root_url %></li>
       <% end %>
-      <% unless top_level_feature_pages.empty? %>
-        <% if top_level_feature_pages.length > 1 %>
+      <% unless published_top_level_feature_pages.empty? %>
+        <% if published_top_level_feature_pages.length > 1 %>
         <li class="dropdown">
           <a href="#" class="dropdown-toggle" data-toggle="dropdown"><%= t(:'spotlight.curation.feature_pages.nav_link') %> <b class="caret"></b></a>
           <ul class="dropdown-menu">
-            <% top_level_feature_pages.each do |page| %>
+            <% published_top_level_feature_pages.each do |page| %>
               <li>
               <%= link_to page.title, [spotlight, page] %>
               </li>
@@ -21,7 +21,7 @@
           </ul>
         </li>
         <% else %>
-        <li class="<%= "active" if current_page?(url_for([spotlight, top_level_feature_pages.first])) %>"><%= link_to top_level_feature_pages.first.title, [spotlight, top_level_feature_pages.first] %></li>
+        <li class="<%= "active" if current_page?(url_for([spotlight, published_top_level_feature_pages.first])) %>"><%= link_to published_top_level_feature_pages.first.title, [spotlight, published_top_level_feature_pages.first] %></li>
         <% end %>
       <% end %>
       <% if current_exhibit.has_browse_categories? %>

--- a/spec/views/shared/_exhibit_navbar.html.erb_spec.rb
+++ b/spec/views/shared/_exhibit_navbar.html.erb_spec.rb
@@ -4,7 +4,9 @@ module Spotlight
   describe "shared/_exhibit_navbar" do
     let(:current_exhibit) {  Spotlight::Exhibit.default }
     let(:feature_page) { FactoryGirl.create(:feature_page) }
+    let(:unpublished_feature_page) { FactoryGirl.create(:feature_page, published: false) }
     let(:about_page) { FactoryGirl.create(:about_page) }
+    let(:unpublished_about_page) { FactoryGirl.create(:about_page, published: false) }
 
     before :each do
       view.stub(current_exhibit: current_exhibit)
@@ -43,6 +45,12 @@ module Spotlight
       expect(response).to_not have_link "Curated Features"
     end
 
+    it "should not display links to feature pages that are not published" do
+      unpublished_feature_page
+      render
+      expect(response).to_not have_link "Curated Features"
+    end
+
     it "should link to the browse index" do
       FactoryGirl.create :search
       render
@@ -68,6 +76,12 @@ module Spotlight
     end
 
     it "should not link to the about page if no about page exists" do
+      render
+      expect(response).to_not have_link "About"
+    end
+
+    it "should not to the about page if none are published" do
+      unpublished_about_page
       render
       expect(response).to_not have_link "About"
     end


### PR DESCRIPTION
@cbeer I defer to you on this.  I noticed that #117 only showed published child pages in the sidebar of feature and about pages so I thought that we should mimic that behavior in the top level nav.

This is a random PR that you very well may already be working on so feel free to close this w/o merging if you already have code to do this.
