### PR TITLE
Change Cancel button styling to btn-link style

### DIFF
--- a/app/views/spotlight/catalog/_edit_default.html.erb
+++ b/app/views/spotlight/catalog/_edit_default.html.erb
@@ -13,7 +13,7 @@
   </div>
   <div class="form-actions">
     <div class="primary-actions">
-      <%= cancel_link @document, spotlight.exhibit_catalog_path(current_exhibit, @document), class: 'btn btn-default' %> 
+      <%= cancel_link @document, spotlight.exhibit_catalog_path(current_exhibit, @document), class: 'btn btn-link' %>
       <%= f.submit nil, class: 'btn btn-primary' %>
       </div>
   </div>

--- a/app/views/spotlight/contacts/_form.html.erb
+++ b/app/views/spotlight/contacts/_form.html.erb
@@ -3,8 +3,8 @@
   <%= f.text_field :email, placeholder: t(:'.email.placeholder') %>
   <%= f.text_field :title, placeholder: t(:'.title.placeholder') %>
   <%= f.text_field :location, placeholder: t(:'.location.placeholder') %>
-  <div class="form-group pull-right">
-    <%= cancel_link @contact, exhibit_about_pages_path(@contact.exhibit), class: "btn btn-default" %>
+  <div class="form-group primary-actions">
+    <%= cancel_link @contact, exhibit_about_pages_path(@contact.exhibit), class: "btn btn-link" %>
     <%= f.submit nil, class: 'btn btn-primary' %>
   </div>
 <% end %>

--- a/app/views/spotlight/custom_fields/_form.html.erb
+++ b/app/views/spotlight/custom_fields/_form.html.erb
@@ -4,7 +4,7 @@
   <%= f.text_area :short_description %>
   <div class="form-actions">
     <div class="primary-actions">
-      <%= link_to t(:"cancel"), exhibit_edit_metadata_path(current_exhibit), class: "btn btn-default" %>
+      <%= link_to t(:"cancel"), exhibit_edit_metadata_path(current_exhibit), class: "btn btn-link" %>
       <%= f.submit nil, class: 'btn btn-primary' %>
     </div>
   </div>

--- a/app/views/spotlight/pages/_form.html.erb
+++ b/app/views/spotlight/pages/_form.html.erb
@@ -40,7 +40,7 @@
 
   <div class="form-actions">
     <div class="primary-actions">
-      <%= link_to(t('cancel'), :back, class: "btn btn-default") %>
+      <%= link_to(t('cancel'), :back, class: "btn btn-link") %>
       <%= f.submit class: 'btn btn-primary' %>
     </div>
   </div>

--- a/app/views/spotlight/searches/edit.html.erb
+++ b/app/views/spotlight/searches/edit.html.erb
@@ -10,7 +10,7 @@
       <%= f.text_area :long_description %>
       <div class="form-actions">
         <div class="primary-actions">
-          <%= cancel_link @search,exhibit_searches_path(@exhibit), class: 'btn btn-default' %>
+          <%= cancel_link @search,exhibit_searches_path(@exhibit), class: 'btn btn-link' %>
           <%= f.submit nil, class: 'btn btn-primary' %>
         </div>
       </div>


### PR DESCRIPTION
Fixes #640 

Just changes `btn-default` to `btn-link` to make Cancel buttons styled as links.

![curation_-_add_exhibit_contact___default_exhibit_-_blacklight](https://cloud.githubusercontent.com/assets/101482/2713210/1a47f53e-c4e3-11e3-89fa-7ca7ee846223.png)
