### PR TITLE
Change Add New Page button interaction.

### DIFF
--- a/app/assets/javascripts/spotlight/add_new_page_button.js
+++ b/app/assets/javascripts/spotlight/add_new_page_button.js
@@ -1,0 +1,74 @@
+(function($){
+  $.fn.addNewPageButton = function( options ) {
+    $.each(this, function(){
+      addExpandBehaviorToButton($(this));
+    });
+    function addExpandBehaviorToButton(button){
+      var settings = $.extend({
+        speed: (button.data('speed') || 450),
+        animate_width: (button.data('animate_width') || 425)
+      }, options);
+      var target = $(button.data('field-target'));
+      var save   = $("input[data-behavior='save']", target);
+      var cancel = $("input[data-behavior='cancel']", target);
+      var input  = $("input[type='text']", target);
+      var original_width  = button.outerWidth();
+
+      // Animate button open when the mouse enters or
+      // the button is given focus (i.e. clicked/tabbed)
+      button.on("mouseenter focus", function(){
+        expandButton();
+      });
+
+      // Don't allow blank titles
+      save.on('click', function(){
+        if ( inputEmpty() ) {
+          return false;
+        }
+      });
+
+      // Empty input and collapse
+      // button on cancel click
+      cancel.on('click', function(e){
+        e.preventDefault();
+        input.val('');
+        collapseButton();
+      });
+
+      // Collapse the button on when
+      // an empty input loses focus
+      input.on("blur", function(){
+        if ( inputEmpty() ) {
+          collapseButton();
+        }
+      });
+      function expandButton(){
+        if(button.outerWidth() <= (original_width + 5)) {
+          button.animate(
+            {width: settings.animate_width + 'px'}, settings.speed, function(){
+              target.show(0, function(){
+                input.focus();
+                // Set the button to auto width to make
+                // sure it has room for any inputs
+                button.width("auto");
+                // Explicitly set the width of the button
+                // so the close animation works properly
+                button.width(button.width());
+              });
+            }
+          )
+        }
+      }
+      function collapseButton(){
+        target.hide();
+        button.animate({width: original_width + 'px'}, settings.speed);
+      }
+      function inputEmpty(){
+        return $.trim(input.val()) == "";
+      }
+    }
+  }
+})( jQuery );
+Spotlight.onLoad(function() {
+  $("[data-expanded-add-button]").addNewPageButton();
+});

--- a/app/assets/javascripts/spotlight/pages.js
+++ b/app/assets/javascripts/spotlight/pages.js
@@ -1,7 +1,6 @@
 // Place all the behaviors and hooks related to the matching controller here.
 // All this logic will automatically be available in application.js.
 Spotlight.onLoad(function() {
-  expandAddButton();
   // Initialize Nestable for nested pages
   $('#nested-pages.about_pages_admin').nestable({maxDepth: 1});
   $('#nested-pages.feature_pages_admin').nestable({maxDepth: 2, expandBtnHTML: "", collapseBtnHTML: ""});
@@ -97,51 +96,3 @@ function parent_page_field(node){
 function find_property(node, property) {
   return node.find("input[data-property=" + property + "]");
  }
-function addButtonElement(){
-  return $("[data-expanded-add-button]");
-}
-function expandAddButton(){
-  addButtonElement().each(function(){
-    var button = $(this);
-    var target = $(button.data('field-target'));
-    var save =  $("input[type='submit']", target);
-    var input = $("input[type='text']", target);
-    var width = button.outerWidth();
-    var speed = 450;
-    // Animate button open when the mouse enters or
-    // the button is given focus (i.e. clicked/tabbed)
-    button.on("mouseenter focus", function(){
-      if(button.outerWidth() <= (width + 5)) {
-        $(this).animate(
-          {width: '425px'}, speed, function(){
-            target.show(0, function(){
-              input.focus(); 
-            });
-          }
-        )
-      }
-    });
-    // Don't allow for blank titles
-    save.on('click', function(){
-      if ($.trim(input.val()) == "") {
-        return false;
-      }
-    });
-    $.each([input, save, button], function(){
-      $(this).on("blur", function(){
-        // Give a small timeout so that the 
-        // button doesn't snap back right away.
-        // This is necessary to let certain browsers
-        // (e.g. Firefox) have enough time to submit the form.
-        setTimeout(function(){
-          // Unless the parent button or the save button is focussed
-          if( !input.is(':focus') && !button.is(':focus') && !save.is(':focus') ) {
-            // Hide the input/save button and animate the button closed
-            target.hide();
-            button.animate({width: width + 'px'}, speed);
-          }
-        }, 100);
-      });
-    });
-  });
-}

--- a/app/assets/stylesheets/spotlight/_curation.css.scss
+++ b/app/assets/stylesheets/spotlight/_curation.css.scss
@@ -7,12 +7,13 @@
   font-style: italic;
 }
 .expanded-add-button {
-  position: relative;
   display: inline-block;
   .input-field {
     input[type='text'] {
       @extend .input-sm;
-      width: 247px;
+      height: auto;
+      padding: 0 5px;
+      width: 195px;
       color: black;
       border-color: white;
     }
@@ -21,9 +22,6 @@
       @extend .btn-default;
       @extend .btn-xs;
     }
-    position: absolute;
-    left: 130px;
-    bottom: 2px;
     display: none;
   }
   [data-expanded-add-button] {

--- a/app/views/spotlight/pages/_order_pages.html.erb
+++ b/app/views/spotlight/pages/_order_pages.html.erb
@@ -25,7 +25,8 @@
       <%= t(:'.new_page') %> <span class="glyphicon glyphicon-chevron-right"></span>
       <span data-title-field="true" class="input-field">
         <%= f.text_field(:title) %>
-        <%= f.submit t(:'.save') %>
+        <%= f.submit t(:'.save'), data: {behavior: "save"} %>
+        <%= f.submit t(:'.cancel'), data: {behavior: "cancel"} %>
       </span>
     </a>
   <%- end -%>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -182,6 +182,7 @@ en:
         instructions: Select the pages you want to be shown. Drag and drop pages to change the order in which they are displayed in the sidebar.
         new_page: "Add new page"
         save: "Save"
+        cancel: "Cancel"
       index:
         home_pages:
           title: Exhibit Home

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,6 +65,6 @@ def add_new_page_via_button(title="New Page")
   within(add_link) do
     input = find("input[type='text']", visible: true)
     input.set(title)
-    find("input[type='submit']").click
+    find("input[data-behavior='save']").click
   end
 end


### PR DESCRIPTION
Turn into a plugin.
Add cancel button.
Only collapse button when input is empty (unless on 'Cancel' click).

Fixes #437 

![screen shot 2014-03-06 at 9 17 05 pm](https://f.cloud.github.com/assets/96776/2354243/29cb5782-a5ba-11e3-8b1d-c57825f832b4.png)
