### PR TITLE
Add an autocomplete member resource to the SearchesController.

### DIFF
--- a/app/controllers/spotlight/catalog_controller.rb
+++ b/app/controllers/spotlight/catalog_controller.rb
@@ -48,17 +48,7 @@ class Spotlight::CatalogController < ::CatalogController
 
     respond_to do |format|
       format.json do
-        render json: {
-          docs: @document_list.map do |doc|
-            {
-              id: doc.id,
-              title: view_context.presenter(doc).raw_document_heading,
-              thumbnail: doc.first(blacklight_config.index.thumbnail_field),
-              description: doc.id,
-              url: exhibit_catalog_path(current_exhibit, doc)
-            }
-          end
-        }
+        render json: { docs: autocomplete_json_response(@document_list) }
       end
     end
   end

--- a/app/views/spotlight/searches/edit.html.erb
+++ b/app/views/spotlight/searches/edit.html.erb
@@ -1,7 +1,7 @@
 <%= render 'spotlight/shared/curation_sidebar' %>
 <div id="content" class="col-md-9">
   <%= curation_page_title %>
-  <%= bootstrap_form_for [@search.exhibit, @search], style: :horizontal, right: "col-sm-5", data: {:'autocomplete-url'=> spotlight.autocomplete_exhibit_catalog_index_path(@search.exhibit, format: "json")}, html: {id: 'edit-search'} do |f| %>
+  <%= bootstrap_form_for [@search.exhibit, @search], style: :horizontal, right: "col-sm-5", data: {:'autocomplete-url'=> spotlight.autocomplete_exhibit_search_path(@search.exhibit, @search, format: "json")}, html: {id: 'edit-search'} do |f| %>
     <div class="row">
       <%= f.text_field :title %>
       <%= f.text_field :featured_item_id, value: (presenter(@search.featured_item).document_heading if @search.featured_item), data: {:"featured-item-typeahead" => true, :id_field => "[data-featured-item-id]" }, id: "featured-item-title" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,9 @@ Spotlight::Engine.routes.draw do
       collection do
         patch :update_all
       end
+      member do
+        get :autocomplete
+      end
     end
     resources :browse, only: [:index, :show]
     resources :tags, only: [:index, :destroy]

--- a/lib/spotlight/base.rb
+++ b/lib/spotlight/base.rb
@@ -10,5 +10,17 @@ module Spotlight
       exhibit_specific_blacklight_config
     end
 
+    def autocomplete_json_response document_list
+      document_list.map do |doc|
+        {
+          id: doc.id,
+          title: view_context.presenter(doc).raw_document_heading,
+          thumbnail: doc.first(blacklight_config.index.thumbnail_field),
+          description: doc.id,
+          url: exhibit_catalog_path(current_exhibit, doc)
+        }
+      end
+    end
+
   end
 end

--- a/spec/controllers/spotlight/searches_controller_spec.rb
+++ b/spec/controllers/spotlight/searches_controller_spec.rb
@@ -59,6 +59,30 @@ describe Spotlight::SearchesController do
       end
     end
 
+    describe "GET autocomplete" do
+      let!(:search) { FactoryGirl.create(:search, exhibit: exhibit, title: "New Mexico Maps", query_params: {q: "New Mexico"} ) }
+      it "should show all the items returned search's query_params" do
+        get :autocomplete, exhibit_id: exhibit, id: search, format: 'json'
+        expect(response).to be_successful
+        docs = JSON.parse(response.body)['docs']
+        doc_ids = docs.map{|d| d["id"] }
+        expect(docs.length).to eq 2
+        expect(doc_ids).to include "cz507zk0531"
+        expect(doc_ids).to include "rz818vx8201"
+      end
+      it "should search within the items returned in the query_params" do
+        get :autocomplete, exhibit_id: exhibit, id: search, q: "Noorder deel",format: 'json'
+        expect(response).to be_successful
+        docs = JSON.parse(response.body)['docs']
+        expect(docs.length).to eq 1
+        expect(docs.first["id"]).to eq "rz818vx8201"
+        expect(docs.first["description"]).to eq "rz818vx8201"
+        expect(docs.first["title"]).to eq "'t Noorder deel van WEST-INDIEN"
+        expect(docs.first).to have_key("thumbnail")
+        expect(docs.first).to have_key("url")
+      end
+    end
+
     describe "GET edit" do
       it "should show edit page" do
         get :edit, id: search, exhibit_id: search.exhibit


### PR DESCRIPTION
Move autocomplete json response format into Spotlight::Base.

Fixes #635 
