### PR TITLE
Update title of default browse category

### DIFF
--- a/app/models/spotlight/exhibit.rb
+++ b/app/models/spotlight/exhibit.rb
@@ -74,7 +74,7 @@ class Spotlight::Exhibit < ActiveRecord::Base
     # and we don't want to have a conflicting slug
 
     if persisted?
-      searches.where(title: "Browse All Exhibit Items").destroy_all
+      searches.where(title: "All Exhibit Items").destroy_all
       reload
     end
     update hash
@@ -89,9 +89,9 @@ class Spotlight::Exhibit < ActiveRecord::Base
   def initialize_browse
     return unless self.searches.blank?
 
-    self.searches.create title: "Browse All Exhibit Items",
+    self.searches.create title: "All Exhibit Items",
       short_description: "Search results for all items in this exhibit",
-      long_description: "All items in this exhibit"
+      long_description: "All items in this exhibit."
   end
 
   def initialize_main_navigation

--- a/spec/features/javascript/search_result_block_spec.rb
+++ b/spec/features/javascript/search_result_block_spec.rb
@@ -26,12 +26,12 @@ describe "Search Results Block", js: true do
 
     # Drop down should exist with all browse categories listed
     within("select[name='searches-options']") do
-      expect(page).to have_css("option", text: "Browse All Exhibit Items", visible: true)
+      expect(page).to have_css("option", text: "All Exhibit Items", visible: true)
       expect(page).to have_css("option", text: "Alt. Search", visible: true)
       expect(page).to have_css("option[value='#{alt_search.id}']", visible: true)
     end
 
-    select("Browse All Exhibit Items", from: "Browse category")
+    select("All Exhibit Items", from: "Browse category")
 
     check "gallery"
     check "slideshow"


### PR DESCRIPTION
Fixes #637 

Removes "Browse" from title of the default "Browse All Exhibit Items" category.

![curation_-_curation_-_browse___default_exhibit_-_blacklight](https://cloud.githubusercontent.com/assets/101482/2701747/16da1494-c426-11e3-9fd9-f94efae98970.png)

![browse_exhibit___default_exhibit_-_blacklight](https://cloud.githubusercontent.com/assets/101482/2701755/3e8f94e6-c426-11e3-93a5-362d240b8c2c.png)
