### PR TITLE
Redirect to exhibit home page when the Spotlight::CatalogController#index ...

### DIFF
--- a/app/controllers/spotlight/catalog_controller.rb
+++ b/app/controllers/spotlight/catalog_controller.rb
@@ -4,6 +4,8 @@ class Spotlight::CatalogController < ::CatalogController
   include Spotlight::Catalog
   before_filter :authenticate_user!, only: [:admin, :edit, :make_public, :make_private]
   before_filter :check_authorization, only: [:admin, :edit, :make_public, :make_private]
+  before_filter :redirect_to_exhibit_home_without_search_params, only: :index
+  before_filter :add_breadcrumb_with_search_params, only: :index
 
   before_filter :attach_breadcrumbs
   helper Openseadragon::OpenseadragonHelper
@@ -11,12 +13,6 @@ class Spotlight::CatalogController < ::CatalogController
 
   def new
     @resource = @exhibit.resources.build
-  end
-
-  def index
-    super
-
-    add_breadcrumb t(:'spotlight.catalog.breadcrumb.index'), request.fullpath if has_search_parameters?
   end
 
   def show
@@ -163,6 +159,18 @@ class Spotlight::CatalogController < ::CatalogController
   def current_browse_category
     @current_browse_category ||= if current_search_session and current_search_session.query_params["action"] == "show" and current_search_session.query_params["controller"] == "spotlight/browse"
       Spotlight::Search.find(current_search_session.query_params["id"]) if current_search_session.query_params["id"]
+    end
+  end
+
+  def redirect_to_exhibit_home_without_search_params
+    unless has_search_parameters?
+      redirect_to spotlight.exhibit_root_path(@exhibit)
+    end
+  end
+
+  def add_breadcrumb_with_search_params
+    if has_search_parameters?
+      add_breadcrumb t(:'spotlight.catalog.breadcrumb.index'), request.fullpath
     end
   end
 

--- a/spec/controllers/spotlight/catalog_controller_spec.rb
+++ b/spec/controllers/spotlight/catalog_controller_spec.rb
@@ -74,11 +74,15 @@ describe Spotlight::CatalogController do
 
 
     describe "GET index" do
-      it "should show the index" do
+      it "should show the index when there are parameters" do
         expect(controller).to receive(:add_breadcrumb).with("Home", exhibit_path(exhibit, q: ''))
         expect(controller).to receive(:add_breadcrumb).with("Search Results", exhibit_catalog_index_path(exhibit, q:'map'))
         get :index, exhibit_id: exhibit, q: 'map'
         expect(response).to be_successful
+      end
+      it "should redirect to the exhibit home page when there are no parameters" do
+        get :index, exhibit_id: exhibit
+        expect(response).to redirect_to(exhibit_root_path(exhibit))
       end
     end
 


### PR DESCRIPTION
... has no search parameters.

Fixes #631 

Clicking the "x" here....

![default_exhibit_-_blacklight_search_results](https://cloud.githubusercontent.com/assets/101482/2685063/4a26b57e-c1c3-11e3-935b-3ff09212fa22.png)

... now redirects to this page:

![home-page](https://cloud.githubusercontent.com/assets/96776/2746407/c54c3bf6-c746-11e3-9c6d-8bf2a59fcf4f.png)
