### PR TITLE
Show tag count on the curation dashboard.

### DIFF
--- a/app/views/spotlight/tags/index.html.erb
+++ b/app/views/spotlight/tags/index.html.erb
@@ -3,7 +3,10 @@
   <% @page_title = t(:'spotlight.curation.tags.title') %>
 
   <h1><%= t :'spotlight.curation.header' %></h1>
-  <h2 class="text-muted"><%= t :'spotlight.curation.tags.header' %></h2>
+  <h4 class="text-muted">
+    <%= t :'spotlight.curation.tags.header' %>
+    <span class="label label-default"><%= @tags.length %></span>
+  </h4>
 
   <table class="table table-striped">
     <thead>

--- a/spec/views/spotlight/tags/index.html.erb_spec.rb
+++ b/spec/views/spotlight/tags/index.html.erb_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe "spotlight/tags/index.html.erb" do
+  let(:exhibit) { Spotlight::Exhibit.default }
+  let(:tag1) { FactoryGirl.create(:tag, name: "TAG1") }
+  let(:tag2) { FactoryGirl.create(:tag, name: "TAG2") }
+  before do
+    assign(:tags, [tag1, tag2])
+    assign(:exhibit, exhibit)
+    view.stub(exhibit_tag_path: "/tags")
+    view.stub(:current_exhibit).and_return(exhibit)
+  end
+  describe "Tags" do
+    it "should be displayed" do
+      render
+      [tag1.name, tag2.name].each do |name|
+        expect(rendered).to have_css("td", text: name)
+      end
+    end
+  end
+  describe "Total tags" do
+    it "should be displayed" do
+      render
+      expect(rendered).to have_css("span.label.label-default", text: 2)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #156 

Although it does not block this ticket you can't create new tags from a record w/o the one of the fixes in spotlight/catalog/edit.html.erb #173
