### PR TITLE
Force display_sidebar to true on published parent pages of published child pages.

### DIFF
--- a/app/models/spotlight/feature_page.rb
+++ b/app/models/spotlight/feature_page.rb
@@ -4,5 +4,28 @@ module Spotlight
                              :foreign_key => "parent_page_id"
 
     belongs_to :parent_page, :class_name  => "Spotlight::FeaturePage"
+    after_save do
+      display_sidebar_for_page_with_published_children
+      display_parent_page_sidebar_when_published
+    end
+    private
+    # Parent pages with published children need
+    # to have their show_sidebar forced to true
+    def display_sidebar_for_page_with_published_children
+      if child_pages.published.present? and !display_sidebar
+        self.display_sidebar = true
+        self.save
+      end
+    end
+    # Force a parent page's display_sidebar
+    # to true for published child pages.
+    def display_parent_page_sidebar_when_published
+      if parent_page and parent_page.published and !parent_page.display_sidebar
+        if published
+          parent_page.display_sidebar = true
+          parent_page.save
+        end
+      end
+    end
   end
 end

--- a/spec/features/feature_page_spec.rb
+++ b/spec/features/feature_page_spec.rb
@@ -30,6 +30,7 @@ describe "Feature page" do
       end
     end
     describe "when configured to not display" do
+      before { parent_feature_page.display_sidebar = false;  parent_feature_page.save }
       it "should not be present" do
         visit spotlight.feature_page_path(parent_feature_page)
         expect(page).not_to have_css("#sidebar")

--- a/spec/models/spotlight/feature_page_spec.rb
+++ b/spec/models/spotlight/feature_page_spec.rb
@@ -10,6 +10,35 @@ describe Spotlight::FeaturePage do
     end
   end
 
+  describe "display_sidebar" do
+    let(:parent)  { FactoryGirl.create(:feature_page) }
+    let(:child) { FactoryGirl.create(:feature_page, parent_page: parent ) }
+    let!(:unpublished_parent)  { FactoryGirl.create(:feature_page, published: false) }
+    let!(:unpublished_child) { FactoryGirl.create(:feature_page, parent_page: unpublished_parent, published: false ) }
+    it "should be set to true on the parent of published child pages" do
+      expect(parent.display_sidebar).to be_false
+      child.save
+      expect(parent.display_sidebar).to be_true
+    end
+    it "should be set to true when publishing a child page" do
+      expect(unpublished_parent.display_sidebar).to be_false
+      unpublished_parent.published = true
+      unpublished_child.published = true
+      unpublished_child.save
+      expect(unpublished_parent.display_sidebar).to be_true
+    end
+    it "should not change the display_sidebar setting when the child page is not published" do
+      unpublished_child.save
+      expect(unpublished_parent.display_sidebar).to be_false
+    end
+    it "should not change the setting when the parent page is not published" do
+      expect(unpublished_parent.display_sidebar).to be_false
+      unpublished_child.published = true
+      unpublished_child.save
+      expect(unpublished_parent.display_sidebar).to be_false
+    end
+  end
+
   describe "weight" do
     let(:good_weight) { FactoryGirl.build(:feature_page, weight: 10) }
     let(:low_weight)  { FactoryGirl.build(:feature_page, weight: -1) }


### PR DESCRIPTION
If we allow parent page's display_sidebar to be false then there would be no way to navigate to the page.

We may want to do this w/ Javascript on the frontend as opposed or in addition to in the backend like this.

I'm submitting this PR to begin discussing what functionality we want here wrt the display sidebar logic for parent/child pages.
