### PR TITLE
Serialize observed forms on sir-trevor editor instantiation

### DIFF
--- a/app/assets/javascripts/spotlight/pages.js
+++ b/app/assets/javascripts/spotlight/pages.js
@@ -40,7 +40,12 @@ Spotlight.onLoad(function(){
 
   while (l--) {
     instance = $(instances[l]);
-    new SirTrevor.Editor({ el: instance });
+    new SirTrevor.Editor({
+      el: instance,
+      onEditorRender: function() {
+        serializeObservedForms(observedForms());
+      }
+    });
   }
 
 });


### PR DESCRIPTION
Sometimes the order of events causes an observed form to be
serialized before sir-trevor has rendered the form elements
and their values. This re-serializes the form when sir-trevor
renders the editor.
