### PR TITLE
Don't duplicate contact field IDs when cloning the input.

### DIFF
--- a/app/assets/javascripts/spotlight/exhibits.js
+++ b/app/assets/javascripts/spotlight/exhibits.js
@@ -3,6 +3,7 @@ Spotlight.onLoad(function() {
     container = $(this).parent().parent();
     input = container.find('.input-group input[type="text"]').first().clone();
     input.val('');
+    input.attr('id', input.attr('id').replace('0', container.children().length));
     input.attr('name', input.attr('name').replace('0', container.children().length));
     container.append(input);
   });

--- a/spec/features/exhibits/administration_spec.rb
+++ b/spec/features/exhibits/administration_spec.rb
@@ -2,23 +2,50 @@ require "spec_helper"
 
 describe "Exhibit Administration" do
   let(:admin) { FactoryGirl.create(:exhibit_admin) }
-  let(:email_id) { "exhibit_contact_emails_attributes_0_email" }
-  let(:email_address) { "admin@example.com" }
+  let(:email_id_0) { "exhibit_contact_emails_attributes_0_email" }
+  let(:email_address_0) { "admin@example.com" }
+  let(:email_id_1) { "exhibit_contact_emails_attributes_1_email" }
+  let(:email_address_1) { "admin2@example.com" }
   before { login_as admin }
 
   describe "Contact Emails" do
     it "should have a blank input field when there are no contacts yet" do
       visit spotlight.edit_exhibit_path( Spotlight::Exhibit.default )
       expect(page).to have_css("input.exhibit-contact")
-      expect(find_field(email_id).value).to be_blank
+      expect(find_field(email_id_0).value).to be_blank
     end
     it "should store and retreive a contact email address" do
       visit spotlight.edit_exhibit_path( Spotlight::Exhibit.default )
-      fill_in email_id, with: email_address
+      fill_in email_id_0, with: email_address_0
       click_button "Save changes"
       expect(page).to have_content("The exhibit was saved.")
       visit spotlight.edit_exhibit_path( Spotlight::Exhibit.default )
-      expect(find_field(email_id).value).to eq email_address
+      expect(find_field(email_id_0).value).to eq email_address_0
+    end
+    it "should do something", js: true do
+      # Exhibit administration edit
+      visit spotlight.edit_exhibit_path( Spotlight::Exhibit.default )
+
+      # fill in first email field
+      fill_in email_id_0, with: email_address_0
+
+      # Additonal blank fields should not exist
+      expect(page).not_to have_css("input##{email_id_1}")
+      # click the + (add contact) button
+      find("#another-email").click
+      # An additional blank field should exist now
+      expect(page).to have_css("input##{email_id_1}")
+      expect(find_field(email_id_1).value).to be_blank
+
+      # fill in the second email field
+      fill_in email_id_1, with: email_address_1
+      click_button "Save changes"
+
+      expect(page).to have_content("The exhibit was saved.")
+      visit spotlight.edit_exhibit_path( Spotlight::Exhibit.default )
+
+      expect(find_field(email_id_0).value).to eq email_address_0
+      expect(find_field(email_id_1).value).to eq email_address_1
     end
   end
 end


### PR DESCRIPTION
Also adding a javascript integration test for the Add Contact button.
