### PR TITLE
Reset warden after each feature spec.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,6 +51,7 @@ RSpec.configure do |config|
   config.include Devise::TestHelpers, type: :view
   config.include Spotlight::TestViewHelpers, type: :view
   config.include Warden::Test::Helpers, type: :feature
+  config.after(:each, type: :feature) { Warden.test_reset! }
   config.include Controllers::EngineHelpers, type: :controller
   config.include Capybara::DSL
 end


### PR DESCRIPTION
This ensures the user session does not carryover from test to test.
