### PR TITLE
Don't print the page title heading when there isn't a title.

### DIFF
--- a/app/views/spotlight/pages/show.html.erb
+++ b/app/views/spotlight/pages/show.html.erb
@@ -1,11 +1,12 @@
 <%= render 'sidebar' if @page.display_sidebar? %>
 
 <div class="<%= 'col-md-9' if @page.display_sidebar? %>">
-<%= edit_link @page, class: 'btn btn-primary pull-right' if can? :edit, @page %>
-  <h1>
-    <%= @page.title %>
-  </h1>
-
+  <%= edit_link @page, class: 'btn btn-primary pull-right' if can? :edit, @page %>
+  <% if @page.title %>
+    <h1 class="page-title">
+      <%= @page.title %>
+    </h1>
+  <% end %>
   <div>
     <%= render_sir_trevor(@page.content) unless @page.content.blank? %>
   </div>

--- a/spec/views/spotlight/pages/show.html.erb_spec.rb
+++ b/spec/views/spotlight/pages/show.html.erb_spec.rb
@@ -14,6 +14,16 @@ module Spotlight
       
     end
 
+    it "should render the title as a heading" do
+      render
+      expect(rendered).to have_css(".page-title", text: @page.title)
+    end
+    it "should not render an empty heading" do
+      @page.stub(title: nil)
+      render
+      expect(rendered).to_not have_css(".page-title")
+    end
+
     it "renders attributes in <p>" do
       render
       rendered.should match(/Title/)


### PR DESCRIPTION
Really small change but we noticed a blank heading being inserted on the default home-page (which is likely to be the case for the home page).

With empty header
![with header](https://f.cloud.github.com/assets/96776/2176754/14139abc-95de-11e3-97ee-952628e60be2.png)

Without empty header
![without header](https://f.cloud.github.com/assets/96776/2176756/257dd934-95de-11e3-8208-12b8bde4617d.png)
