### PR TITLE
Add a #to_s method on the exhibit class.

### DIFF
--- a/app/models/spotlight/exhibit.rb
+++ b/app/models/spotlight/exhibit.rb
@@ -66,6 +66,10 @@ class Spotlight::Exhibit < ActiveRecord::Base
     searches.published.any?
   end
 
+  def to_s
+    title
+  end
+
   protected
 
   def initialize_config

--- a/spec/models/spotlight/exhibit_spec.rb
+++ b/spec/models/spotlight/exhibit_spec.rb
@@ -26,6 +26,12 @@ describe Spotlight::Exhibit do
     expect(subject.errors[:contact_emails]).to eq ['@-foo is not valid']
   end
 
+  it "should have a #to_s" do
+    expect(subject.to_s).to eq "Sample"
+    subject.title = "New Title"
+    expect(subject.to_s).to eq "New Title"
+  end
+
   describe "that is saved" do
     before { subject.save!  }
 


### PR DESCRIPTION
Fixes #349 
This is primarily so that MailForm can properly print out the current exhibit in the email body.

We may want to drop the current exhibit from the email body in the future, but for now this will address the current issue.

![screen shot 2014-02-26 at 1 25 44 pm](https://f.cloud.github.com/assets/96776/2275926/6d7b5d30-9f2d-11e3-8f48-7f43db5e627f.png)
