### PR TITLE
Peg to acts-as-taggable-on 3.1.0.

### DIFF
--- a/blacklight-spotlight.gemspec
+++ b/blacklight-spotlight.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency "mini_magick"
   s.add_dependency "bootstrap_form", "~> 2.0.1"
   s.add_dependency "mail_form"
-  s.add_dependency "acts-as-taggable-on"
+  s.add_dependency "acts-as-taggable-on", "3.1.0"
   s.add_dependency "friendly_id"
   s.add_dependency "breadcrumbs_on_rails", "~> 2.3.0"
   s.add_dependency "social-share-button", "~> 0.1.5"


### PR DESCRIPTION
Not sure why 3.1.1 breaks. Maintainer has no 3.1.1 tag in GitHub currently.

Fixing test errors in https://travis-ci.org/sul-dlss/spotlight/builds/22243366
