### PR TITLE
make the autocomplete fields configurable as config.default_autocomplete...

### DIFF
--- a/app/assets/javascripts/spotlight/search_typeahead.js
+++ b/app/assets/javascripts/spotlight/search_typeahead.js
@@ -10,7 +10,7 @@ function initBloodhound() {
       url: $('form[data-autocomplete-url]').data('autocomplete-url') + '?q=%QUERY',
       filter: function(response) {
         return $.map(response['docs'], function(doc) {
-          return { id: doc['id'], title: doc['full_title_tesim'][0] }
+          return { id: doc['id'], title: doc['title'] }
         })
       }
     }

--- a/app/controllers/spotlight/catalog_controller.rb
+++ b/app/controllers/spotlight/catalog_controller.rb
@@ -41,11 +41,11 @@ class Spotlight::CatalogController < Spotlight::ApplicationController
   # setup within their index analyzer. This will ensure that this method returns
   # results when a partial match is passed in the "q" parameter.
   def autocomplete
-    (_, @document_list) = get_search_results(params, :fl => 'id full_title_tesim', :qf => 'id_ng full_title_ng')
+    (_, @document_list) = get_search_results(params, blacklight_config.default_autocomplete_solr_params)
       
     respond_to do |format|
       format.json do
-        render json: {docs: @document_list}
+        render json: {docs: @document_list.map { |doc| { id: doc.id, title: view_context.document_heading(doc) }}}
       end
     end
   end

--- a/app/models/spotlight/blacklight_configuration.rb
+++ b/app/models/spotlight/blacklight_configuration.rb
@@ -58,6 +58,8 @@ module Spotlight
 
         config.index.timestamp_field ||= 'timestamp'
 
+        config.default_autocomplete_solr_params[:fl] = "id #{config.index.title_field}"
+
         config.default_solr_params = config.default_solr_params.merge(default_solr_params)
 
         config.show.partials.insert(2, "spotlight/catalog/tags")

--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -30,6 +30,7 @@ module Spotlight
     end
 
     Blacklight::Engine.config.inject_blacklight_helpers = false
+    Blacklight::Configuration.default_values[:default_autocomplete_solr_params] = {fl: '*', qf: 'id^1000 full_title_tesim^100 id_ng full_title_ng'}
 
   end
 end

--- a/spec/controllers/spotlight/catalog_controller_spec.rb
+++ b/spec/controllers/spotlight/catalog_controller_spec.rb
@@ -65,7 +65,7 @@ describe Spotlight::CatalogController do
         expect(response).to be_successful
         json = JSON.parse(response.body)
         expect(json['docs'].first['id']).to eq 'dx157dh4345'
-        expect(json['docs'].first['full_title_tesim']).to eq ["KAART der REYZE van drie Schepen naar het ZUYDLAND in de Jaaren 1721 en 1722"]
+        expect(json['docs'].first['title']).to eq "KAART der REYZE van drie Schepen naar het ZUYDLAND in de Jaaren 1721 en 1722"
       end
       it "should have partial matches for id" do
         get :autocomplete, exhibit_id: exhibit, q: 'dx157', format: 'json'
@@ -73,7 +73,7 @@ describe Spotlight::CatalogController do
         expect(response).to be_successful
         json = JSON.parse(response.body)
         expect(json['docs'].first['id']).to eq 'dx157dh4345'
-        expect(json['docs'].first['full_title_tesim']).to eq ["KAART der REYZE van drie Schepen naar het ZUYDLAND in de Jaaren 1721 en 1722"]
+        expect(json['docs'].first['title']).to eq "KAART der REYZE van drie Schepen naar het ZUYDLAND in de Jaaren 1721 en 1722"
       end
     end
   end


### PR DESCRIPTION
..._solr_params, and don't hard-code solr fields in the javascript
