### PR TITLE
Don't lookup featured items for searches if the featured_item_id is an ...

### DIFF
--- a/app/models/spotlight/search.rb
+++ b/app/models/spotlight/search.rb
@@ -18,7 +18,7 @@ class Spotlight::Search < ActiveRecord::Base
   include Spotlight::Catalog::AccessControlsEnforcement
 
   def featured_item
-    if self.featured_item_id
+    if self.featured_item_id.present?
       @featured_item ||= get_solr_response_for_doc_id(self.featured_item_id).last
     end
   end

--- a/spec/models/spotlight/search_spec.rb
+++ b/spec/models/spotlight/search_spec.rb
@@ -16,6 +16,15 @@ describe Spotlight::Search do
     expect(subject.featured_image).to eq "https://stacks.stanford.edu/image/dq287tq6352/dq287tq6352_05_0001_thumb"
   end
 
+  it "should handle blank and nil featured_image_ids" do
+    subject.stub(:featured_item_id).and_return("")
+    subject.save
+    expect(subject.featured_item).to be_nil
+    subject.stub(:featured_item_id).and_return(nil)
+    subject.save
+    expect(subject.featured_item).to be_nil
+  end
+
   it "should #default_featured_iamge should not thrown an error when no images are present" do
     subject.stub(images: nil)
     expect(subject.default_featured_item_id).to be_nil


### PR DESCRIPTION
... empty string or nil.
