### PR TITLE
hide page edit buttons from users who can't edit.

### DIFF
--- a/app/views/spotlight/pages/show.html.erb
+++ b/app/views/spotlight/pages/show.html.erb
@@ -1,4 +1,4 @@
-<%= link_to t('helpers.submit.edit'), spotlight.polymorphic_path([:edit, @page]), :class => 'btn btn-primary pull-right' %>
+<%= link_to t('helpers.submit.edit'), spotlight.polymorphic_path([:edit, @page]), :class => 'btn btn-primary pull-right' if can? :edit, @page %>
 <%= render 'sidebar' %>
 <h1>
   <%= @page.title %>

--- a/spec/views/spotlight/pages/show.html.erb_spec.rb
+++ b/spec/views/spotlight/pages/show.html.erb_spec.rb
@@ -17,5 +17,24 @@ module Spotlight
       render
       rendered.should match(/Title/)
     end
+
+    describe "admin user" do
+
+      let(:user) { FactoryGirl.create(:exhibit_curator) }
+      before {sign_in user }
+
+      it "should have an edit link" do
+        render
+        expect(rendered).to have_link "Edit", href: spotlight.polymorphic_path([:edit, @page])
+      end
+    end
+
+    describe "anonymous user" do
+
+      it "should not give them an edit link" do
+        render
+        expect(rendered).to_not have_link "Edit"
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #136
