### PR TITLE
Only display published browse categories on Browse#index.

### DIFF
--- a/app/controllers/spotlight/browse_controller.rb
+++ b/app/controllers/spotlight/browse_controller.rb
@@ -9,7 +9,7 @@ module Spotlight
     record_search_parameters only: :show
     
     def index
-      @searches = @exhibit.searches.accessible_by(current_ability)
+      @searches = @exhibit.searches.published
     end
 
     def show

--- a/spec/controllers/spotlight/browse_controller_spec.rb
+++ b/spec/controllers/spotlight/browse_controller_spec.rb
@@ -5,40 +5,59 @@ describe Spotlight::BrowseController do
   let(:exhibit) { FactoryGirl.create(:exhibit) }
   let!(:search) { FactoryGirl.create(:published_search, exhibit: exhibit) }
   let!(:unpublished) { FactoryGirl.create(:search, exhibit: exhibit) }
+  let(:admin) { FactoryGirl.create(:site_admin) }
 
   it { should be_a Spotlight::Catalog::AccessControlsEnforcement }
 
-  describe "#index" do
-    it "should show the list of browse categories" do
-      expect(controller).to receive(:add_breadcrumb).with("Home", exhibit)
-      expect(controller).to receive(:add_breadcrumb).with("Browse", exhibit_browse_index_path(exhibit))
-      get :index, exhibit_id: exhibit
-      expect(response).to be_successful
-      expect(assigns[:searches]).to eq [search]
-      expect(assigns[:searches]).to_not include unpublished
-      expect(assigns[:exhibit]).to eq exhibit
-      expect(response).to render_template "spotlight/browse/index"
+  describe "when authenticated as an admin" do
+    before { sign_in admin }
+    describe "#index" do
+      it "should not show unpublished categories" do
+        expect(controller).to receive(:add_breadcrumb).with("Home", exhibit)
+        expect(controller).to receive(:add_breadcrumb).with("Browse", exhibit_browse_index_path(exhibit))
+        get :index, exhibit_id: exhibit
+        expect(response).to be_successful
+        expect(assigns[:searches]).to eq [search]
+        expect(assigns[:searches]).to_not include unpublished
+        expect(assigns[:exhibit]).to eq exhibit
+        expect(response).to render_template "spotlight/browse/index"
+      end
     end
   end
 
-  describe "#show" do
-    let(:mock_response) { double }
-    let(:document_list) { double }
-    before do
-      controller.stub(get_search_results: [mock_response, document_list])
-    end
-    it "should show the items in the category" do
-      expect(controller).to receive(:add_breadcrumb).with("Home", exhibit)
-      expect(controller).to receive(:add_breadcrumb).with("Browse", exhibit_browse_index_path(exhibit))
-      expect(controller).to receive(:add_breadcrumb).with(search.title, exhibit_browse_path(exhibit, search))
-      get :show, id: search, exhibit_id: exhibit
-      expect(response).to be_successful
-      expect(assigns[:search]).to be_a Spotlight::Search
-      expect(assigns[:response]).to eq mock_response
-      expect(assigns[:document_list]).to eq document_list
-      expect(response).to render_template "spotlight/browse/show"
+  describe "when unauthenticated" do
+    describe "#index" do
+      it "should show the list of browse categories" do
+        expect(controller).to receive(:add_breadcrumb).with("Home", exhibit)
+        expect(controller).to receive(:add_breadcrumb).with("Browse", exhibit_browse_index_path(exhibit))
+        get :index, exhibit_id: exhibit
+        expect(response).to be_successful
+        expect(assigns[:searches]).to eq [search]
+        expect(assigns[:searches]).to_not include unpublished
+        expect(assigns[:exhibit]).to eq exhibit
+        expect(response).to render_template "spotlight/browse/index"
+      end
     end
 
+    describe "#show" do
+      let(:mock_response) { double }
+      let(:document_list) { double }
+      before do
+        controller.stub(get_search_results: [mock_response, document_list])
+      end
+      it "should show the items in the category" do
+        expect(controller).to receive(:add_breadcrumb).with("Home", exhibit)
+        expect(controller).to receive(:add_breadcrumb).with("Browse", exhibit_browse_index_path(exhibit))
+        expect(controller).to receive(:add_breadcrumb).with(search.title, exhibit_browse_path(exhibit, search))
+        get :show, id: search, exhibit_id: exhibit
+        expect(response).to be_successful
+        expect(assigns[:search]).to be_a Spotlight::Search
+        expect(assigns[:response]).to eq mock_response
+        expect(assigns[:document_list]).to eq document_list
+        expect(response).to render_template "spotlight/browse/show"
+      end
+
+    end
   end
 
 end


### PR DESCRIPTION
Fixes #568 

![browse-admin](https://cloud.githubusercontent.com/assets/96776/2556556/a59cb7e2-b6d7-11e3-9aad-708961547195.png)

---

![browse-index](https://cloud.githubusercontent.com/assets/96776/2556557/a9359176-b6d7-11e3-834a-aec04f2aa152.png)
