### PR TITLE
Add in-place-edit to about/feature pages.

### DIFF
--- a/app/assets/javascripts/spotlight/pages.js
+++ b/app/assets/javascripts/spotlight/pages.js
@@ -1,6 +1,7 @@
 // Place all the behaviors and hooks related to the matching controller here.
 // All this logic will automatically be available in application.js.
 Spotlight.onLoad(function() {
+  expandAddButton();
   // Initialize Nestable for nested pages
   $('#nested-pages.about_pages_admin').nestable({maxDepth: 1});
   $('#nested-pages.feature_pages_admin').nestable({maxDepth: 2, expandBtnHTML: "", collapseBtnHTML: ""});
@@ -96,3 +97,49 @@ function parent_page_field(node){
 function find_property(node, property) {
   return node.find("input[data-property=" + property + "]");
  }
+function addButtonElement(){
+  return $("[data-expanded-add-button]");
+}
+function expandAddButton(){
+  addButtonElement().each(function(){
+    var button = $(this);
+    var target = $(button.data('field-target'));
+    var save =  $("input[type='submit']", target);
+    var input = $("input[type='text']", target);
+    var width = button.outerWidth();
+    var speed = 800;
+    // Animate button open when the mouse enters or
+    // the button is given focus (i.e. clicked/tabbed)
+    button.on("mouseenter focus", function(){
+      if(button.outerWidth() <= (width + 5)) {
+        $(this).animate(
+          {width: '425px'}, speed, function(){
+            target.show(0, function(){
+              input.focus(); 
+            });
+          }
+        )
+      }
+    });
+    // Don't allow for blank titles
+    save.on('click', function(){
+      if ($.trim(input.val()) == "") {
+        return false;
+      }
+    });
+    $.each([input, save, button], function(){
+      $(this).on("blur", function(){
+        // Give a little timeout so that the 
+        // button doesn't snap back right away
+        setTimeout(function(){
+          // Unless the parent button or the save button is focussed
+          if( !input.is(':focus') && !button.is(':focus') && !save.is(':focus') ) {
+            // Hide the input/save button and animate the button closed
+            target.hide();
+            button.animate({width: width + 'px'}, speed);
+          }
+        }, 25);
+      });
+    });
+  });
+}

--- a/app/assets/stylesheets/spotlight/_curation.css.scss
+++ b/app/assets/stylesheets/spotlight/_curation.css.scss
@@ -6,15 +6,61 @@
 .missing-description {
   font-style: italic;
 }
+.expanded-add-button {
+  position: relative;
+  display: inline-block;
+  .input-field {
+    input[type='text'] {
+      @extend .input-sm;
+      width: 247px;
+      color: black;
+      border-color: white;
+    }
+    input[type='submit'] {
+      @extend .btn;
+      @extend .btn-default;
+      @extend .btn-xs;
+    }
+    position: absolute;
+    left: 130px;
+    bottom: 2px;
+    display: none;
+  }
+  [data-expanded-add-button] {
+    text-align: left;
+  }
+}
 
 .panel-heading.page {
+  .panel-title {
+    a {
+      cursor: text;
+      &:hover {
+        text-decoration: none;
+      }
+    }
+  }
   .checkbox {
     width: 3%;
     vertical-align: top;
     display: inline-block;
   }
+  .display-sidebar-control {
+    .checkbox {
+      width: auto;
+    }
+  }
+  .publish-control {
+    display: inline;
+    .checkbox {
+      padding-top: 0;
+    }
+  }
+  .page-links {
+    padding-left: 4px;
+  }
   .main {
-    width: 80%;
+    width: 96%;
     vertical-align: top;
     display: inline-block;
   }

--- a/app/views/spotlight/pages/_order_pages.html.erb
+++ b/app/views/spotlight/pages/_order_pages.html.erb
@@ -19,9 +19,14 @@
     </div>
 <%- end -%>
 <div>
-  <%= form_for @page, url: spotlight.polymorphic_path([@exhibit, page_collection_name]) do |f|%>
-    <%= f.hidden_field(:title) %>
-    <%= f.submit nil, class: "btn btn-primary" %>
+  <%= form_for @page, url: spotlight.polymorphic_path([@exhibit, page_collection_name]), html: {class: "expanded-add-button"} do |f|%>
+    <a href='#add-new' class="btn btn-primary" data-expanded-add-button="true" data-field-target="[data-title-field]">
+      <%= t(:'.new_page') %> <span class="glyphicon glyphicon-chevron-right"></span>
+      <span data-title-field="true" class="input-field">
+        <%= f.text_field(:title) %>
+        <%= f.submit t(:'.save') %>
+      </span>
+    </a>
   <%- end -%>
 </div>
 

--- a/app/views/spotlight/pages/_page.html.erb
+++ b/app/views/spotlight/pages/_page.html.erb
@@ -3,30 +3,32 @@
   <div class="dd-handle dd3-handle"><%= t :drag %></div>
   <div class="dd3-content panel panel-default">
     <div class="panel-heading page">
-      <a class="pull-right btn btn-text" data-toggle="collapse" href="#collapse-page-<%= page.id %>"><%= t(:'spotlight.feature_pages.options') %>
+      <!-- <a class="pull-right btn btn-text" data-toggle="collapse" href="#collapse-page-<%= page.id %>"><%= t(:'spotlight.feature_pages.options') %>
         <span class="glyphicon glyphicon-chevron-right"></span>
-      </a>
-      <%= f.check_box :published, label: '' %>
+      </a> -->
+      <div class="publish-control">
+        <%= f.check_box :published, label: '' %>
+      </div>
       <div class="main">
-        <h3 class="panel-title"><%= page.title_or_default %></h3>
-        <div class="page-links">
+        <%= f.hidden_field :id %>
+        <%= f.hidden_field :weight, data: {property: "weight"} %>
+        <h3 class="panel-title">
+          <a href="#edit-in-place" class="field-label"><%= page.title_or_default %></a>
+          <%= f.hidden_field :title, value: page.title_or_default , class: 'form-control input-sm' %>
+        </h3>
+        <div class="row">
+        <div class="page-links col-sm-9">
           <%= exhibit_view_link page, :class => 'btn btn-text' %> &middot;
           <%= exhibit_edit_link page, :class => 'btn btn-text' %> &middot;
           <%= exhibit_delete_link page, :class => 'btn btn-text' %>
         </div>
-      </div>
-    </div>
-    <div id="collapse-page-<%= page.id %>" class="panel-collapse collapse">
-      <div class="panel-body">
-        <%= f.text_field :title, label: t('spotlight.administration.page_title') %>
-        <%= f.hidden_field :id %>
-        <%= f.hidden_field :weight, data: {property: "weight"} %>
         <%- if page.feature_page? -%>
-          <div class="col-sm-offset-2 col-sm-10">
-            <%= f.hidden_field :parent_page_id, data: {property: "parent_page"} %>
+          <%= f.hidden_field :parent_page_id, data: {property: "parent_page"} %>
+          <div class="col-sm-3 display-sidebar-control">
             <%= f.check_box :display_sidebar, label: t('spotlight.administration.show_sidebar') %>
           </div>
         <% end %>
+        </div>
       </div>
     </div>
   </div>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -164,6 +164,8 @@ en:
       order_pages:
         pages_header: Defined Pages
         instructions: Select the pages you want to be shown. Drag and drop pages to change the order in which they are displayed in the sidebar.
+        new_page: "Add new page"
+        save: "Save"
       index:
         home_pages:
           title: Exhibit Home

--- a/spec/features/create_page_spec.rb
+++ b/spec/features/create_page_spec.rb
@@ -19,18 +19,4 @@ describe "Creating a page", :type => :feature do
       expect(page).to have_content "A new one"
     end
   end
-
-  it "should be able to create new About Pages" do
-    login_as exhibit_curator
-
-    visit '/'
-    within '.dropdown-menu' do
-      click_link 'Dashboard'
-    end
-
-    click_link "About pages"
-    click_button "Add new page"
-    expect(page).to have_content "Page was successfully created."
-    expect(page).to have_css("li.dd-item")
-  end
 end

--- a/spec/features/javascript/about_page_admin_spec.rb
+++ b/spec/features/javascript/about_page_admin_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+feature "About Pages Adminstration", js:  true do
+  let(:exhibit_curator) { FactoryGirl.create(:exhibit_curator) }
+  let(:exhibit) { Spotlight::Exhibit.default }
+  before { login_as exhibit_curator }
+  it "should be able to create new pages" do
+    login_as exhibit_curator
+
+    visit '/'
+    click_link exhibit_curator.email
+
+    within '.dropdown-menu' do
+      click_link 'Dashboard'
+    end
+
+    click_link "Feature pages"
+
+    add_new_page_via_button("My New Page")
+
+    expect(page).to have_content "Page was successfully created."
+    expect(page).to have_css("li.dd-item")
+    expect(page).to have_css("h3", text: "My New Page")
+  end
+end

--- a/spec/features/javascript/feature_page_admin_spec.rb
+++ b/spec/features/javascript/feature_page_admin_spec.rb
@@ -19,6 +19,24 @@ feature "Feature Pages Adminstration", js:  true do
     )
   }
   before { login_as exhibit_curator }
+  it "should be able to create new pages" do
+    login_as exhibit_curator
+
+    visit '/'
+    click_link exhibit_curator.email
+
+    within '.dropdown-menu' do
+      click_link 'Dashboard'
+    end
+
+    click_link "Feature pages"
+
+    add_new_page_via_button("My New Page")
+
+    expect(page).to have_content "Page was successfully created."
+    expect(page).to have_css("li.dd-item")
+    expect(page).to have_css("h3", text: "My New Page")
+  end
   it "should update the page titles" do
     visit '/'
     click_link exhibit_curator.email
@@ -31,9 +49,11 @@ feature "Feature Pages Adminstration", js:  true do
     within("[data-id='#{page1.id}']") do
       within("h3") do
         expect(page).to have_content("FeaturePage1")
+        expect(page).to have_css("input", visible: false)
+        click_link("FeaturePage1")
+        expect(page).to have_css("input", visible: true)
+        find("input").set("NewFeaturePage1")
       end
-      click_link "Options"
-      fill_in("Page title", with: "NewFeaturePage1")
     end
     click_button "Save changes"
     expect(page).to have_content("Feature pages were successfully updated.")
@@ -51,13 +71,11 @@ feature "Feature Pages Adminstration", js:  true do
     end
     click_link "Feature pages"
     within("[data-id='#{page1.id}']") do
-      click_link "Options"
       expect(field_labeled("Show sidebar")).to_not be_checked
       check "Show sidebar"
     end
     click_button "Save changes"
     within("[data-id='#{page1.id}']") do
-      click_link "Options"
       expect(field_labeled("Show sidebar")).to be_checked
     end
   end
@@ -104,8 +122,13 @@ feature "Feature Pages Adminstration", js:  true do
 
     click_link "Feature pages"
     within("[data-id='#{page1.id}']") do
-      click_link "Options"
-      fill_in("Page title", with: "NewFancyTitle")
+      within("h3") do
+        expect(page).to have_content("FeaturePage1")
+        expect(page).to have_css("input", visible: false)
+        click_link("FeaturePage1")
+        expect(page).to have_css("input", visible: true)
+        find("input").set("NewFancyTitle")
+      end
     end
     click_link "Home"
     expect(page).not_to have_content("Feature pages were successfully updated.")

--- a/spec/features/javascript/item_text_block_spec.rb
+++ b/spec/features/javascript/item_text_block_spec.rb
@@ -13,7 +13,10 @@ feature "Item + Image Block" do
       click_link 'Dashboard'
     end
     click_link "Feature pages"
-    click_button "Add new page"
+
+    add_new_page_via_button("My New Feature Page")
+
+    expect(page).to have_css("h3", text: "My New Feature Page")
 
     expect(page).to have_content("Page was successfully created.", visible: true)
     within("li.dd-item") do
@@ -54,7 +57,8 @@ feature "Item + Image Block" do
       click_link 'Dashboard'
     end
     click_link "Feature pages"
-    click_button "Add new page"
+
+    add_new_page_via_button
 
     expect(page).to have_content("Page was successfully created.", visible: true)
     within("li.dd-item") do
@@ -101,7 +105,8 @@ feature "Item + Image Block" do
       click_link 'Dashboard'
     end
     click_link "Feature pages"
-    click_button "Add new page"
+
+    add_new_page_via_button
 
     expect(page).to have_content("Page was successfully created.", visible: true)
     within("li.dd-item") do
@@ -145,7 +150,8 @@ feature "Item + Image Block" do
       click_link 'Dashboard'
     end
     click_link "Feature pages"
-    click_button "Add new page"
+
+    add_new_page_via_button
 
     expect(page).to have_content("Page was successfully created.", visible: true)
     within("li.dd-item") do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,3 +52,16 @@ RSpec.configure do |config|
   config.include Controllers::EngineHelpers, type: :controller
   config.include Capybara::DSL
 end
+
+def add_new_page_via_button(title="New Page")
+  add_link = find("[data-expanded-add-button]")
+  within(add_link) do
+    expect(page).to have_css("input[type='text']", visible: false)
+  end
+  add_link.hover
+  within(add_link) do
+    input = find("input[type='text']", visible: true)
+    input.set(title)
+    find("input[type='submit']").click
+  end
+end


### PR DESCRIPTION
Closes #205 

This also adds a title field in the 'Add new page' button.

This PR does not add edit in place for the title of the home page (since that would require moving that into the form).  I'll create another ticket for that.
### New button

---

![screen shot 2014-02-25 at 7 39 51 pm](https://f.cloud.github.com/assets/96776/2266527/848759c6-9e9b-11e3-8696-28f8980ebee0.png)
### Title field in on button hover

---

![screen shot 2014-02-25 at 5 58 42 pm](https://f.cloud.github.com/assets/96776/2266528/927333b6-9e9b-11e3-9a35-5bac62141498.png)
### New page added

---

![screen shot 2014-02-25 at 6 01 21 pm](https://f.cloud.github.com/assets/96776/2266537/b3ddd218-9e9b-11e3-94d4-0fae046dafaf.png)
### Page title edit-in-place

---

![screen shot 2014-02-25 at 5 58 56 pm](https://f.cloud.github.com/assets/96776/2266540/bfc3cde4-9e9b-11e3-8dc5-a330ec6f4a24.png)
