### PR TITLE
Don't pass the Search's query_params to #get_solr_response_for_doc_id ...

### DIFF
--- a/app/models/spotlight/search.rb
+++ b/app/models/spotlight/search.rb
@@ -19,7 +19,7 @@ class Spotlight::Search < ActiveRecord::Base
 
   def featured_item
     if self.featured_item_id
-      @featured_item ||= get_solr_response_for_doc_id(self.featured_item_id, query_params).last
+      @featured_item ||= get_solr_response_for_doc_id(self.featured_item_id).last
     end
   end
 


### PR DESCRIPTION
when getting the featured_item.
