### PR TITLE
Make display_sidebar true by default for pages.

### DIFF
--- a/app/models/spotlight/about_page.rb
+++ b/app/models/spotlight/about_page.rb
@@ -2,10 +2,5 @@ module Spotlight
   class AboutPage < Spotlight::Page
     extend FriendlyId
     friendly_id :title, use: [:slugged,:scoped,:finders,:history], scope: :exhibit
-
-    before_save do
-      self.display_sidebar = true
-    end
-
   end
 end

--- a/app/models/spotlight/feature_page.rb
+++ b/app/models/spotlight/feature_page.rb
@@ -12,28 +12,8 @@ module Spotlight
       self.exhibit = top_level_page_or_self.exhibit
     end
 
-    after_save do
-      display_sidebar_for_page_with_published_children
-      display_parent_page_sidebar_when_published
-    end
-    private
-    # Parent pages with published children need
-    # to have their show_sidebar forced to true
-    def display_sidebar_for_page_with_published_children
-      if child_pages.published.present? and !display_sidebar
-        self.display_sidebar = true
-        self.save
-      end
-    end
-    # Force a parent page's display_sidebar
-    # to true for published child pages.
-    def display_parent_page_sidebar_when_published
-      if parent_page and parent_page.published and !parent_page.display_sidebar
-        if published
-          parent_page.display_sidebar = true
-          parent_page.save
-        end
-      end
+    def display_sidebar?
+      child_pages.published.present? || self.display_sidebar
     end
   end
 end

--- a/app/models/spotlight/home_page.rb
+++ b/app/models/spotlight/home_page.rb
@@ -20,7 +20,6 @@ module Spotlight
     end
 
     def publish
-      self.display_sidebar = true
       self.published = true
     end
 

--- a/app/models/spotlight/page.rb
+++ b/app/models/spotlight/page.rb
@@ -14,7 +14,16 @@ module Spotlight
     scope :at_top_level, -> { where(parent_page_id: nil) }
     scope :published, -> { where(published: true) }
     scope :recent, -> { order("updated_at DESC").limit(10)}
-    
+
+    # display_sidebar should be set to true by default
+    before_create do
+      self.display_sidebar = true
+    end
+
+    def display_sidebar?
+      true
+    end
+
     # explicitly set the partial path so that 
     # we don't have to duplicate view logic.
     def to_partial_path

--- a/app/views/spotlight/feature_pages/_page_options.html.erb
+++ b/app/views/spotlight/feature_pages/_page_options.html.erb
@@ -2,5 +2,5 @@
   <%= f.check_box :published %> <%= f.label :published, t(:'.published') %>
 </div>
 <div>
-  <%= f.check_box :display_sidebar %> <%= f.label :display_sidebar, t(:'spotlight.administration.show_sidebar') %>
+  <%= f.check_box :display_sidebar?, disabled: @page.child_pages.published.present? %> <%= f.label :display_sidebar?, t(:'spotlight.administration.show_sidebar') %>
 </div>

--- a/spec/features/feature_page_spec.rb
+++ b/spec/features/feature_page_spec.rb
@@ -33,10 +33,21 @@ describe "Feature page" do
     end
     describe "when configured to not display" do
       before { parent_feature_page.display_sidebar = false;  parent_feature_page.save }
-      it "should not be present" do
-        visit spotlight.exhibit_feature_page_path(parent_feature_page.exhibit, parent_feature_page)
-        expect(page).not_to have_css("#sidebar")
-        expect(page).not_to have_content(child_feature_page.title)
+      context "with a child page" do
+        it "should be present anyway" do
+          visit spotlight.exhibit_feature_page_path(parent_feature_page.exhibit, parent_feature_page)
+          expect(page).to have_css("#sidebar")
+          expect(page).to have_content(child_feature_page.title)
+        end
+      end
+      
+      context "with an unpublished child page" do
+        before { child_feature_page.published = false; child_feature_page.save }
+        it "should not be present" do
+          visit spotlight.exhibit_feature_page_path(parent_feature_page.exhibit, parent_feature_page)
+          expect(page).not_to have_css("#sidebar")
+          expect(page).not_to have_content(child_feature_page.title)
+        end
       end
     end
   end
@@ -61,8 +72,9 @@ describe "Feature page" do
     end
     describe "display_sidebar" do
       let!(:feature_page) { FactoryGirl.create(:feature_page, display_sidebar: false, exhibit: exhibit) }
+      before { feature_page.display_sidebar = false; feature_page.save }
       it "should be updatable from the edit page" do
-        expect(feature_page.display_sidebar).to be_false
+        expect(feature_page.display_sidebar?).to be_false
 
         visit spotlight.edit_exhibit_feature_page_path(feature_page.exhibit, feature_page)
         expect(find("#feature_page_display_sidebar")).not_to be_checked
@@ -70,7 +82,7 @@ describe "Feature page" do
         check "Show sidebar"
         click_button "Save changes"
 
-        expect(feature_page.reload.display_sidebar).to be_true
+        expect(feature_page.reload.display_sidebar?).to be_true
 
         visit spotlight.edit_exhibit_feature_page_path(feature_page.exhibit, feature_page)
         expect(find("#feature_page_display_sidebar")).to be_checked

--- a/spec/models/spotlight/about_page_spec.rb
+++ b/spec/models/spotlight/about_page_spec.rb
@@ -1,10 +1,16 @@
 require 'spec_helper'
 
 describe Spotlight::AboutPage do
+  let(:page) { Spotlight::AboutPage.create! exhibit: FactoryGirl.create(:exhibit)  }
   it {should_not be_feature_page}
   it {should be_about_page}
   it "should display the sidebar" do
-    page = Spotlight::AboutPage.create! exhibit: FactoryGirl.create(:exhibit) 
-    expect(page.display_sidebar).to be_true
+    expect(page.display_sidebar?).to be_true
+  end
+  it "should force the sidebar to display (we do not provide an interface for setting this to false)" do
+    expect(page.display_sidebar?).to be_true
+    page.display_sidebar = false
+    page.save
+    expect(page.display_sidebar?).to be_true
   end
 end

--- a/spec/models/spotlight/feature_page_spec.rb
+++ b/spec/models/spotlight/feature_page_spec.rb
@@ -11,32 +11,25 @@ describe Spotlight::FeaturePage do
     end
   end
 
-  describe "display_sidebar" do
+  describe "display_sidebar?" do
     let(:parent)  { FactoryGirl.create(:feature_page, exhibit: exhibit) }
-    let(:child) { FactoryGirl.create(:feature_page, parent_page: parent, exhibit: exhibit ) }
+    let!(:child) { FactoryGirl.create(:feature_page, parent_page: parent, exhibit: exhibit ) }
     let!(:unpublished_parent)  { FactoryGirl.create(:feature_page, published: false, exhibit: exhibit) }
     let!(:unpublished_child) { FactoryGirl.create(:feature_page, parent_page: unpublished_parent, published: false, exhibit: exhibit ) }
+    before { unpublished_parent.display_sidebar = false }
+    it "should be set to true if the page has a published child" do
+      expect(parent.display_sidebar?).to be_true
+    end
     it "should be set to true on the parent of published child pages" do
-      expect(parent.display_sidebar).to be_false
-      child.save
-      expect(parent.display_sidebar).to be_true
+      parent.display_sidebar = false
+      expect(parent.display_sidebar?).to be_true
     end
     it "should be set to true when publishing a child page" do
-      expect(unpublished_parent.display_sidebar).to be_false
+      expect(unpublished_parent.display_sidebar?).to be_false
       unpublished_parent.published = true
       unpublished_child.published = true
       unpublished_child.save
-      expect(unpublished_parent.display_sidebar).to be_true
-    end
-    it "should not change the display_sidebar setting when the child page is not published" do
-      unpublished_child.save
-      expect(unpublished_parent.display_sidebar).to be_false
-    end
-    it "should not change the setting when the parent page is not published" do
-      expect(unpublished_parent.display_sidebar).to be_false
-      unpublished_child.published = true
-      unpublished_child.save
-      expect(unpublished_parent.display_sidebar).to be_false
+      expect(unpublished_parent.display_sidebar?).to be_true
     end
   end
 

--- a/spec/models/spotlight/home_page_spec.rb
+++ b/spec/models/spotlight/home_page_spec.rb
@@ -5,7 +5,7 @@ describe Spotlight::HomePage do
   it {should_not be_feature_page}
   it {should_not be_about_page}
   it "should display the sidebar" do
-    expect(home_page.display_sidebar).to be_true
+    expect(home_page.display_sidebar?).to be_true
   end
   it "should be published" do
     expect(home_page.published).to be_true

--- a/spec/models/spotlight/page_spec.rb
+++ b/spec/models/spotlight/page_spec.rb
@@ -35,6 +35,11 @@ describe Spotlight::Page do
 
     end
   end
+  describe ".display_sidebar" do
+    it "should be set to true by default" do
+      expect(parent_page.display_sidebar?).to be_true
+    end
+  end
   describe "should_display_title?" do
     let(:page) { FactoryGirl.create(:feature_page) }
     it "should return if the title is present or not" do

--- a/spec/views/spotlight/pages/show.html.erb_spec.rb
+++ b/spec/views/spotlight/pages/show.html.erb_spec.rb
@@ -36,7 +36,7 @@ module Spotlight
     end
 
     it "should not render the sidebar if the page has it disabled" do
-      @page.stub(display_sidebar: false)
+      @page.stub(display_sidebar?: false)
       render
       expect(rendered).to_not match("Sidebar")
     end


### PR DESCRIPTION
Closes #613 

I'm making `#show_sidebar` true by default for all page types (since we're using STI for all pages) but Feature Pages are the only ones that take action on it.
