### PR TITLE
add Spotlight access control enforcement to browse and pages controllers...

### DIFF
--- a/app/controllers/spotlight/browse_controller.rb
+++ b/app/controllers/spotlight/browse_controller.rb
@@ -2,6 +2,7 @@ module Spotlight
   class BrowseController < Spotlight::ApplicationController
     load_resource :exhibit, class: "Spotlight::Exhibit"
     include Spotlight::Base
+    include Spotlight::Catalog::AccessControlsEnforcement
 
     load_and_authorize_resource :search, except: :index, through: :exhibit, parent: false
     before_filter :attach_breadcrumbs

--- a/app/controllers/spotlight/pages_controller.rb
+++ b/app/controllers/spotlight/pages_controller.rb
@@ -5,6 +5,7 @@ module Spotlight
 
     include Spotlight::Base
     include Blacklight::Catalog::SearchContext
+    include Spotlight::Catalog::AccessControlsEnforcement
 
     helper_method :get_search_results, :get_solr_response_for_doc_id, :get_solr_response_for_field_values, :page_collection_name
 

--- a/app/controllers/spotlight/searches_controller.rb
+++ b/app/controllers/spotlight/searches_controller.rb
@@ -5,7 +5,6 @@ class Spotlight::SearchesController < Spotlight::ApplicationController
   load_and_authorize_resource through: :exhibit
   before_filter :attach_breadcrumbs, only: [:index, :edit], unless: -> { request.format.json? }
 
-
   def create
     params_copy = params.dup
     params_copy.delete(:exhibit_id)

--- a/app/models/spotlight/search.rb
+++ b/app/models/spotlight/search.rb
@@ -14,6 +14,7 @@ class Spotlight::Search < ActiveRecord::Base
   end
 
   include Blacklight::SolrHelper
+  include Spotlight::Catalog::AccessControlsEnforcement
 
   def count
     query_solr(query_params, rows: 0, facet: false)['response']['numFound']
@@ -47,5 +48,7 @@ class Spotlight::Search < ActiveRecord::Base
   def blacklight_config
     exhibit.blacklight_config
   end
+  
+  alias_method :current_exhibit, :exhibit
 
 end

--- a/lib/spotlight/catalog/access_controls_enforcement.rb
+++ b/lib/spotlight/catalog/access_controls_enforcement.rb
@@ -8,8 +8,7 @@ module Spotlight::Catalog::AccessControlsEnforcement
   protected
 
   def apply_permissive_visibility_filter solr_params, user_params
-    unless can? :curate, current_exhibit
-      solr_params.append_filter_query "-#{Spotlight::SolrDocument.visibility_field(current_exhibit)}:false"
-    end
+    return if respond_to? :can? and can? :curate, current_exhibit
+    solr_params.append_filter_query "-#{Spotlight::SolrDocument.visibility_field(current_exhibit)}:false"
   end
 end

--- a/spec/controllers/spotlight/about_pages_controller_spec.rb
+++ b/spec/controllers/spotlight/about_pages_controller_spec.rb
@@ -3,6 +3,9 @@ require 'spec_helper'
 describe Spotlight::AboutPagesController do
   routes { Spotlight::Engine.routes }
   let(:valid_attributes) { { "title" => "MyString" } }
+
+  it { should be_a Spotlight::Catalog::AccessControlsEnforcement }
+
   describe "when not logged in" do
 
     describe "POST update_all" do

--- a/spec/controllers/spotlight/browse_controller_spec.rb
+++ b/spec/controllers/spotlight/browse_controller_spec.rb
@@ -6,6 +6,8 @@ describe Spotlight::BrowseController do
   let!(:search) { FactoryGirl.create(:published_search, exhibit: exhibit) }
   let!(:unpublished) { FactoryGirl.create(:search, exhibit: exhibit) }
 
+  it { should be_a Spotlight::Catalog::AccessControlsEnforcement }
+
   describe "#index" do
     it "should show the list of browse categories" do
       expect(controller).to receive(:add_breadcrumb).with("Home", exhibit)

--- a/spec/controllers/spotlight/feature_pages_controller_spec.rb
+++ b/spec/controllers/spotlight/feature_pages_controller_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 describe Spotlight::FeaturePagesController do
   routes { Spotlight::Engine.routes }
 
+  it { should be_a Spotlight::Catalog::AccessControlsEnforcement }
+
   # This should return the minimal set of attributes required to create a valid
   # Page. As you add validations to Page, be sure to
   # adjust the attributes here as well.

--- a/spec/controllers/spotlight/home_pages_controller_spec.rb
+++ b/spec/controllers/spotlight/home_pages_controller_spec.rb
@@ -6,6 +6,8 @@ describe Spotlight::HomePagesController do
   let(:exhibit) { FactoryGirl.create(:exhibit) }
   let(:page) { exhibit.home_page }
 
+  it { should be_a Spotlight::Catalog::AccessControlsEnforcement }
+
   describe "when signed in as a curator" do
     let(:user) { FactoryGirl.create(:exhibit_curator) }
     before do

--- a/spec/models/spotlight/search_spec.rb
+++ b/spec/models/spotlight/search_spec.rb
@@ -7,6 +7,8 @@ describe Spotlight::Search do
     subject.exhibit = FactoryGirl.create(:exhibit)
   end
 
+  it { should be_a Spotlight::Catalog::AccessControlsEnforcement }
+
   it "should have a default feature image" do
     subject.stub(images: [['title', 'image_url'], ['title1', 'image2']])
     subject.save


### PR DESCRIPTION
... and the search model, so they respect exhibit visibility

ref #533
