### PR TITLE
Fixed dragable styling for Firefox. Fixes #291

### DIFF
--- a/app/assets/stylesheets/spotlight/_blacklight_configuration.css.scss
+++ b/app/assets/stylesheets/spotlight/_blacklight_configuration.css.scss
@@ -1,8 +1,8 @@
-#nested-fields {
-  margin-bottom: 1em;
-  .dd-item td:first-child {
-    padding-left: 40px;
-    position: relative;
+.dd-item td {
+  text-align:center;
+
+  &:first-child {
+    padding: 0;
     
     a {
       cursor: text;
@@ -13,21 +13,21 @@
       background: #F7F7D0;
       cursor: text;
     }
-  }
 
-  th:first-child {
-    padding-left: 40px;
-  }
-
-  th, td {
-    &:first-child {
-      text-align: left;
+    // the effect of position: relative on table elements is undefined, so put a div in there.
+    // this fix is for Firefox
+    .handle-wrap {
+      position: relative;
+      padding: 8px 8px 8px 40px;
+      margin: 0;
+      margin-top: -1px;
+      
     }
 
-    text-align:center;
+    text-align: left;
   }
 
-  .checkbox-cell  {
+  &.checkbox-cell  {
     padding-top: 0;
     padding-bottom: 0;
 
@@ -45,4 +45,16 @@
       margin: 0;
     }
   }
+}
+
+#nested-fields {
+  margin-bottom: 1em;
+  th {
+    &:first-child {
+      padding-left: 40px;
+      text-align: left;
+    }
+    text-align:center;
+  }
+
 }

--- a/app/assets/stylesheets/spotlight/_nestable.css.scss
+++ b/app/assets/stylesheets/spotlight/_nestable.css.scss
@@ -92,7 +92,10 @@ tr.dd-item {
 
 .dd3-item > button { margin-left: 30px; }
 
-.dd3-handle { position: absolute; margin: 0; left: 0; top: 0; cursor: pointer; width: 30px; text-indent: 100%; white-space: nowrap; overflow: hidden;
+.dd3-handle { 
+    position: absolute; margin: 0; left: 0; top: 0; cursor: pointer; width: 30px;
+    text-indent: 100px;
+    white-space: nowrap; overflow: hidden;
     border: 1px solid #aaa;
     background: #ddd;
     background: -webkit-linear-gradient(top, #ddd 0%, #bbb 100%);

--- a/app/views/spotlight/blacklight_configurations/edit_metadata_fields.html.erb
+++ b/app/views/spotlight/blacklight_configurations/edit_metadata_fields.html.erb
@@ -23,11 +23,13 @@
               <tr data-id="<%= key.parameterize %>" class="dd-item">
                 <%= idxf.fields_for key do |field| %>
                   <td>
-                    <%= field.hidden_field :weight, 'data-property' => 'weight' %>
-                    <div class="dd-handle dd3-handle"><%= t :drag %></div>
+                    <div class="handle-wrap">
+                      <%= field.hidden_field :weight, 'data-property' => 'weight' %>
+                      <div class="dd-handle dd3-handle"><%= t :drag %></div>
 
-                  <a href="#edit-in-place" class="field-label"><%= config.label %></a>
-                  <%= field.hidden_field :label, value: config.label, class: 'form-control input-sm' %>
+                      <a href="#edit-in-place" class="field-label"><%= config.label %></a>
+                      <%= field.hidden_field :label, value: config.label, class: 'form-control input-sm' %>
+                     </div>
                   </td>
                   <td class="checkbox-cell"><%= field.check_box :show, inline: true, checked: config.show, label: "" %></td>
                   <% @blacklight_configuration.blacklight_config.view.keys.each do |type| %>


### PR DESCRIPTION
- Switched text-indent from 100% to 100px to move the "D" over so that it
  wasn't visible.
- Since position: relative isn't defined for table elements, I added a
  div which can have relative position inside the first column.
- Moved styles out of the #nested-fields scope, because when an element
  is picked up, it is not within #nested-fields and it loses its
  styles.
