### PR TITLE
Improve consistency of subheading styling on Curation pages. Fixes #555

### DIFF
--- a/app/views/spotlight/about_pages/index.html.erb
+++ b/app/views/spotlight/about_pages/index.html.erb
@@ -4,7 +4,7 @@
   <%= bootstrap_form_for @exhibit, url: exhibit_contacts_path(@exhibit),
       style: :horizontal, html: {class: 'exhibit-contacts'} do |f| %>
     <h3><%= t :".contacts" %></h3>
-    <p><%= t :'.instructions' %></p>
+    <p class="instructions"><%= t :'.instructions' %></p>
     <div class="panel-group dd contacts_admin">
       <ol class="dd-list">
         <%= f.fields_for :contacts do |c| %>

--- a/app/views/spotlight/exhibits/import.html.erb
+++ b/app/views/spotlight/exhibits/import.html.erb
@@ -4,7 +4,7 @@
 <%= bootstrap_form_for [:import, @exhibit], html: { class: 'clearfix', multipart: true } do |f| %>
   <div class="row col-md-9">
     <h3><%= t :'.import.header' %></h3>
-    <p><%= t :'.import.instructions' %></p>
+    <p class="instructions"><%= t :'.import.instructions' %></p>
     <div class="form-group">
       <%= file_field_tag :file, class: 'form-control' %>
     </div>
@@ -19,7 +19,7 @@
 
   <div class="row col-md-9">
     <h3><%= t :'.export.header' %></h3>
-    <p><%= t :'.export.instructions' %></p>
+    <p class="instructions"><%= t :'.export.instructions' %></p>
     <%= link_to t(:'.export.download'), get_exhibit_path(@exhibit, format: 'json'), class: 'btn btn-default' %>
   </div>
 </div>

--- a/app/views/spotlight/pages/_order_pages.html.erb
+++ b/app/views/spotlight/pages/_order_pages.html.erb
@@ -3,7 +3,7 @@
 
     <%= render partial: 'header', locals: {f: f} %>
     <h3><%= t :'.pages_header' %></h3>
-    <p><%= t :'.instructions' %></p>
+    <p class="instructions"><%= t :'.instructions' %></p>
     <div class="panel-group dd <%= page_collection_name %>_admin" id="nested-pages">
       <ol class="dd-list">
         <%= f.fields_for page_collection_name do |p| %>

--- a/app/views/spotlight/searches/index.html.erb
+++ b/app/views/spotlight/searches/index.html.erb
@@ -6,9 +6,9 @@
   <% if @searches.empty? %>
     <%= t :'.no_saved_searches' %>
   <% else %>
+      <p class="instructions"><%= t(:'.instructions') %></p>
   <%= bootstrap_form_for @exhibit, url: update_all_exhibit_searches_path(@exhibit), style: :horizontal, right: "col-sm-10" do |f| %>
 
-    <p class="instructions"><%= t(:'.instructions') %></p>
     <div class="panel-group dd search_admin" id="nested-pages">
       <ol class="dd-list">
       <%= f.fields_for :searches do |p| %>


### PR DESCRIPTION
Just added `class="instructions"` (and in one case moved the relevant `p`) to get the border styling between the H3 and paragraph tags.

![curation_-_about_pages___default_exhibit_-_blacklight](https://f.cloud.github.com/assets/101482/2432782/ef482e02-ad73-11e3-8ab2-16ec875254e0.png)
