### PR TITLE
Send problem reports to all of the emails configured in the exhibit administration.

### DIFF
--- a/app/models/spotlight/contact_form.rb
+++ b/app/models/spotlight/contact_form.rb
@@ -12,7 +12,7 @@ module Spotlight
     def headers
       {
         subject: "#{I18n.t(:'blacklight.application_name')} Contact Form",
-        to: Spotlight::Exhibit.default.contact_emails.first,
+        to: Spotlight::Exhibit.default.contact_emails,
         from: %("#{name}" <#{email}>),
         cc: Spotlight::Exhibit.default.contact_emails.join(", ")
       }

--- a/spec/features/report_a_problem_spec.rb
+++ b/spec/features/report_a_problem_spec.rb
@@ -8,7 +8,7 @@ describe "Report a Problem" do
     expect(page).to have_content "Report a problem"
   end
 
-  it "should accept a problem report" do
+  it "should send a problem report to the contact emails cofigured for the exhibit" do
     e = Spotlight::Exhibit.default
     e.contact_emails = ["test@example.com", "test2@example.com"]
     e.save
@@ -22,6 +22,6 @@ describe "Report a Problem" do
 
     click_on "Send"
     expect(ActionMailer::Base.deliveries).to have(1).email
-
+    expect(ActionMailer::Base.deliveries.last.to).to eq e.contact_emails
   end
 end


### PR DESCRIPTION
@ggeisler: I'm not sure if this is even desirable or not.  Currently we are only sending the problem reports to the first contact email configured in the exhibit administration.  This PR changes that to send the problem reports to all emails configured.
