### PR TITLE
Fix layout of contacts on about pages admin

### DIFF
--- a/app/views/spotlight/about_pages/_contact.html.erb
+++ b/app/views/spotlight/about_pages/_contact.html.erb
@@ -2,14 +2,14 @@
   <div class="dd-handle dd3-handle"><%= t :drag %></div>
   <div class="dd3-content panel panel-default">
     <div class="panel-heading page">
-      <div class="contact-links pull-right">
-        <%= exhibit_edit_link f.object, :class => 'btn btn-link' %> &middot;
-        <%= exhibit_delete_link f.object, :class => 'btn btn-link' %>
-      </div>
       <%= f.check_box :show_in_sidebar, label: '' %>
       <%= f.hidden_field :id %>
       <%= f.hidden_field :weight, data: {property: "weight"} %>
       <div class="main">
+        <div class="contact-links pull-right">
+          <%= exhibit_edit_link f.object, :class => 'btn btn-link' %> &middot;
+          <%= exhibit_delete_link f.object, :class => 'btn btn-link' %>
+        </div>
         <%= render partial: "contact_properties", locals: {contact: f.object} %>
       </div>
     </div>


### PR DESCRIPTION
Fixes #518 

![contacts-layout](https://f.cloud.github.com/assets/96776/2455243/cf0f78a6-aefa-11e3-9f7c-00b848cb1356.png)

NOTE: I address the issue of the checkbox styling in the panel in another PR.
