### PR TITLE
Removing second Spotlight::Role.create statement

### DIFF
--- a/lib/tasks/spotlight_tasks.rake
+++ b/lib/tasks/spotlight_tasks.rake
@@ -7,7 +7,6 @@ namespace :spotlight do
     password = prompt_password
     u = User.create!(email: email, password: password)
     Spotlight::Role.create(user: u, exhibit: nil, role: 'admin')
-    Spotlight::Role.create(user: u, exhibit: Spotlight::Exhibit.default, role: 'admin')
     puts "User created."
   end
 


### PR DESCRIPTION
Replaces #676 
