### PR TITLE
update searches controller to redirect to :back instead of the catalog index page; fixes #544

### DIFF
--- a/app/controllers/spotlight/searches_controller.rb
+++ b/app/controllers/spotlight/searches_controller.rb
@@ -13,7 +13,7 @@ class Spotlight::SearchesController < Spotlight::ApplicationController
     @search.query_params = params_copy.reject { |k,v| blacklisted_search_session_params.include?(k.to_sym) or v.blank? }
     @search.save!
 
-    redirect_to exhibit_catalog_index_path(@search.exhibit), notice: t(:'helpers.submit.search.created', model: @search.class.model_name.human.downcase)
+    redirect_to :back, notice: t(:'helpers.submit.search.created', model: @search.class.model_name.human.downcase)
   end
 
   def index

--- a/spec/controllers/spotlight/searches_controller_spec.rb
+++ b/spec/controllers/spotlight/searches_controller_spec.rb
@@ -30,8 +30,9 @@ describe Spotlight::SearchesController do
     let(:search) { FactoryGirl.create(:search, exhibit: exhibit) }
 
     it "should create a saved search" do
+      request.env["HTTP_REFERER"] = "/referring_url"
       post :create, "search"=>{"title"=>"A bunch of maps"}, "f"=>{"genre_ssim"=>["map"]}, exhibit_id: exhibit 
-      expect(response).to redirect_to exhibit_catalog_index_path(exhibit)
+      expect(response).to redirect_to "/referring_url"
       expect(flash[:notice]).to eq "The search was created."
       expect(assigns[:search].title).to eq "A bunch of maps"
       expect(assigns[:search].query_params).to eq("f"=>{"genre_ssim"=>["map"]})


### PR DESCRIPTION
@ggeisler is returning to the original search the right behavior? Should it go to the search#index or search#edit pages instead?
