### PR TITLE
Replace edit button on Pages with curation mode toggle widget.

### DIFF
--- a/app/views/spotlight/catalog/_curation_mode_toggle_default.html.erb
+++ b/app/views/spotlight/catalog/_curation_mode_toggle_default.html.erb
@@ -9,4 +9,4 @@
     </span>
   </div>
   <% end %>
-<% end %> 
+<% end %>

--- a/app/views/spotlight/pages/_curation_mode_toggle.html.erb
+++ b/app/views/spotlight/pages/_curation_mode_toggle.html.erb
@@ -1,0 +1,12 @@
+<% if can?(:edit, object) %>
+  <% content_for(:curation_mode_widget) do %>
+    <span class="label label-<%= curation_mode_label_class %> curation-widget">
+      <%- if curation_mode? -%>
+        <%= t(:'spotlight.curation.mode.curation') %> <%= link_to t(:'spotlight.curation.link.show'), spotlight.polymorphic_path(object) %>
+      <%- else -%>
+        <%= t(:'spotlight.curation.mode.end_user') %> <%= link_to t(:'spotlight.curation.link.edit'), spotlight.edit_polymorphic_path(object) %>
+      <%- end -%>
+    </span>
+  </div>
+  <% end %>
+<% end %>

--- a/app/views/spotlight/pages/edit.html.erb
+++ b/app/views/spotlight/pages/edit.html.erb
@@ -3,3 +3,5 @@
 <%= render 'form' %>
 
 <%= link_to t('spotlight.curation.dashboard'), [spotlight, @page.exhibit, :catalog, :index] %>
+
+<%= render "curation_mode_toggle", object: @page %>

--- a/app/views/spotlight/pages/show.html.erb
+++ b/app/views/spotlight/pages/show.html.erb
@@ -1,7 +1,6 @@
 <%= render 'sidebar' if @page.display_sidebar? %>
 
 <div class="<%= 'col-md-9' if @page.display_sidebar? %>">
-  <%= edit_link @page, class: 'btn btn-primary pull-right' if can? :edit, @page %>
   <% if @page.title %>
     <h1 class="page-title">
       <%= @page.title %>
@@ -11,3 +10,5 @@
     <%= render_sir_trevor(@page.content) unless @page.content.blank? %>
   </div>
 </div>
+
+<%= render "curation_mode_toggle", object: @page %>

--- a/spec/features/curation_mode_widget_spec.rb
+++ b/spec/features/curation_mode_widget_spec.rb
@@ -2,20 +2,63 @@ require "spec_helper"
 
 describe "Curation Mode Widget" do
   let(:exhibit_curator) { FactoryGirl.create(:exhibit_curator) }
+  let(:feature_page) { FactoryGirl.create(:feature_page) }
   let(:doc_id) { "dq287tq6352" }
-  before {login_as exhibit_curator}
-  describe "on the edit page" do
-    it "should have text indicating that the user is in curation mode and a link to turn it off" do
-      visit spotlight.edit_exhibit_catalog_path(Spotlight::Exhibit.default, doc_id)
-      expect(page).to have_content("You are in curation mode. Turn off.")
-      expect(page).to have_link("Turn off.")
+  let(:curation_mode_link) { "Turn off." }
+  let(:curation_mode_text) { "You are in curation mode. #{curation_mode_link}" }
+  let(:user_mode_link) { "Enter curation mode." }
+  let(:user_mode_text) { "You are in end-user mode. #{user_mode_link}" }
+  describe "when not logged in" do
+    describe "the feature pages" do
+      describe "edit page" do
+        it "should not render the widget" do
+          visit spotlight.edit_polymorphic_path(feature_page)
+          expect(page).not_to have_content(curation_mode_text)
+          expect(page).not_to have_link(curation_mode_link)
+        end
+      end
+      describe "show page" do
+        it "should not render the widget" do
+          visit spotlight.polymorphic_path(feature_page)
+          expect(page).not_to have_content(curation_mode_text)
+          expect(page).not_to have_link(curation_mode_link)
+        end
+      end
     end
   end
-  describe "on the show page" do
-    it "should have text indicating that the user is in end-user mode and a link to turn go into curation mode" do
-      visit spotlight.exhibit_catalog_path(Spotlight::Exhibit.default, doc_id)
-      expect(page).to have_content("You are in end-user mode. Enter curation mode.")
-      expect(page).to have_link("Enter curation mode.")
+  describe "when logged in" do
+    before {login_as exhibit_curator}
+    describe "the feature pages" do
+      describe "edit page" do
+        it "should have text indicating that the user is in curation mode and a link to turn it off" do
+          visit spotlight.edit_polymorphic_path(feature_page)
+          expect(page).to have_content(curation_mode_text)
+          expect(page).to have_link(curation_mode_link)
+        end
+      end
+      describe "show page" do
+        it "should have text indicating that the user is in end-user mode and a link to turn go into curation mode" do
+          visit spotlight.polymorphic_path(feature_page)
+          expect(page).to have_content(user_mode_text)
+          expect(page).to have_link(user_mode_link)
+        end
+      end
+    end
+    describe "the spotlight catalog" do
+      describe "edit page" do
+        it "should have text indicating that the user is in curation mode and a link to turn it off" do
+          visit spotlight.edit_exhibit_catalog_path(Spotlight::Exhibit.default, doc_id)
+          expect(page).to have_content(curation_mode_text)
+          expect(page).to have_link(curation_mode_link)
+        end
+      end
+      describe "show page" do
+        it "should have text indicating that the user is in end-user mode and a link to turn go into curation mode" do
+          visit spotlight.exhibit_catalog_path(Spotlight::Exhibit.default, doc_id)
+          expect(page).to have_content(user_mode_text)
+          expect(page).to have_link(user_mode_link)
+        end
+      end
     end
   end
 end

--- a/spec/views/spotlight/pages/show.html.erb_spec.rb
+++ b/spec/views/spotlight/pages/show.html.erb_spec.rb
@@ -4,6 +4,7 @@ module Spotlight
   describe "spotlight/pages/show" do
     let(:exhibit) { stub_model(Exhibit) }
     before(:each) do
+      view.stub(:current_exhibit).and_return(exhibit)
       view.send(:extend, Spotlight::CrudLinkHelpers)
       @page = assign(:page, stub_model(FeaturePage,
         :exhibit => exhibit,
@@ -27,25 +28,6 @@ module Spotlight
     it "renders attributes in <p>" do
       render
       rendered.should match(/Title/)
-    end
-
-    describe "admin user" do
-
-      let(:user) { FactoryGirl.create(:exhibit_curator) }
-      before {sign_in user }
-
-      it "should have an edit link" do
-        render
-        expect(rendered).to have_link "Edit", href: spotlight.polymorphic_path([:edit, @page])
-      end
-    end
-
-    describe "anonymous user" do
-
-      it "should not give them an edit link" do
-        render
-        expect(rendered).to_not have_link "Edit"
-      end
     end
 
     it "should render the sidebar" do


### PR DESCRIPTION
Fixes #232 

`PagesController#show`
![screen shot 2014-02-18 at 12 17 13 pm](https://f.cloud.github.com/assets/96776/2199851/b7114bf8-98d9-11e3-8db5-2d11e28f5e4a.png)

`PagesController#edit`
![screen shot 2014-02-18 at 12 12 57 pm](https://f.cloud.github.com/assets/96776/2199855/bb8971c4-98d9-11e3-9cf9-e32b865d9944.png)
