### PR TITLE
add explicit line-height to glyphicons with sr-only labels

### DIFF
--- a/app/assets/stylesheets/spotlight/_bootstrap_overrides.css.scss
+++ b/app/assets/stylesheets/spotlight/_bootstrap_overrides.css.scss
@@ -27,3 +27,15 @@ h1,h2,h3,h4,h5,h6 {
     vertical-align: super;
   }
 }
+
+.dropdown-toggle {
+  .glyphicon {
+    line-height: 1.5;
+  }
+}
+
+ .search-btn, .view-type-group {
+  .glyphicon {
+    line-height: 1.45;
+  }
+ }


### PR DESCRIPTION
Trying to fix the button groups with a mis-matched glyphicon height (which seems to be a problem with precompiled assets, and intermittently in development mode).. This seems like it works, but I still can't explain why it's a problem for us, but not for the Blacklight demo.
