### PR TITLE
use .navbar-right to position the more exhibits dropdown

### DIFF
--- a/app/assets/stylesheets/spotlight/_bootstrap_overrides.css.scss
+++ b/app/assets/stylesheets/spotlight/_bootstrap_overrides.css.scss
@@ -8,6 +8,15 @@
   }
 }
 
+.navbar-sm {
+  li > a {
+    padding-top:$padding-base-vertical !important;
+    padding-bottom:$padding-base-vertical !important;
+  }
+
+  margin-top: -10px;
+}
+
 .sidenav {
 
   margin-bottom: 24px;
@@ -47,4 +56,3 @@ h1,h2,h3,h4,h5,h6 {
 label.radio {
   font-weight: normal;
 }
-

--- a/app/assets/stylesheets/spotlight/_header.css.scss
+++ b/app/assets/stylesheets/spotlight/_header.css.scss
@@ -21,15 +21,8 @@
     display: block;
   }
 
-  ul.navbar-nav {
-    float: right;
-    margin-top: -20px;
-    li a {
-      padding-bottom: 0;
-    }
-  }
-  .site-title {
-    clear: both; // Needed for more-exhibits menu on small screens
+  .more-exhibits {
+    @extend .navbar-right;
   }
 }
 

--- a/app/views/shared/_exhibit_masthead.html.erb
+++ b/app/views/shared/_exhibit_masthead.html.erb
@@ -1,11 +1,11 @@
 <% if current_exhibit %>
 <div id="exhibit-masthead" class="jumbotron">
   <div class="container">
-    <ul class="nav navbar-nav">
+    <ul class="more-exhibits nav navbar-nav navbar-sm">
       <% if Spotlight::Exhibit.many? %>
         <li class="dropdown">
           <a href="#" class="dropdown-toggle" data-toggle="dropdown"><%= t(:'.more_exhibits') %> <b class="caret"></b></a>
-          <ul class="dropdown-menu pull-right">
+          <ul class="dropdown-menu">
             <% Spotlight::Exhibit.where.not(id: current_exhibit).each do |exhibit| %>
               <li>
               <%= link_to exhibit.title, [spotlight, exhibit] %>


### PR DESCRIPTION
After:
![screen shot 2014-03-11 at 8 14 33](https://f.cloud.github.com/assets/111218/2386799/f40a6fd8-a92f-11e3-9092-eb1538caeefe.png)

<hr />

![screen shot 2014-03-11 at 8 14 38](https://f.cloud.github.com/assets/111218/2386798/f3f0eb4e-a92f-11e3-830d-af04e73cb232.png)

<hr />

![screen shot 2014-03-11 at 8 14 47](https://f.cloud.github.com/assets/111218/2386797/f3f0e130-a92f-11e3-9a45-361b5fffe2e6.png)

<hr />

![screen shot 2014-03-11 at 8 14 50](https://f.cloud.github.com/assets/111218/2386796/f3ec4602-a92f-11e3-9212-bf8bb4d48561.png)
