### PR TITLE
Update exhibit masthead and navbar; fixes #259

### DIFF
--- a/app/assets/stylesheets/spotlight/_header.css.scss
+++ b/app/assets/stylesheets/spotlight/_header.css.scss
@@ -4,8 +4,8 @@
 }
 
 #exhibit-masthead {
-padding: 24px 0;
-  h1, .h1 {
+  padding: 24px 0;
+  .site-title {
     font-size: 30px;
   }
 
@@ -19,5 +19,23 @@ padding: 24px 0;
     padding: 8px 0;
     background: none;
     margin-bottom: 0;
+  }
+}
+
+.col-md-4 {
+  .submit-search-text {
+    // hide 'search' label 
+      // copied from .sr-only, sadly can't seem to use @extend in a media
+      // query like this, have to copy. 
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0,0,0,0);
+      border: 0;
+  }
+  .glyphicon-search {
+    line-height: $line-height-computed;
   }
 }

--- a/app/assets/stylesheets/spotlight/spotlight.css.scss
+++ b/app/assets/stylesheets/spotlight/spotlight.css.scss
@@ -1,3 +1,5 @@
+@import "bootstrap/variables";
+
 @import "sir-trevor";
 @import "attachments";
 @import "pages";

--- a/app/views/shared/_exhibit_masthead.html.erb
+++ b/app/views/shared/_exhibit_masthead.html.erb
@@ -1,12 +1,12 @@
 <% if current_exhibit %>
 <div id="exhibit-masthead" class="jumbotron">
   <div class="container">
-    <h1>
+    <div class="site-title h1">
       <%= current_exhibit.title %>
       <% if current_exhibit.subtitle %>
         <small><%= current_exhibit.subtitle %></small>
       <% end %>
-    </h1>
+    </div>
   </div>
 </div>
 <% end %>

--- a/spec/views/shared/_exhibit_masthead.html.erb_spec.rb
+++ b/spec/views/shared/_exhibit_masthead.html.erb_spec.rb
@@ -8,15 +8,15 @@ module Spotlight
     it "should display the title and subtitle" do
       view.stub(current_exhibit: current_exhibit)
       render
-      expect(rendered).to have_selector('h1', text: "Some title")
-      expect(rendered).to have_selector('h1 small', text: "Subtitle")
+      expect(rendered).to have_selector('.site-title', text: "Some title")
+      expect(rendered).to have_selector('.site-title small', text: "Subtitle")
     end
 
     it "should display just the title" do
       view.stub(current_exhibit: current_exhibit_without_subtitle)
       render
-      expect(rendered).to have_selector('h1', text: "Some title")
-      expect(rendered).to_not have_selector('h1 small')
+      expect(rendered).to have_selector('.site-title', text: "Some title")
+      expect(rendered).to_not have_selector('.site-title small')
     end
   end
 end


### PR DESCRIPTION
![screen shot 2014-02-20 at 10 07 45](https://f.cloud.github.com/assets/111218/2221542/4616b168-9a5a-11e3-93f8-fe42550a4479.png)
