### PR TITLE
Don't render breadcrumbs on the home page.

### DIFF
--- a/app/controllers/spotlight/home_pages_controller.rb
+++ b/app/controllers/spotlight/home_pages_controller.rb
@@ -4,7 +4,7 @@ module Spotlight
 
     load_and_authorize_resource through: :exhibit, singleton: true, instance_name: 'page'
 
-    before_filter :attach_breadcrumbs
+    before_filter :attach_breadcrumbs, except: :show
 
     def edit
       add_breadcrumb t(:'spotlight.curation.sidebar.feature_pages'), exhibit_feature_pages_path(@exhibit)

--- a/spec/controllers/spotlight/home_pages_controller_spec.rb
+++ b/spec/controllers/spotlight/home_pages_controller_spec.rb
@@ -48,12 +48,17 @@ describe Spotlight::HomePagesController do
 
   describe "Rendering home page" do
     it "should get search results for display facets" do
-      expect(controller).to receive(:add_breadcrumb).with("Home", exhibit_root_path(exhibit))
       controller.stub(get_search_results: [double, double])
       get :show, exhibit_id: exhibit
       expect(assigns[:response]).to_not be_blank
       expect(assigns[:document_list]).to_not be_blank
       expect(assigns[:page]).to eq exhibit.home_page
+    end
+    it "should not render breadcrumbs" do
+      expect(controller).not_to receive(:add_breadcrumb)
+      controller.stub(get_search_results: [double, double])
+      get :show, exhibit_id: exhibit
+      expect(response).to be_successful
     end
   end
 end


### PR DESCRIPTION
Fixes #582 

![breadcrumbs](https://cloud.githubusercontent.com/assets/96776/2573081/368f652e-b91c-11e3-9671-f82e3ec6ef23.png)
