### PR TITLE
Update alignment and styling of tags in show (non-edit) mode

### DIFF
--- a/app/assets/stylesheets/spotlight/_catalog.css.scss
+++ b/app/assets/stylesheets/spotlight/_catalog.css.scss
@@ -29,9 +29,15 @@
 }
 
 #document {
-  ul.tags li {
-    @extend .label;
-    @extend .label-default;
+  ul.tags {
+    text-align: center;
+    li {
+      @extend .label;
+      @extend .label-default;
+      a {
+        color: #fff;
+      }
+    }
   }
 
   .osd-toolbar {


### PR DESCRIPTION
Fixes #656 
- Center align tags list
- Update text (link) color to white to be readable on current default background color

Before:
![a_new_and_exact_map_of_asia_according_to_the_best_observations_-_default_exhibit_-_blacklight 2](https://cloud.githubusercontent.com/assets/101482/2858229/50c88bf8-d183-11e3-9e6c-79294036db1f.png)

After:
![a_new_and_exact_map_of_asia_according_to_the_best_observations_-_default_exhibit_-_blacklight](https://cloud.githubusercontent.com/assets/101482/2858230/5616cb7e-d183-11e3-9e18-e542e14dbd43.png)
