### PR TITLE
Install friendly_id and social-share-button as gems in the host application

### DIFF
--- a/lib/generators/spotlight/install_generator.rb
+++ b/lib/generators/spotlight/install_generator.rb
@@ -15,6 +15,7 @@ module Spotlight
     end
 
     def friendly_id
+      gem "friendly_id"
       generate "friendly_id"
     end
 
@@ -47,6 +48,7 @@ module Spotlight
     end
 
     def generate_social_share_button_initializer
+      gem 'social-share-button'
       directory 'config'
     end
   end


### PR DESCRIPTION
When we add initializers into the host app, we should give the host app an explicit dependency on those gems (because even if you remove the spotlight gem, your app will still require those gems.)
