### PR TITLE
Render "Contact emails" input on exhibit admin page when there are no contacts

### DIFF
--- a/app/assets/stylesheets/spotlight/exhibit_admin.css.scss
+++ b/app/assets/stylesheets/spotlight/exhibit_admin.css.scss
@@ -1,0 +1,11 @@
+.exhibit-admin {
+  input.exhibit-contact {
+    margin-top: 5px;
+    &:first-child {
+      margin-top: 0;
+    }
+  }
+  #another-email {
+    cursor: hand;
+  }
+}

--- a/app/controllers/spotlight/exhibits_controller.rb
+++ b/app/controllers/spotlight/exhibits_controller.rb
@@ -6,6 +6,7 @@ class Spotlight::ExhibitsController < Spotlight::ApplicationController
   authorize_resource
 
   def edit
+    @exhibit.contact_emails << "" unless @exhibit.contact_emails.present?
   end
 
   def update

--- a/app/views/spotlight/exhibits/edit.html.erb
+++ b/app/views/spotlight/exhibits/edit.html.erb
@@ -1,5 +1,5 @@
 <%= render 'spotlight/shared/curation_sidebar' %>
-<div id="content" class="col-md-9">
+<div id="content" class="col-md-9 exhibit-admin">
 <%= bootstrap_form_for @exhibit, url: spotlight.exhibit_path(@exhibit), style: :horizontal, right: "col-sm-5" do |f| %>
   <div class="row">
     <h1><%= t :'spotlight.administration.header' %></h1>
@@ -16,17 +16,17 @@
     <%= f.text_field :title %>
     <%= f.text_field :subtitle %>
     <%= f.form_group(:contact_emails, label: { text: nil, class: nil }, help: nil) do %>
-      <%= f.fields_for :contact_emails, @exhibit.contact_emails do |e| %>
-        <% if e.index == 0 %>
-        <div class="input-group">
-          <%= text_field_tag "#{e.object_name}[email]", e.object, class: 'form-control' %>
-          <span id='another-email' class="input-group-addon">+</span>
-        </div>
+      <%= f.fields_for :contact_emails, @exhibit.contact_emails do |contact| %>
+        <% if contact.index == 0 %>
+          <div class="input-group">
+            <%= text_field_tag "#{contact.object_name}[email]", contact.object, class: 'exhibit-contact form-control' %>
+            <span id='another-email' class="input-group-addon">+</span>
+          </div>
         <% else %>
-          <%= text_field_tag "#{e.object_name}[email]", e.object, class: 'form-control' %>
+          <%= text_field_tag "#{contact.object_name}[email]", contact.object, class: 'exhibit-contact form-control' %>
         <% end %>
       <% end %>
-    <%end %>
+    <% end %>
     <%= f.text_area :description %>
   </div>
 <% end %>

--- a/spec/features/exhibits/administration_spec.rb
+++ b/spec/features/exhibits/administration_spec.rb
@@ -1,0 +1,24 @@
+require "spec_helper"
+
+describe "Exhibit Administration" do
+  let(:admin) { FactoryGirl.create(:exhibit_admin) }
+  let(:email_id) { "exhibit_contact_emails_attributes_0_email" }
+  let(:email_address) { "admin@example.com" }
+  before { login_as admin }
+
+  describe "Contact Emails" do
+    it "should have a blank input field when there are no contacts yet" do
+      visit spotlight.edit_exhibit_path( Spotlight::Exhibit.default )
+      expect(page).to have_css("input.exhibit-contact")
+      expect(find_field(email_id).value).to be_blank
+    end
+    it "should store and retreive a contact email address" do
+      visit spotlight.edit_exhibit_path( Spotlight::Exhibit.default )
+      fill_in email_id, with: email_address
+      click_button "Save changes"
+      expect(page).to have_content("The exhibit was saved.")
+      visit spotlight.edit_exhibit_path( Spotlight::Exhibit.default )
+      expect(find_field(email_id).value).to eq email_address
+    end
+  end
+end


### PR DESCRIPTION
Fixes #145

![screen shot 2014-02-12 at 9 09 10 pm](https://f.cloud.github.com/assets/96776/2156937/3285f188-946d-11e3-8ed9-a86ca0fc5fb9.png)
