### PR TITLE
Add in-place editing for metadata fields; fixes #211

### DIFF
--- a/app/assets/javascripts/spotlight/blacklight_configuration.js
+++ b/app/assets/javascripts/spotlight/blacklight_configuration.js
@@ -6,4 +6,32 @@ Spotlight.onLoad(function() {
   // Handle weighting the pages and their children.
   updateWeightsAndRelationships($('#nested-fields .metadata_fields'));
   updateWeightsAndRelationships($('#nested-fields.facet_fields'));
+
+  $('.field-label').on('click.inplaceedit', function() {
+    var $input = $(this).next('input');
+    var $label = $(this);
+
+    $label.hide();
+    $input.val($label.text());
+    $input.attr('type', 'text');
+    $input.select();
+    $input.focus();
+
+    $input.on('keypress', function(e) {
+      if(e.which == 13) {
+        $input.trigger('blur.inplaceedit');
+        return false;
+      }
+    });
+
+    $input.on('blur.inplaceedit', function() {
+      $label.text($input.val());
+      $label.show();
+      $input.attr('type', 'hidden');
+
+      return false;
+    });
+
+    return false;
+  });
 });

--- a/app/assets/stylesheets/spotlight/_blacklight_configuration.css.scss
+++ b/app/assets/stylesheets/spotlight/_blacklight_configuration.css.scss
@@ -2,5 +2,15 @@
   .dd-item td:first-child {
     padding-left: 40px;
     position: relative;
+    
+    a {
+      cursor: text;
+      color: inherit;
+      text-decoration: none;
+    }
+    &:hover {
+      background: #F7F7D0;
+      cursor: text;
+    }
   }
 }

--- a/app/controllers/spotlight/blacklight_configurations_controller.rb
+++ b/app/controllers/spotlight/blacklight_configurations_controller.rb
@@ -36,7 +36,7 @@ class Spotlight::BlacklightConfigurationsController < Spotlight::ApplicationCont
   def exhibit_configuration_index_params
     views = @blacklight_configuration.default_blacklight_config.view.keys | [:show]
 
-    (@blacklight_configuration.all_index_fields.keys  + @blacklight_configuration.custom_index_fields.keys).inject({}) { |result, element| result[element] = ([:enabled, :weight] | views); result }
+    (@blacklight_configuration.all_index_fields.keys  + @blacklight_configuration.custom_index_fields.keys).inject({}) { |result, element| result[element] = ([:enabled, :label, :weight] | views); result }
   end
 
   def exhibit_configuration_facet_params

--- a/app/views/spotlight/blacklight_configurations/edit_metadata_fields.html.erb
+++ b/app/views/spotlight/blacklight_configurations/edit_metadata_fields.html.erb
@@ -30,7 +30,8 @@
                     <%= field.hidden_field :weight, 'data-property' => 'weight' %>
                     <div class="dd-handle dd3-handle"><%= t :drag %></div>
 
-                  <%= config.label %>
+                  <a href="#edit-in-place" class="field-label"><%= (@exhibit.blacklight_configuration.index_fields[key] || {}).fetch(:label, config.label) %></a>
+                  <%= field.hidden_field :label, value: @exhibit.blacklight_configuration.index_fields.fetch(key, {})[:label], class: 'form-control input-sm' %>
                   </td>
                   <td><%= field.check_box :show, checked: (@exhibit.blacklight_configuration.index_fields[key] || {})[:show], label: "" %></td>
                   <% @exhibit.blacklight_configuration.default_blacklight_config.view.keys.each do |type| %>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -95,7 +95,7 @@ en:
           one: "%{count} unique value"
           other: "%{count} unique values"
       edit_metadata_fields:
-        fields:
+        field:
           label: "Field name"
         header: "Metadata"
         order_header: "Display and Order Metadata Fields"
@@ -105,7 +105,7 @@ en:
             "You can add metadata fields to supplement the metadata fields that are part of the repository item record."
         view:
           show: "Item Details"
-        instructions: Select metadata fields to display on each type of page. Drag and drop fields to specify the order they are displayed on the Item Details page.
+        instructions: Select metadata fields to display on each type of page. Click a field name to edit its display label. Drag and drop fields to specify the order they are displayed on the Item Details page.
     catalog:
       fields:
         title: "Title"

--- a/spec/features/exhibits/edit_metadata_fields_spec.rb
+++ b/spec/features/exhibits/edit_metadata_fields_spec.rb
@@ -26,4 +26,18 @@ describe "Editing metadata fields", type: :feature do
     expect(Spotlight::Exhibit.default.blacklight_config('list').index_fields).to have(2).fields
     expect(Spotlight::Exhibit.default.blacklight_config.show_fields).to include("language_ssm", "abstract_tesim")
   end
+
+  it "should have in-place editing of labels", js: true do
+    visit spotlight.exhibit_edit_metadata_path Spotlight::Exhibit.default
+    check :blacklight_configuration_index_fields_language_ssm_show
+    check :blacklight_configuration_index_fields_language_ssm_list
+
+    click_on "Language"
+
+    expect(page).to have_field :blacklight_configuration_index_fields_language_ssm_label, visible: true
+    fill_in :blacklight_configuration_index_fields_language_ssm_label, with: "Language of Origin"
+
+    click_on "Save changes"
+    expect(Spotlight::Exhibit.default.blacklight_config.index_fields['language_ssm'].label).to eq "Language of Origin"
+  end
 end


### PR DESCRIPTION
![screen shot 2014-02-14 at 16 09 13](https://f.cloud.github.com/assets/111218/2176501/727aef78-95d5-11e3-9d92-965f22055913.png)

There's a small problem with the CSS and the height of the text field being a little bigger than the text, but it's pretty close. Maybe @jkeck could take a look at the styling sometime?
