### PR TITLE
Display the item title instead of the item ID on the typeahead forms for widgets

### DIFF
--- a/app/assets/javascripts/spotlight/item_text_block.js
+++ b/app/assets/javascripts/spotlight/item_text_block.js
@@ -10,6 +10,7 @@
 SirTrevor.Blocks.ItemText =  (function(){
 
   var id_key = "item-id";
+  var id_text_key = "item-text-id";
   var title_key = "show-title";
   var text_key = "item-text"
   var align_key = "text-align"
@@ -23,10 +24,11 @@ SirTrevor.Blocks.ItemText =  (function(){
       '</div>',
       '<div class="col-sm-9">',
         '<div class="form-group">',
-          '<label for="' + id_key + '" class="col-sm-2 control-label">Selected item</label>',
+          '<label for="' + id_text_key + '" class="col-sm-2 control-label">Selected item</label>',
           '<div class="col-sm-6 field">',
-            '<input name="' + id_key + '"',
-            ' class="st-input-string form-control ' + type + '" type="text" id="' + id_key + '" data-twitter-typeahead="true" />',
+            '<input data-id_field="#' + id_key + '" name="' + id_text_key + '"',
+            ' class="st-input-string form-control ' + type + '" type="text" id="' + id_text_key + '" data-twitter-typeahead="true" />',
+            '<input name="' + id_key + '" type="hidden" id="' + id_key + '" />',
           '</div>',
         '</div>',
         '<div class="form-group">',
@@ -69,6 +71,7 @@ SirTrevor.Blocks.ItemText =  (function(){
     toData: function() {
       var data = {};
       data[id_key] = this.$('#' + id_key).val();
+      data[id_text_key] = this.$('#' + id_text_key).val();
       data[title_key] = this.$('#' + title_key).is(':checked');
 
       if (this.hasTextBlock()) {
@@ -86,10 +89,12 @@ SirTrevor.Blocks.ItemText =  (function(){
 
     onBlockRender: function() {
       addAutocompletetoSirTrevorForm();
+      $('#' + id_text_key).focus();
     },
 
     loadData: function(data){
       this.getTextBlock().html(SirTrevor.toHTML(data.text, this.type));
+      this.$('#' + id_text_key).val(data[id_text_key]);
       this.$('#' + id_key).val(data[id_key]);
       this.$('#' + title_key).prop('checked', data[title_key]);
       this.$('#' + align_key + "-" + data[align_key]).prop("checked", true);

--- a/app/assets/javascripts/spotlight/multi_up_item_grid.js
+++ b/app/assets/javascripts/spotlight/multi_up_item_grid.js
@@ -89,7 +89,8 @@ function buildInputFields(times, id, checkbox){
     output += '<div class="col-sm-9 field">';
       output += '<input name="' + checkbox + '_' + i + '" type="hidden" value="false" />';
       output += '<input name="' + checkbox + '_' + i + '" id="' + checkbox + '_' + i + '" type="checkbox" class="item-grid-checkbox" value="true" />';
-      output += '<input name="' + id + '_' + i + '" class="st-input-string item-grid-input form-control" data-twitter-typeahead="true" type="text" id="' + id + '_' + i + '" />';
+      output += '<input name="' + id + '_' + i + '" class="item-grid-input" type="hidden" id="' + id + '_' + i + '" />';
+      output += '<input data-checkbox_field="#' + checkbox + '_' + i + '" data-id_field="#' + id + '_' + i + '" name="' + id + '_' + i + '_title" class="st-input-string item-grid-input form-control" data-twitter-typeahead="true" type="text" id="' + id + '_' + i + '_title" />';
     output += '</div>';
   }
   return output;

--- a/app/assets/javascripts/spotlight/search_typeahead.js
+++ b/app/assets/javascripts/spotlight/search_typeahead.js
@@ -16,13 +16,28 @@ var results = new Bloodhound({
 });
 
 function addAutocompletetoSirTrevorForm() {
-  $('[data-twitter-typeahead]').typeahead(null, {
-      displayKey: 'id',
+  $('[data-twitter-typeahead]').typeahead({ highlight: true, hint: false, autoselect: true }, {
+      displayKey: 'title',
       source: results.ttAdapter(),
       templates: {
         suggestion: Handlebars.compile(
           '{{title}}<br/><small>&nbsp;&nbsp;{{id}}</small>'
           )
+      }
+    }).on('click', function() {
+      $(this).select();
+      $(this).closest('.field').removeClass('has-error');
+      $($(this).data('checkbox_field')).prop('disabled', false);
+    }).on('change', function() {
+      $($(this).data('id_field')).val("");
+    }).on('typeahead:selected typeahead:autocompleted', function(e, data) {
+      $($(this).data('id_field')).val(data['id']);
+      $($(this).data('checkbox_field')).prop('checked', true);
+    }).on('blur', function() {
+      if($(this).val() != "" && $($(this).data('id_field')).val() == "") {
+        $(this).closest('.field').addClass('has-error');
+      $($(this).data('checkbox_field')).prop('checked', false);
+        $($(this).data('checkbox_field')).prop('disabled', true);
       }
     });
 }

--- a/app/assets/stylesheets/spotlight/_item_text_block.css.scss
+++ b/app/assets/stylesheets/spotlight/_item_text_block.css.scss
@@ -25,6 +25,11 @@
     }
   }
 }
+
+.st-block input[type="text"] {
+    @extend .form-control;
+}
+
 .item-text-admin {
   .text-align {
     margin-top: 15px;

--- a/spec/features/javascript/multi_up_item_grid_spec.rb
+++ b/spec/features/javascript/multi_up_item_grid_spec.rb
@@ -21,11 +21,43 @@ describe "Mutli-Up Item Grid", js: true do
 
     find("a[data-type='multi-up-item-grid']").click
 
-    fill_in("item-grid-id_0", with: "dq287tq6352")
-    check("item-grid-display_0")
-    fill_in("item-grid-id_1", with: "jp266yb7109")
-    check("item-grid-display_1")
-    fill_in("item-grid-id_2", with: "zv316zr9542")
+
+    # Poltergeist / Capybara doesn't fire the events typeahead.js
+    # is listening for, so we help it out a little:
+    fill_in("item-grid-id_0_title", with: "dq287tq6352")
+    page.execute_script '
+      $("#item-grid-id_0_title").val("dq287tq6352").keydown();
+      $("#item-grid-id_0_title").typeahead("open");
+      $(".tt-suggestion").click();
+    ';
+    find('.tt-suggestion').click
+ 
+    fill_in("item-grid-id_1_title", with: "jp266yb7109")
+    page.execute_script '
+      $("#item-grid-id_1_title").val("jp266yb7109").keydown();
+      $("#item-grid-id_1_title").typeahead("open");
+      $(".tt-suggestion").click();
+    ';
+    find('.tt-suggestion').click
+
+    fill_in("item-grid-id_2_title", with: "zv316zr9542")
+    page.execute_script '
+      $("#item-grid-id_2_title").val("zv316zr9542").keydown();
+      $("#item-grid-id_2_title").typeahead("open");
+      $(".tt-suggestion").click();
+    ';
+    find('.tt-suggestion').click
+
+
+    ##
+    # Dunno why this isn't working correctly:
+    #   Unable to find checkbox "item-grid-display_2"
+    # uncheck("item-grid-display_2")
+    # instead, we use #execute_script:
+    page.execute_script '
+      $("#item-grid-display_2").prop("checked", false);
+
+    ';
 
     click_button "Save changes"
     expect(page).to have_content("Page was successfully updated.")


### PR DESCRIPTION
Fixes #321 

![screen shot 2014-02-24 at 13 29 13](https://f.cloud.github.com/assets/111218/2251269/bf6909c4-9d9a-11e3-9686-93f8772ad196.png)
![screen shot 2014-02-24 at 13 29 06](https://f.cloud.github.com/assets/111218/2251270/bf7c55d8-9d9a-11e3-943f-816e8544db2f.png)
