### PR TITLE
Stay on PagesController#index on new page instantiation.

### DIFF
--- a/app/assets/stylesheets/spotlight/nestable.css.scss
+++ b/app/assets/stylesheets/spotlight/nestable.css.scss
@@ -15,7 +15,7 @@
 .dd-item,
 .dd-empty,
 .dd-placeholder { display: block; position: relative; margin: 0; padding: 0; min-height: 20px; font-size: 13px; line-height: 20px; }
-
+.dd-item .panel-heading {min-height: 71px;}
 .dd-handle { display: block; height: 73px; margin: 5px 0; padding: 5px 10px; color: #333; text-decoration: none; font-weight: bold; border: 1px solid #ccc;
     background: #fafafa;
     background: -webkit-linear-gradient(top, #fafafa 0%, #eee 100%);

--- a/app/views/spotlight/pages/index.html.erb
+++ b/app/views/spotlight/pages/index.html.erb
@@ -22,6 +22,9 @@
     </div>
   <%- end -%>
   <div>
-    <%= link_to t(:'helpers.submit.new', :model => "Page"), new_polymorphic_path([@exhibit, page_model]), class: 'btn btn-primary' %>
+    <%= form_for "spotlight/#{page_model}".classify.constantize.new, url: spotlight.polymorphic_path([@exhibit, page_collection_name]) do |f|%>
+      <%= f.hidden_field(:title) %>
+      <%= f.submit t(:'helpers.submit.new', model: "Page"), class: "btn btn-primary" %>
+    <%- end -%>
   </div>
 </div>

--- a/db/migrate/20131119213142_create_spotlight_pages.rb
+++ b/db/migrate/20131119213142_create_spotlight_pages.rb
@@ -4,7 +4,7 @@ class CreateSpotlightPages < ActiveRecord::Migration
       t.string     :title
       t.string     :type
       t.text       :content
-      t.integer    :weight, :default => 0
+      t.integer    :weight, default: 50
       t.boolean    :published
       t.references :exhibit
       t.timestamps

--- a/spec/features/create_page_spec.rb
+++ b/spec/features/create_page_spec.rb
@@ -25,20 +25,8 @@ describe "Creating a page", :type => :feature do
     # TODO get here via navigation menus
     visit spotlight.exhibit_catalog_index_path(Spotlight::Exhibit.default)
     click_link "About pages"
-    click_link "Add new Page"
-    fill_in "about_page_title", :with => "New Page Title!"
-    click_button "Save"
+    click_button "Add new Page"
     expect(page).to have_content "Page was successfully created."
-  end
-
-  it "should be possible with only a title" do
-    login_as exhibit_curator
-    # TODO get here via navigation menus
-    visit spotlight.exhibit_catalog_index_path(Spotlight::Exhibit.default)
-    click_link "Feature pages"
-    click_link "Add new Page"
-    fill_in "feature_page_title", :with => "New Page Title!"
-    click_button "Save"
-    expect(page).to have_content "Page was successfully created."
+    expect(page).to have_css("li.dd-item")
   end
 end

--- a/spec/features/javascript/record_thumbnail_block_spec.rb
+++ b/spec/features/javascript/record_thumbnail_block_spec.rb
@@ -9,7 +9,12 @@ feature "Record Thumbnail Block" do
     # TODO find this via a menu
     visit spotlight.exhibit_catalog_index_path(Spotlight::Exhibit.default)
     click_link "Feature pages"
-    click_link "Add new Page"
+    click_button "Add new Page"
+
+    expect(page).to have_content("Page was successfully created.")
+    within("li.dd-item") do
+      click_link "Edit"
+    end
     # fill in title
     fill_in "feature_page_title", :with => "Exhibit Title"
     # click to add widget
@@ -23,7 +28,7 @@ feature "Record Thumbnail Block" do
     # create the page
     click_button("Save")
     # veryify that the page was created
-    expect(page).to have_content("Page was successfully created.")
+    expect(page).to have_content("Page was successfully updated.")
     # visit the show page for the document we just saved
     visit spotlight.feature_page_path(id: Spotlight::FeaturePage.last)
     # veryify that the record thumbnail widget is displaying an image from the document.
@@ -38,7 +43,12 @@ feature "Record Thumbnail Block" do
     # TODO find this via a menu
     visit spotlight.exhibit_catalog_index_path(Spotlight::Exhibit.default)
     click_link "Feature pages"
-    click_link "Add new Page"
+    click_button "Add new Page"
+
+    expect(page).to have_content("Page was successfully created.")
+    within("li.dd-item") do
+      click_link "Edit"
+    end
     # fill in title
     fill_in "feature_page_title", :with => "Exhibit Title"
     # click to add widget
@@ -54,7 +64,7 @@ feature "Record Thumbnail Block" do
     # create the page
     click_button("Save")
     # veryify that the page was created
-    expect(page).to have_content("Page was successfully created.")
+    expect(page).to have_content("Page was successfully updated.")
     # visit the show page for the document we just saved
     visit spotlight.feature_page_path(id: Spotlight::FeaturePage.last)
     # veryify that the record thumbnail widget is displaying image and title from the requested document.

--- a/spec/models/spotlight/feature_page_spec.rb
+++ b/spec/models/spotlight/feature_page_spec.rb
@@ -14,8 +14,8 @@ describe Spotlight::FeaturePage do
     let(:good_weight) { FactoryGirl.build(:feature_page, weight: 10) }
     let(:low_weight)  { FactoryGirl.build(:feature_page, weight: -1) }
     let(:high_weight) { FactoryGirl.build(:feature_page, weight:  51) }
-    it "should default to 0" do
-      expect(Spotlight::FeaturePage.new.weight).to eq 0
+    it "should default to 50" do
+      expect(Spotlight::FeaturePage.new.weight).to eq 50
     end
     it "should validate when in the 0 to 50 range" do
       expect(good_weight).to be_valid

--- a/spec/views/spotlight/about_pages/_sidebar.html.erb_spec.rb
+++ b/spec/views/spotlight/about_pages/_sidebar.html.erb_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe "spotlight/about_pages/_sidebar.html.erb" do
   let!(:page1) { FactoryGirl.create(:about_page, title: "One", weight: 4) }
   let!(:page2) { FactoryGirl.create(:about_page, exhibit: page1.exhibit, title: "Two", published: false) }
-  let!(:page3) { FactoryGirl.create(:about_page, exhibit: page1.exhibit, title: "Three") }
+  let!(:page3) { FactoryGirl.create(:about_page, exhibit: page1.exhibit, title: "Three", weight: 3) }
   
   before do
     view.stub(current_exhibit: page1.exhibit)


### PR DESCRIPTION
Fixes #113

Should we remove the `#new` action in the pages controller and all logic for it?

![screen shot 2014-02-10 at 10 45 02 pm](https://f.cloud.github.com/assets/96776/2134604/d3d22758-92e9-11e3-8021-a7fda0354ebd.png)
