### PR TITLE
Move drag handle inside panel and make panel relative to make parent/child pages look better.

### DIFF
--- a/app/assets/stylesheets/spotlight/_nestable.css.scss
+++ b/app/assets/stylesheets/spotlight/_nestable.css.scss
@@ -87,6 +87,9 @@ tr.dd-item {
             border-radius: 3px;
     box-sizing: border-box; -moz-box-sizing: border-box;
 }
+.dd3-content.page-admin {
+  position: relative;
+}
 .dd3-content .panel-body {background: white;}
 .dd-dragel > .dd3-item > .dd3-content { margin: 0; }
 

--- a/app/views/spotlight/pages/_page.html.erb
+++ b/app/views/spotlight/pages/_page.html.erb
@@ -1,11 +1,8 @@
 <% page = f.object %>
 <li class="dd-item dd3-item" data-id="<%= page.id %>">
-  <div class="dd-handle dd3-handle"><%= t :drag %></div>
-  <div class="dd3-content panel panel-default">
+  <div class="dd3-content panel panel-default page-admin">
+    <div class="dd-handle dd3-handle"><%= t :drag %></div>
     <div class="panel-heading page">
-      <!-- <a class="pull-right btn btn-link" data-toggle="collapse" href="#collapse-page-<%= page.id %>"><%= t(:'spotlight.feature_pages.options') %>
-        <span class="glyphicon glyphicon-chevron-right"></span>
-      </a> -->
       <div class="publish-control">
         <%= f.check_box :published, label: '' %>
       </div>


### PR DESCRIPTION
Forgot about what child pages would do to the changed drag handle.  It currently looks like
![screen shot 2014-03-03 at 1 21 55 pm](https://f.cloud.github.com/assets/96776/2314722/7f4ce75e-a31a-11e3-8664-61631cceb1c0.png)

And this PR changes that to:
![screen shot 2014-03-03 at 1 22 13 pm](https://f.cloud.github.com/assets/96776/2314725/851803e4-a31a-11e3-9458-3112c7551979.png)
