### PR TITLE
Add typeahead support for selecting the featured image of a browse category

### DIFF
--- a/app/assets/javascripts/spotlight/search_typeahead.js
+++ b/app/assets/javascripts/spotlight/search_typeahead.js
@@ -46,3 +46,29 @@ function addAutocompletetoSirTrevorForm() {
       }
     });
 }
+
+function addAutocompletetoFeaturedImage() {
+  var typeaheadElement = $('[data-featured-item-typeahead]');
+  results = initBloodhound();
+  typeaheadElement.typeahead({
+      highlight: true,
+      hint: false,
+      autoselect: true },
+      { displayKey: 'title',
+        source: results.ttAdapter(),
+        templates: {
+          suggestion: Handlebars.compile('<div class="document-thumbnail thumbnail"><img src="{{thumbnail}}" /></div>{{title}}<br/><small>&nbsp;&nbsp;{{description}}</small>'
+        )
+      }
+    }).on('click', function() {
+      $(this).select();
+    }).on('change', function() {
+      $($(this).data('id-field')).val("");
+    }).on('typeahead:selected typeahead:autocompleted', function(e, data) {
+      $($(this).data('id-field')).val(data['id']);
+    });
+}
+
+Spotlight.onLoad(function(){
+  addAutocompletetoFeaturedImage();
+});

--- a/app/assets/javascripts/spotlight/searches.js
+++ b/app/assets/javascripts/spotlight/searches.js
@@ -1,6 +1,0 @@
-Spotlight.onLoad(function() {
-  $("#preview").attr('src', $("#search_featured_image").val());
-  $("#search_featured_image").on("change", function() {
-    $("#preview").attr('src', $(this).val());
-  });
-});

--- a/app/assets/stylesheets/spotlight/typeahead.css
+++ b/app/assets/stylesheets/spotlight/typeahead.css
@@ -34,47 +34,36 @@
 }
 
 .tt-suggestion {
-  padding: 3px 20px;
+  padding: 3px 20px 3px 100px;
   font-size: 18px;
   line-height: 24px;
-}
+  &.tt-cursor {
+    color: #fff;
+    background-color: #0097cf;
+  }
+  p {
+    margin: 0;
+  }
+  .document-thumbnail {
+    float: left;
+    width: 60px;
+    padding: 0;
+    margin: 0;
+    margin-left: -80px;
+    position: relative;
 
-.tt-suggestion.tt-cursor {
-  color: #fff;
-  background-color: #0097cf;
+    img {
+      max-width: 60px;
+      max-height: 60px;
+    }
 
-}
-
-.tt-suggestion p {
-  margin: 0;
-}
-
-
-.st-outer {
-  .tt-suggestion {
-    padding-left: 100px;
-
-    .document-thumbnail {
-      float: left;
-      width: 60px;
-      padding: 0;
-      margin: 0;
-      margin-left: -80px;
-      position: relative;
-
-      img {
-        max-width: 60px;
-        max-height: 60px;
-      }
-
-      img:hover {
-        position: absolute;
-        right: -3px;
-        top: -3px;
-        max-width: 160px;
-        max-height: 100px;
-        border: 3px solid $panel-info-heading-bg;
-      }
+    img:hover {
+      position: absolute;
+      right: -3px;
+      top: -3px;
+      max-width: 160px;
+      max-height: 100px;
+      border: 3px solid $panel-info-heading-bg;
     }
   }
 }

--- a/app/controllers/spotlight/searches_controller.rb
+++ b/app/controllers/spotlight/searches_controller.rb
@@ -28,7 +28,7 @@ class Spotlight::SearchesController < Spotlight::ApplicationController
   end
 
   def update
-    if @search.update params.require(:search).permit(:title, :short_description, :long_description, :featured_image)
+    if @search.update params.require(:search).permit(:title, :short_description, :long_description, :featured_item_id)
       redirect_to exhibit_searches_path(@search.exhibit), notice: t(:'helpers.submit.search.updated', model: @search.class.model_name.human.downcase)
     else
       render action: 'edit'

--- a/app/models/spotlight/search.rb
+++ b/app/models/spotlight/search.rb
@@ -10,11 +10,23 @@ class Spotlight::Search < ActiveRecord::Base
   scope :published, -> { where(on_landing_page: true) }
 
   before_create do
-    self.featured_image ||= default_featured_image
+    self.featured_item_id ||= default_featured_item_id
   end
 
   include Blacklight::SolrHelper
   include Spotlight::Catalog::AccessControlsEnforcement
+
+  def featured_item
+    if self.featured_item_id
+      @featured_item ||= get_solr_response_for_doc_id(self.featured_item_id, query_params).last
+    end
+  end
+
+  def featured_image
+    if featured_item
+      Array[featured_item[blacklight_config.index.thumbnail_field]].flatten.first
+    end
+  end
 
   def count
     query_solr(query_params, rows: 0, facet: false)['response']['numFound']
@@ -23,21 +35,22 @@ class Spotlight::Search < ActiveRecord::Base
   def images
     response = query_solr(query_params,
       rows: 1000,
-      fl: [blacklight_config.index.title_field, blacklight_config.index.thumbnail_field],
+      fl: ['id', blacklight_config.index.title_field, blacklight_config.index.thumbnail_field],
       facet: false)
 
     Blacklight::SolrResponse.new(response, {}).docs.map do |result|
       doc = ::SolrDocument.new(result)
 
       [
+        doc.first('id'),
         doc.first(blacklight_config.index.title_field),
         doc.first(blacklight_config.index.thumbnail_field)
       ]
     end
   end
 
-  def default_featured_image
-    images.first.last if images.present?
+  def default_featured_item_id
+    images.first.first if images.present?
   end
 
   private

--- a/app/views/spotlight/searches/edit.html.erb
+++ b/app/views/spotlight/searches/edit.html.erb
@@ -1,18 +1,20 @@
 <%= render 'spotlight/shared/curation_sidebar' %>
 <div id="content" class="col-md-9">
   <%= curation_page_title %>
-  <%= bootstrap_form_for [@search.exhibit, @search], style: :horizontal, right: "col-sm-5", html: {id: 'edit-search'} do |f| %>
-  <div class="row">
-    <%= f.text_field :title %>
-    <%= f.select :featured_image, f.object.images, {}, prepend: "<img id=\"preview\"></img>".html_safe %>
-    <%= f.text_area :short_description %>
-    <%= f.text_area :long_description %>
-    <div class="form-actions">
-      <div class="primary-actions">
-        <%= cancel_link @search,exhibit_searches_path(@exhibit), class: 'btn btn-default' %>
-        <%= f.submit nil, class: 'btn btn-primary' %>
+  <%= bootstrap_form_for [@search.exhibit, @search], style: :horizontal, right: "col-sm-5", data: {:'autocomplete-url'=> spotlight.autocomplete_exhibit_catalog_index_path(@search.exhibit, format: "json")}, html: {id: 'edit-search'} do |f| %>
+    <div class="row">
+      <%= f.text_field :title %>
+      <%= f.text_field :featured_item_id, value: presenter(@search.featured_item).document_heading, data: {:"featured-item-typeahead" => true, :id_field => "[data-featured-item-id]" }, id: "featured-item-title" %>
+      <%= f.hidden_field :featured_item_id, data: {:"featured-item-id" => true} %>
+      <%= f.text_area :short_description %>
+      <%= f.text_area :long_description %>
+      <div class="form-actions">
+        <div class="primary-actions">
+          <%= cancel_link @search,exhibit_searches_path(@exhibit), class: 'btn btn-default' %>
+          <%= f.submit nil, class: 'btn btn-primary' %>
+        </div>
       </div>
     </div>
-  </div>
-<% end %>
+  <% end %>
+</div>
 

--- a/db/migrate/20140401232956_change_featured_image_to_featured_image_id.rb
+++ b/db/migrate/20140401232956_change_featured_image_to_featured_image_id.rb
@@ -1,0 +1,6 @@
+class ChangeFeaturedImageToFeaturedImageId < ActiveRecord::Migration
+  def change
+    remove_column :spotlight_searches, :featured_image, :string
+    add_column :spotlight_searches, :featured_item_id, :string
+  end
+end

--- a/spec/factories/searches.rb
+++ b/spec/factories/searches.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :search, class: Spotlight::Search do
     exhibit
     title "Search1"
-    featured_image 'https://stacks.stanford.edu/image/dq287tq6352/dq287tq6352_05_0001_thumb'
+    featured_item_id 'dq287tq6352'
   end
 
   factory :published_search, class: Spotlight::Search do

--- a/spec/features/javascript/browse_category_admin_spec.rb
+++ b/spec/features/javascript/browse_category_admin_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe "Browse Category Administration", type: :feature, js: true do
+  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:admin)   { FactoryGirl.create(:exhibit_admin, exhibit: exhibit) }
+  before { login_as admin }
+  describe "Featured Image" do
+    it "should be selectable by choosing a featured item" do
+      visit spotlight.edit_exhibit_search_path exhibit, exhibit.searches.first
+      autocomplete_field = find("input#featured-item-title")
+      fill_in_typeahead_field "search[featured_item_id]", with: "gt736xf9712"
+      click_button "Save changes"
+      expect(page).to have_content "The search was successfully updated."
+      within(".pic.thumbnail") do
+        expect(page).to have_css('img[src="https://stacks.stanford.edu/image/gt736xf9712/gt736xf9712_05_0001_thumb"]')
+      end
+    end
+  end
+end

--- a/spec/models/spotlight/search_spec.rb
+++ b/spec/models/spotlight/search_spec.rb
@@ -10,14 +10,15 @@ describe Spotlight::Search do
   it { should be_a Spotlight::Catalog::AccessControlsEnforcement }
 
   it "should have a default feature image" do
-    subject.stub(images: [['title', 'image_url'], ['title1', 'image2']])
+    subject.stub(images: [['dq287tq6352', 'title', 'image_url']])
+    subject.stub(:featured_item_id).and_return("dq287tq6352")
     subject.save
-    expect(subject.featured_image).to eq 'image_url'
+    expect(subject.featured_image).to eq "https://stacks.stanford.edu/image/dq287tq6352/dq287tq6352_05_0001_thumb"
   end
 
   it "should #default_featured_iamge should not thrown an error when no images are present" do
     subject.stub(images: nil)
-    expect(subject.default_featured_image).to be_nil
+    expect(subject.default_featured_item_id).to be_nil
   end
 
   it "should have items" do

--- a/spec/views/spotlight/searches/_search.html.erb_spec.rb
+++ b/spec/views/spotlight/searches/_search.html.erb_spec.rb
@@ -7,6 +7,8 @@ describe "spotlight/searches/_search.html.erb" do
   before do
     view.stub(:edit_search_path).and_return("/edit")
     view.stub(:search_path).and_return("/search")
+    search.stub(:featured_item_id).and_return("dq287tq6352")
+    search.stub(:params).and_return({})
 
     form_for(search, url: '/update') do |f|
       @f = f
@@ -17,6 +19,7 @@ describe "spotlight/searches/_search.html.erb" do
     render :partial => "spotlight/searches/search", :locals => { f: @f}
     expect(rendered).to have_selector "li[data-id='99']"
     expect(rendered).to have_selector '.panel-heading .main .title', text: 'Title1'
+    expect(rendered).to have_selector 'img[src="https://stacks.stanford.edu/image/dq287tq6352/dq287tq6352_05_0001_thumb"]'
     expect(rendered).to have_selector 'input[type=hidden][data-property=weight]'
   end
 end


### PR DESCRIPTION
Fixes #546 

Change from storing the URL of a featured image to storing the solr document ID of a featured item.

`featured_image` still exists and returns the configured thumbnail url of the `featured_item`.

![browse-typeahead](https://cloud.githubusercontent.com/assets/96776/2597309/4d77c2e4-bab2-11e3-85a2-97b652c40312.png)
