### PR TITLE
Force Spotlight::HomePage to be published.

### DIFF
--- a/app/models/spotlight/home_page.rb
+++ b/app/models/spotlight/home_page.rb
@@ -2,6 +2,7 @@ module Spotlight
   class HomePage < Spotlight::Page
     before_save do
       self.display_sidebar = true
+      self.published = true
     end
 
   end

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -13,7 +13,6 @@ FactoryGirl.define do
   factory :home_page, class: Spotlight::HomePage do
     exhibit Spotlight::Exhibit.default
     title "Page1"
-    published  true
   end
 end
   

--- a/spec/models/spotlight/home_page_spec.rb
+++ b/spec/models/spotlight/home_page_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe Spotlight::HomePage do
+  let(:home_page) { FactoryGirl.create(:home_page) }
+  it {should_not be_feature_page}
+  it {should_not be_about_page}
+  it "should display the sidebar" do
+    expect(home_page.display_sidebar).to be_true
+  end
+  it "should be published" do
+    expect(home_page.published).to be_true
+  end
+end


### PR DESCRIPTION
We don't have a control to publish the home page so it has to
always be published. In the future we'll automatically generate
a home page on exhibit creation and we will also want the home
page to be auto-published then too.

@cbeer I think [this](https://github.com/sul-dlss/spotlight/blob/master/app/controllers/spotlight/home_pages_controller.rb#L19) is why the home page wasn't showing up in the demo today. 
