### PR TITLE
Allow the spotlight default exhibit home page to live at the root_url, a...

### DIFF
--- a/app/controllers/spotlight/home_pages_controller.rb
+++ b/app/controllers/spotlight/home_pages_controller.rb
@@ -1,10 +1,41 @@
 module Spotlight
   class HomePagesController < Spotlight::PagesController
+    include Blacklight::SolrHelper
+    skip_authorize_resource only: :show
+
     def index
       redirect_to exhibit_feature_pages_path(@exhibit)
     end
 
+    def show
+      @page = @home_page = if params[:id]
+        Spotlight::HomePage.find_by(id: params[:id])
+      else
+        Spotlight::Exhibit.default.home_page
+      end
+
+      (@response, @document_list) = get_search_results
+
+      if @page.nil? or !@page.published?
+        render '/catalog/index'
+      else
+        render 'show'
+      end
+    end
+
+    def _prefixes
+      @_prefixes ||= super + ['catalog']
+    end
+    
     private
+    def blacklight_config
+      if @page
+        @page.exhibit.blacklight_config
+      else 
+        Spotlight::Exhibit.default.blacklight_config
+      end
+    end
+
     def page_model
       :home_page
     end

--- a/app/helpers/spotlight/home_pages_helper.rb
+++ b/app/helpers/spotlight/home_pages_helper.rb
@@ -1,0 +1,22 @@
+module Spotlight::HomePagesHelper
+  include Blacklight::UrlHelperBehavior
+
+  ##
+  # Standard display of a facet value in a list. Used in both _facets sidebar
+  # partial and catalog/facet expanded list. Will output facet value name as
+  # a link to add that to your restrictions, with count in parens.
+  #
+  # @param [Blacklight::SolrResponse::Facets::FacetField]
+  # @param [String] facet item
+  # @param [Hash] options
+  # @option options [Boolean] :suppress_link display the facet, but don't link to it
+  # @option options [Rails::Engine] :route_set route set to use to render the link
+  # @return [String]
+  def render_facet_value(facet_solr_field, item, options ={})    
+    scope = options.delete(:route_set) || main_app
+    path = scope.catalog_index_url(add_facet_params_and_redirect(facet_solr_field, item).merge(only_path: true))
+    content_tag(:span, :class => "facet-label") do
+      link_to_unless(options[:suppress_link], facet_display_value(facet_solr_field, item), path, :class=>"facet_select")
+    end + render_facet_count(item.hits)
+  end
+end

--- a/app/views/shared/_exhibit_navbar.html.erb
+++ b/app/views/shared/_exhibit_navbar.html.erb
@@ -3,11 +3,7 @@
 <div id="exhibit-navbar" class="navbar navbar-default" role="navigation">
   <div class="container">
     <ul class="nav navbar-nav">
-      <% if current_exhibit.home_page %>
-        <li class="<%= "active" if current_page?(url_for([spotlight, current_exhibit.home_page])) %>"><%= link_to t(:'spotlight.curation.home.nav_link'), [spotlight, current_exhibit.home_page] %></li>
-      <% else %>
-        <li class="<%= "active" if current_page?(root_url) %>"><%= link_to t(:'spotlight.curation.home.nav_catalog_link'), root_url %></li>
-      <% end %>
+      <li class="<%= "active" if current_page?(root_url) %>"><%= link_to t(:'spotlight.curation.home.nav_catalog_link'), root_url %></li>
       <% unless published_top_level_feature_pages.empty? %>
         <% if published_top_level_feature_pages.length > 1 %>
         <li class="dropdown">

--- a/app/views/spotlight/home_pages/_sidebar.html.erb
+++ b/app/views/spotlight/home_pages/_sidebar.html.erb
@@ -1,0 +1,3 @@
+<div id="sidebar" class="col-md-3">
+ <%= render 'catalog/search_sidebar' %>
+ </div>

--- a/lib/generators/spotlight/install_generator.rb
+++ b/lib/generators/spotlight/install_generator.rb
@@ -7,6 +7,11 @@ module Spotlight
 
     def inject_spotlight_routes
       route "mount Spotlight::Engine, at: 'spotlight'"
+      gsub_file 'config/routes.rb', /^\s*root.*/ do |match|
+        "#" + match + " # replaced by spotlight_root"
+      end
+
+      route "spotlight_root"
     end
 
     def assets

--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -1,6 +1,7 @@
 #Load blacklight which will give spotlight views a higher preference than those in blacklight
 require 'blacklight'
 require 'blacklight/gallery'
+require 'spotlight/rails/routes'
 
 module Spotlight
   class Engine < ::Rails::Engine

--- a/lib/spotlight/rails/routes.rb
+++ b/lib/spotlight/rails/routes.rb
@@ -1,0 +1,8 @@
+module ActionDispatch::Routing
+  class Mapper
+
+    def spotlight_root
+      root to: "spotlight/home_pages#show"
+    end
+  end
+end

--- a/spec/controllers/spotlight/home_pages_controller_spec.rb
+++ b/spec/controllers/spotlight/home_pages_controller_spec.rb
@@ -28,4 +28,16 @@ describe Spotlight::HomePagesController do
       end
     end
   end
+
+  describe "Rendering home page" do
+    let!(:page) { FactoryGirl.create(:home_page) }
+    
+    it "should get search results for display facets" do
+      controller.stub(get_search_results: [double, double])
+      get :show, id: page.id
+      expect(assigns[:response]).to_not be_blank
+      expect(assigns[:document_list]).to_not be_blank
+    end
+
+  end
 end

--- a/spec/views/shared/_exhibit_navbar.html.erb_spec.rb
+++ b/spec/views/shared/_exhibit_navbar.html.erb_spec.rb
@@ -22,7 +22,7 @@ module Spotlight
     it "should link to the home page" do
       current_exhibit.stub home_page: feature_page
       render
-      expect(response).to have_link "Home", href: spotlight.feature_page_path(feature_page)
+      expect(response).to have_link "Home", href: main_app.root_url
     end
 
     it "should link directly to a single feature page" do

--- a/spec/views/spotlight/home_pages/_sidebar.html.erb_spec.rb
+++ b/spec/views/spotlight/home_pages/_sidebar.html.erb_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe "spotlight/home_pages/_sidebar.html.erb" do
+  before do
+    stub_template 'catalog/_search_sidebar.html.erb' => "Sidebar"
+  end
+
+  it { render; expect(rendered).to match "Sidebar"  }
+
+end
+
+


### PR DESCRIPTION
...nd add the search sidebar to the display

Fixes #134 
