### PR TITLE
Add top margin to site footer

### DIFF
--- a/app/assets/stylesheets/spotlight/_footer.css.scss
+++ b/app/assets/stylesheets/spotlight/_footer.css.scss
@@ -1,6 +1,7 @@
 footer {
   background-color: $gray-lighter;
   color: $gray-light;
+  margin-top: $footer-top-margin;
   padding: 10px;
 
   // Styles below keep footer at bottom of viewport

--- a/app/assets/stylesheets/spotlight/_spotlight.css.scss
+++ b/app/assets/stylesheets/spotlight/_spotlight.css.scss
@@ -35,5 +35,5 @@ html {
   min-height: 100%;
 }
 body {
-  margin-bottom: $footer-height;
+  margin-bottom: $footer-height + $footer-top-margin;
 }

--- a/app/assets/stylesheets/spotlight/_variables.css.scss
+++ b/app/assets/stylesheets/spotlight/_variables.css.scss
@@ -1,1 +1,2 @@
+$footer-top-margin: 3 * $padding-small-vertical;
 $footer-height: 118px;


### PR DESCRIPTION
Fixes #707 

Because we're using a sticky footer technique, also need to compensate for size of top margin in the bottom margin of the body tag.

**Before**

![browse_exhibit___default_exhibit_-_blacklight](https://cloud.githubusercontent.com/assets/101482/5075398/6b4d3756-6e47-11e4-9428-02970452493c.png)

**After**

![browse_exhibit___default_exhibit_-_blacklight](https://cloud.githubusercontent.com/assets/101482/5075448/ae358500-6e47-11e4-84b8-4a050e42bdfb.png)
