### PR TITLE
Don't call #first on images that are not present.

### DIFF
--- a/app/models/spotlight/search.rb
+++ b/app/models/spotlight/search.rb
@@ -37,7 +37,7 @@ class Spotlight::Search < ActiveRecord::Base
   end
 
   def default_featured_image
-    images.first.last
+    images.first.last if images.present?
   end
 
   private

--- a/spec/models/spotlight/search_spec.rb
+++ b/spec/models/spotlight/search_spec.rb
@@ -15,6 +15,11 @@ describe Spotlight::Search do
     expect(subject.featured_image).to eq 'image_url'
   end
 
+  it "should #default_featured_iamge should not thrown an error when no images are present" do
+    subject.stub(images: nil)
+    expect(subject.default_featured_image).to be_nil
+  end
+
   it "should have items" do
     expect(subject.count).to eq 55
   end


### PR DESCRIPTION
Fixes #593 
