### PR TITLE
Peg bootstrap_form to 2.0.1

### DIFF
--- a/blacklight-spotlight.gemspec
+++ b/blacklight-spotlight.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "sir-trevor-rails"
   s.add_dependency "carrierwave"
   s.add_dependency "mini_magick"
-  s.add_dependency "bootstrap_form"
+  s.add_dependency "bootstrap_form", "~> 2.0.1"
   s.add_dependency "mail_form"
   s.add_dependency "acts-as-taggable-on"
   s.add_dependency "friendly_id"


### PR DESCRIPTION
bootstrap_form 2.1 changes some form input names and introduces a
problem with Blacklight configuration-backed forms. See
https://travis-ci.org/sul-dlss/spotlight/jobs/22049647#L537
