### PR TITLE
Removing second Spotlight::Role.create statement, per advice from Chris ...

### DIFF
--- a/lib/tasks/spotlight_tasks.rake
+++ b/lib/tasks/spotlight_tasks.rake
@@ -7,7 +7,7 @@ namespace :spotlight do
     password = prompt_password
     u = User.create!(email: email, password: password)
     Spotlight::Role.create(user: u, exhibit: nil, role: 'admin')
-    Spotlight::Role.create(user: u, exhibit: Spotlight::Exhibit.default, role: 'admin')
+    # Spotlight::Role.create(user: u, exhibit: Spotlight::Exhibit.default, role: 'admin')
     puts "User created."
   end
 


### PR DESCRIPTION
...Beer. This line throws a stack trace when we run the template.rb installer and we are already making the user an admin so we shouldn't need to do it a second time.

I commented the line out instead of deleting it, because I'm going on faith that it isn't needed, but I don't have a good way of testing that. 

For me, a new pull of the spotlight code currently has three failing tests. The travis build is green, but the last build there was 26 days ago. 
