### PR TITLE
Consolidate all of the page_model pluralization into a page_collection_name helper.

### DIFF
--- a/app/controllers/spotlight/about_pages_controller.rb
+++ b/app/controllers/spotlight/about_pages_controller.rb
@@ -3,7 +3,7 @@ module Spotlight
 
     private
     def page_model
-      "about_page"
+      :about_page
     end
     def cast_page_instance_variable
       if @about_pages

--- a/app/controllers/spotlight/feature_pages_controller.rb
+++ b/app/controllers/spotlight/feature_pages_controller.rb
@@ -3,7 +3,7 @@ module Spotlight
 
     private
     def page_model
-      "feature_page"
+      :feature_page
     end
     def cast_page_instance_variable
       if @feature_pages

--- a/app/controllers/spotlight/home_pages_controller.rb
+++ b/app/controllers/spotlight/home_pages_controller.rb
@@ -6,7 +6,7 @@ module Spotlight
 
     private
     def page_model
-      "home_page"
+      :home_page
     end
     def cast_page_instance_variable
       if @home_pages

--- a/app/controllers/spotlight/pages_controller.rb
+++ b/app/controllers/spotlight/pages_controller.rb
@@ -13,7 +13,7 @@ module Spotlight
 
     copy_blacklight_config_from(CatalogController)
 
-    helper_method :get_search_results, :get_solr_response_for_doc_id, :page_model
+    helper_method :get_search_results, :get_solr_response_for_doc_id, :page_model, :page_collection_name
 
     # GET /exhibits/1/pages
     def index
@@ -36,7 +36,7 @@ module Spotlight
       @page.attributes = page_params
 
       if @page.save
-        redirect_to [@page.exhibit, page_model.pluralize.to_sym], notice: 'Page was successfully created.'
+        redirect_to [@page.exhibit, page_collection_name], notice: 'Page was successfully created.'
       else
         render action: 'new'
       end
@@ -45,7 +45,7 @@ module Spotlight
     # PATCH/PUT /pages/1
     def update
       if @page.update(page_params)
-        redirect_to [@page.exhibit, page_model.pluralize.to_sym], notice: 'Page was successfully updated.'
+        redirect_to [@page.exhibit, page_collection_name], notice: 'Page was successfully updated.'
       else
         render action: 'edit'
       end
@@ -69,11 +69,11 @@ module Spotlight
     protected
 
     def update_all_page_params
-      params.require(:exhibit).permit("#{page_model.pluralize}_attributes" => [:id, :published, :title, :weight, :display_sidebar, :parent_page_id ])
+      params.require(:exhibit).permit("#{page_collection_name}_attributes" => [:id, :published, :title, :weight, :display_sidebar, :parent_page_id ])
     end
 
     def human_name
-      page_model.pluralize.humanize
+      page_collection_name.to_s.humanize
     end
 
     private
@@ -81,9 +81,12 @@ module Spotlight
       def page_model
         ""
       end
+      def page_collection_name
+        page_model.to_s.pluralize.to_sym
+      end
       # Only allow a trusted parameter "white list" through.
       def page_params
-        params.require(page_model.to_sym).permit(:title, :content)
+        params.require(page_model).permit(:title, :content)
       end
   end
 end

--- a/app/helpers/spotlight/application_helper.rb
+++ b/app/helpers/spotlight/application_helper.rb
@@ -26,10 +26,6 @@ module Spotlight
       main_app_url_helper?(method) or super
     end
 
-    def update_pages_path(exhibit, model=page_model)
-      model == 'feature_page' ? update_all_exhibit_feature_pages_path(exhibit) : update_all_exhibit_about_pages_path(exhibit)
-    end
-
     private
 
     def main_app_url_helper?(method)

--- a/app/views/spotlight/pages/_page.html.erb
+++ b/app/views/spotlight/pages/_page.html.erb
@@ -21,7 +21,6 @@
         <%= f.text_field :title, label: t('spotlight.administration.page_title') %>
         <%= f.hidden_field :id %>
         <%= f.hidden_field :weight, data: {property: "weight"} %>
-        <!--<input type="hidden" id="page_<%= page.id %>_weight" name="pages[<%= page_model %>][<%= page.id %>][weight]" value="<%= page.weight %>" />-->
         <%- if page.feature_page? -%>
           <div class="col-sm-offset-2 col-sm-10">
             <%= f.hidden_field :parent_page_id, data: {property: "parent_page"} %>
@@ -34,7 +33,7 @@
   <% if page.feature_page? and page.child_pages.present? %>
     <ol class="dd-list">
       <% page.child_pages.each do |child_page| %>
-        <%= parent_form.fields_for page_model.pluralize.to_sym, child_page do |p| %>
+        <%= parent_form.fields_for page_collection_name, child_page do |p| %>
           <%= render partial: 'page', locals: {f: p, parent_form: parent_form} %>
         <% end %>
       <% end %>

--- a/app/views/spotlight/pages/index.html.erb
+++ b/app/views/spotlight/pages/index.html.erb
@@ -1,19 +1,19 @@
 <%= render 'spotlight/shared/curation_sidebar' %>
 <div id="content" class="col-md-9">
-  <% @page_title = t :"spotlight.curation.#{page_model.pluralize}.header" %>
-  <%= bootstrap_form_for @exhibit, url: update_pages_path(@exhibit), style: :horizontal, right: "col-sm-10" do |f| %>
+  <% @page_title = t :"spotlight.curation.#{page_collection_name}.header" %>
+  <%= bootstrap_form_for @exhibit, url: polymorphic_path([:update_all, @exhibit, page_collection_name]), style: :horizontal, right: "col-sm-10" do |f| %>
     <h1><%= t :'spotlight.curation.header' %></h1>
     <div class="col-xs-2 pull-right">
-      <%= button_tag(t(:"spotlight.curation.#{page_model.pluralize}.update"), class: "btn btn-default") %>
+      <%= button_tag(t(:"spotlight.curation.#{page_collection_name}.update"), class: "btn btn-default") %>
     </div>
-    <h2 class="text-muted clearfix"><%= t :"spotlight.curation.#{page_model.pluralize}.header" %></h2>
+    <h2 class="text-muted clearfix"><%= t :"spotlight.curation.#{page_collection_name}.header" %></h2>
 
     <%= render partial: 'header' %>
     <h3>Defined Pages</h3>
     <p>Select the pages you want to be shown. Drag and drop pages to change the order in which they are displayed in the sidebar.</p>
     <div class="panel-group dd <%= page_model %>_admin" id="nested-pages">
       <ol class="dd-list">
-        <%= f.fields_for page_model.pluralize.to_sym do |p| %>
+        <%= f.fields_for page_collection_name do |p| %>
           <%- if p.object.about_page? || p.object.top_level_page? -%>
             <%= render partial: 'page', locals: {f: p, parent_form: f} %>
           <%- end -%>
@@ -22,6 +22,6 @@
     </div>
   <%- end -%>
   <div>
-    <%= link_to t(:'helpers.submit.new', :model => "Page"), new_polymorphic_path([@exhibit, page_model.to_sym]), class: 'btn btn-primary' %>
+    <%= link_to t(:'helpers.submit.new', :model => "Page"), new_polymorphic_path([@exhibit, page_model]), class: 'btn btn-primary' %>
   </div>
 </div>

--- a/spec/views/spotlight/pages/index.html.erb_spec.rb
+++ b/spec/views/spotlight/pages/index.html.erb_spec.rb
@@ -16,9 +16,10 @@ describe "spotlight/pages/index.html.erb" do
   let(:exhibit) { stub_model(Spotlight::Exhibit) }
   before do
     exhibit.stub(:feature_pages).and_return pages
-    view.stub(:page_model).and_return("feature_page")
-    view.stub(:update_pages_path).and_return("/update")
+    view.stub(:page_model).and_return(:feature_page)
+    view.stub(:page_collection_name).and_return(:feature_pages)
     view.stub(:new_exhibit_feature_page_path).and_return("/exhibit/features")
+    view.stub(:update_all_exhibit_feature_pages_path).and_return("/exhibit/features/update_all")
     assign(:exhibit, exhibit)
   end
 


### PR DESCRIPTION
This also removes the `update_pages_path` helper in favor of a polymorphic path.

@jcoyne I found a few instances where we were need the singularized version.  Also the symbol vs. string differences in using inflections made the few lines where we would have to singularize exceptionally nasty looking.

So instead I have changed the return value of the helper to a symbol and added a new helper that pluralizes the `page_model` and use that around the application where necessary.  I suppose I could have done the reverse (have the controllers override the pluralized version and then the helper singularizes that) but I'm not sure there is a difference in approach.
