### PR TITLE
Make drag handle 100% height and remove js to manually set height.

### DIFF
--- a/app/assets/javascripts/spotlight/pages.js
+++ b/app/assets/javascripts/spotlight/pages.js
@@ -11,23 +11,13 @@ Spotlight.onLoad(function() {
   updateWeightsAndRelationships($('#nested-pages'));
   updateWeightsAndRelationships($('.contacts_admin'));
 
-   $.each($('.dd-handle'), function(k, el){
-      var height;
-      if ($(el).next('.dd3-content').length > 0) {
-        height = $(el).next('.dd3-content').outerHeight();
-      } else {
-        height = $(el).closest(".dd-item").outerHeight();
-      }
-      $(el).css('height', height);
-    });
+  SirTrevor.EventBus.on('block:create:new', addTitleToSirTrevorBlock);
+  SirTrevor.EventBus.on('block:create:existing', addTitleToSirTrevorBlock);
 
-    SirTrevor.EventBus.on('block:create:new', addTitleToSirTrevorBlock);
-    SirTrevor.EventBus.on('block:create:existing', addTitleToSirTrevorBlock);
-
-    $('.slideshow-indicators li').on('click', function() {
-      $(this).closest('.slideshow').find('li.active').removeClass('active');
-      $(this).addClass('active');
-    });
+  $('.slideshow-indicators li').on('click', function() {
+    $(this).closest('.slideshow').find('li.active').removeClass('active');
+    $(this).addClass('active');
+  });
 });
 
 Spotlight.onLoad(function(){

--- a/app/assets/stylesheets/spotlight/_nestable.css.scss
+++ b/app/assets/stylesheets/spotlight/_nestable.css.scss
@@ -30,7 +30,7 @@ tr.dd-item {
 .dd-empty,
 .dd-placeholder { display: block; position: relative; margin: 0; padding: 0; min-height: 20px; font-size: 13px; line-height: 20px; }
 .dd-item .panel-heading {min-height: 71px;}
-.dd-handle { display: block; height: 73px; margin: 5px 0; padding: 5px 10px; color: #333; text-decoration: none; font-weight: bold; border: 1px solid #ccc;
+.dd-handle { display: block; height: 100%; margin: 5px 0; padding: 5px 10px; color: #333; text-decoration: none; font-weight: bold; border: 1px solid #ccc;
     background: #fafafa;
     background: -webkit-linear-gradient(top, #fafafa 0%, #eee 100%);
     background:    -moz-linear-gradient(top, #fafafa 0%, #eee 100%);


### PR DESCRIPTION
## PROPOSAL

At first a 100% height handle seemed like a bad idea because of the expand/collapse sections on feature pages (since removed) and facet configuration.  Currently we've been setting a height then updating with javascript to fit the height of the containing element.  This causes certain issues when the height of the parent element changes after page load (e.g. edit-in-place).  I think having the drag handle be 100% of the height of collapsible areas is better than the oddities around setting the hight in javascript.

The only issue that I see is if we don't want the handle to be 100% height on expanded elements and there is an odd 1 pixel space on metadata fields that I can't seem to address (but perhaps isn't that big of a deal).  Screenshots of the current handles and the proposed handles as of this PR attached below.
### Current Handles
#### Facets

---

![current-facet-handle](https://f.cloud.github.com/assets/96776/2299742/9c36bc12-a0d3-11e3-8793-514f536f27d1.png)
#### Edit-in-place titles

---

![current-edit-in-place](https://f.cloud.github.com/assets/96776/2299745/ac73949c-a0d3-11e3-9240-816e9a09ac6e.png)
#### Metadata fields

---

![current-metadata-handles](https://f.cloud.github.com/assets/96776/2299746/bd071a54-a0d3-11e3-929a-b154dd30a6a5.png)
### Proposed Handles
#### Facets

---

![propsed-facet-handle](https://f.cloud.github.com/assets/96776/2299756/d5e03eb6-a0d3-11e3-8d13-a1e3dc11a77e.png)
#### Edit-in-place titles

---

![propsed-edit-in-place](https://f.cloud.github.com/assets/96776/2299758/e0d1e0d6-a0d3-11e3-89b4-34db92db8984.png)
#### Metadata fields

---

![proposed-metadata-handles](https://f.cloud.github.com/assets/96776/2299760/ed6f7d6c-a0d3-11e3-818e-4c6178b4be30.png)
