### PR TITLE
Call trigger('click') on slideshow element.

### DIFF
--- a/spec/features/slideshow_spec.rb
+++ b/spec/features/slideshow_spec.rb
@@ -14,7 +14,7 @@ describe "Slideshow", js: true do
     within ".view-type" do
       click_link "Slideshow"
     end
-    find('.grid [data-slide-to="1"]').click
+    find('.grid [data-slide-to="1"]').trigger('click')
     expect(page).to have_selector '#slideshow', visible: true
   end
   


### PR DESCRIPTION
Poltergeist complains that the parent element is covering it
but that isn't a problem for triggering the javascript event.

Fixing this test error https://travis-ci.org/sul-dlss/spotlight/jobs/22306521
