### PR TITLE
Remove thumbnail configuration option from UI.

### DIFF
--- a/app/controllers/spotlight/appearances_controller.rb
+++ b/app/controllers/spotlight/appearances_controller.rb
@@ -25,7 +25,7 @@ class Spotlight::AppearancesController < Spotlight::ApplicationController
   end
 
   def appearance_params
-    params.require(:appearance).permit(:default_per_page, :thumbnail_size,
+    params.require(:appearance).permit(:default_per_page,
       document_index_view_types: @appearance.view_type_options,
       sort_fields: @appearance.allowed_params,
       main_navigations: [:id, :label, :weight])

--- a/app/forms/spotlight/appearance.rb
+++ b/app/forms/spotlight/appearance.rb
@@ -8,7 +8,7 @@ module Spotlight
     end
 
     attr_reader :configuration
-    delegate :persisted?, :exhibit, :exhibit_id, :default_per_page, :thumbnail_size,
+    delegate :persisted?, :exhibit, :exhibit_id, :default_per_page,
       :default_blacklight_config, to: :configuration
 
     delegate :main_navigations, to: :exhibit

--- a/app/models/concerns/spotlight/blacklight_configuration_defaults.rb
+++ b/app/models/concerns/spotlight/blacklight_configuration_defaults.rb
@@ -11,7 +11,6 @@ module Spotlight::BlacklightConfigurationDefaults
       default_sort_fields
       default_view_types
       set_default_per_page
-      default_thumbnail_size
     end
 
     def default_sort_fields
@@ -38,10 +37,5 @@ module Spotlight::BlacklightConfigurationDefaults
       # is created or we run into a circular dependency.
       self.default_per_page ||= ::CatalogController.blacklight_config.per_page.first
     end
-
-    def default_thumbnail_size
-      self.thumbnail_size ||= 'small'
-    end
-
 
 end

--- a/app/views/spotlight/appearances/edit.html.erb
+++ b/app/views/spotlight/appearances/edit.html.erb
@@ -54,12 +54,6 @@
       <% end %>
     <% end %>
 
-    <%= f.form_group :thumbnail_size, label: { text: t(:'.thumbnail_size')} do %>
-      <%= f.radio_button :thumbnail_size, 'small', label: t(:'.thumbnail.small') %>
-      <%= f.radio_button :thumbnail_size, 'medium', label: t(:'.thumbnail.medium') %>
-      <%= f.radio_button :thumbnail_size, 'large', label: t(:'.thumbnail.large') %>
-    <% end %>
-
     <%= f.form_group :sort_fields, label: {text: t(:'.sort_fields')} do %>
       <%= f.fields_for :sort_fields, @appearance.sort_fields do |vt| %>
         <%= vt.check_box :relevance, {  checked: true, disabled: true, data: { readonly: true }} %>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -114,7 +114,6 @@ en:
         restore_default: "Restore default"
         search_results: Search Results
         sort_fields: Sort fields
-        thumbnail_size: Thumbnail size
         thumbnail:
           small: Small
           medium: Medium

--- a/spec/controllers/spotlight/appearances_controller_spec.rb
+++ b/spec/controllers/spotlight/appearances_controller_spec.rb
@@ -44,7 +44,6 @@ describe Spotlight::AppearancesController, :type => :controller do
         patch :update, exhibit_id: exhibit, appearance: { 
           document_index_view_types: {"list"=>"1", "gallery"=>"1", "map"=>"0"},
           default_per_page: "50",
-          thumbnail_size: "medium",
           sort_fields: {"relevance"=>"1", "title"=>"1", "type"=>"1", "date"=>"0", "source"=>"0", "identifier"=>"0"}
         }
         expect(flash[:notice]).to eq "The appearance was successfully updated."
@@ -52,7 +51,6 @@ describe Spotlight::AppearancesController, :type => :controller do
         assigns[:exhibit].tap do |saved|
           expect(saved.blacklight_configuration.document_index_view_types).to eq ['list', 'gallery']
           expect(saved.blacklight_configuration.default_per_page).to eq 50
-          expect(saved.blacklight_configuration.thumbnail_size).to eq 'medium' 
           expect(saved.blacklight_configuration.sort_fields).to eq(
             {"score desc, sort_title_ssi asc" => {"show"=>true, "enabled"=>true},
              "sort_title_ssi asc" => {"show"=>true, "enabled"=>true},

--- a/spec/features/update_appearance_spec.rb
+++ b/spec/features/update_appearance_spec.rb
@@ -15,8 +15,6 @@ describe "Update the appearance", :type => :feature do
 
     choose "20"
 
-    choose "Large"
-
     # #feild_labeled doesn't appear to work for disabled inputs
     expect(page).to have_css("input[name='appearance[sort_fields][relevance]'][disabled='disabled']")
     uncheck "Title"
@@ -35,8 +33,6 @@ describe "Update the appearance", :type => :feature do
 
     expect(field_labeled('20')).to be_checked
     expect(field_labeled('10')).to_not be_checked
-
-    expect(field_labeled('Large')).to be_checked
 
     # #feild_labeled doesn't appear to work for disabled inputs
     expect(page).to have_css("input[name='appearance[sort_fields][relevance]'][disabled='disabled']")

--- a/spec/models/spotlight/blacklight_configuration_spec.rb
+++ b/spec/models/spotlight/blacklight_configuration_spec.rb
@@ -216,7 +216,6 @@ describe Spotlight::BlacklightConfiguration, :type => :model do
           "sort_type_ssi asc" => {:show=>true}
         })}
       its(:default_per_page) { should eq 10 }
-      its(:thumbnail_size) { should eq 'small' }
       its(:document_index_view_types) { should match_array ::CatalogController.blacklight_config.view.keys.map { |x| x.to_s } }
     end
   end


### PR DESCRIPTION
Closes #724 

![no-thumb](https://cloud.githubusercontent.com/assets/96776/5076271/aa514c6a-6e4e-11e4-94bd-8683976c0c53.png)
