### PR TITLE
Update instructions for importing an exported JSON file

### DIFF
--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -228,7 +228,7 @@ en:
         header: Import/Export
         import:
           header: Import exhibit data
-          instructions: You can import an exported exhibit data file to use that data to define this exhibit.
+          instructions: You can import an exhibit JSON file exported from this application to use that data file to define this exhibit.
           button: Import data
         export:
           header: Export exhibit data


### PR DESCRIPTION
Fixes #659 

Updates instruction text slightly to look like this:

![administration_-_import_export___default_exhibit_-_blacklight](https://cloud.githubusercontent.com/assets/101482/2858358/dab5a8bc-d185-11e3-9ddc-5da2813a5635.png)
