### PR TITLE
style the sir-trevor contenteditable fields like a form control

### DIFF
--- a/app/assets/stylesheets/spotlight/_pages.css.scss
+++ b/app/assets/stylesheets/spotlight/_pages.css.scss
@@ -116,3 +116,10 @@
     }
   }
 }
+
+
+.form-group .st-text-block {
+  @extend .form-control;
+  height: auto;
+  min-height: 6em;
+}


### PR DESCRIPTION
Fixes #353 

I also styled the default text widget the same for consistency. 

![screen shot 2014-02-26 at 12 07 42](https://f.cloud.github.com/assets/111218/2274915/b1f3abe0-9f21-11e3-8c65-5eed5b6b5820.png)
![screen shot 2014-02-26 at 12 07 46](https://f.cloud.github.com/assets/111218/2274914/b1f365fe-9f21-11e3-91f9-2bd8d8f4b05b.png)
