### PR TITLE
Pages should be 'locked' when a user starts editing a page

### DIFF
--- a/app/controllers/spotlight/pages_controller.rb
+++ b/app/controllers/spotlight/pages_controller.rb
@@ -26,6 +26,7 @@ module Spotlight
 
     # GET /pages/1/edit
     def edit
+      try_lock
     end
 
     # POST /exhibits/1/pages
@@ -42,6 +43,7 @@ module Spotlight
 
     # PATCH/PUT /pages/1
     def update
+      release_lock
       if @page.update(page_params.merge(last_edited_by: current_user))
         redirect_to [@page.exhibit, @page], notice: t(:'helpers.submit.page.updated', model: @page.class.model_name.human.downcase)
       else
@@ -69,6 +71,19 @@ module Spotlight
     end
 
     protected
+
+    def try_lock
+      @lock = if @page.lock
+        @page.lock
+      else
+        @page.create_lock by: current_user
+        nil
+      end
+    end
+
+    def release_lock
+      @page.lock.delete if @page.lock
+    end
 
     ##
     # Browsing an exhibit should start a new search session

--- a/app/models/spotlight/lock.rb
+++ b/app/models/spotlight/lock.rb
@@ -1,0 +1,10 @@
+module Spotlight
+  class Lock < ActiveRecord::Base
+    belongs_to :on, polymorphic: true
+    belongs_to :by, polymorphic: true
+
+    def stale?
+      created_at < (Time.now - 12.hours)
+    end
+  end
+end

--- a/app/models/spotlight/page.rb
+++ b/app/models/spotlight/page.rb
@@ -15,6 +15,8 @@ module Spotlight
     scope :published, -> { where(published: true) }
     scope :recent, -> { order("updated_at DESC").limit(10)}
 
+    has_one :lock, as: :on
+
     # display_sidebar should be set to true by default
     before_create do
       self.display_sidebar = true

--- a/app/views/spotlight/locks/_lock.html.erb
+++ b/app/views/spotlight/locks/_lock.html.erb
@@ -1,0 +1,4 @@
+<p class="alert alert-warning alert-lock">
+  <button type="button" class="close" data-dismiss="alert"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+  <%= t :'spotlight.pages.edit.locked', user: lock.by, created_at: time_ago_in_words(lock.created_at) + " ago"%>
+</p>

--- a/app/views/spotlight/pages/_form.html.erb
+++ b/app/views/spotlight/pages/_form.html.erb
@@ -8,6 +8,8 @@
                 :'available-configurations-endpoint' => spotlight.exhibit_available_configurations_path(@page.exhibit, format: "json")
               }
             }) do |f| %>
+
+  <%= render @lock if @lock and not @lock.stale? %>
   <% if @page.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(@page.errors.count, "error") %> prohibited this page from being saved:</h2>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -269,6 +269,7 @@ en:
         header: New page
       edit:
         header: Edit page
+        locked: "This page is currently being edited by %{user} (%{created_at})"
       form:
         title_placeholder: "Title"
         page_options: "Page options"

--- a/db/migrate/20141117111311_create_locks.rb
+++ b/db/migrate/20141117111311_create_locks.rb
@@ -1,0 +1,11 @@
+class CreateLocks < ActiveRecord::Migration
+  def change
+    create_table :spotlight_locks do |t|
+      t.references :on, polymorphic: true
+      t.references :by, polymorphic: true
+      t.timestamps
+    end
+
+    add_index :spotlight_locks, [:on_id, :on_type], unique: true
+  end
+end

--- a/spec/features/feature_page_spec.rb
+++ b/spec/features/feature_page_spec.rb
@@ -89,4 +89,22 @@ describe "Feature page", :type => :feature do
       end
     end
   end
+
+  describe "page locking" do
+    before { login_as exhibit_curator }
+    let!(:feature_page) { FactoryGirl.create(:feature_page, display_sidebar: false, exhibit: exhibit) }
+
+    it "should show a lock message if someone is currently editing the page" do
+      # open the edit page
+      visit spotlight.edit_exhibit_feature_page_path(feature_page.exhibit, feature_page)
+
+      # and then open the edit page again
+      visit spotlight.edit_exhibit_feature_page_path(feature_page.exhibit, feature_page)
+
+      expect(page).to have_css '.alert'
+      within ".alert" do
+        expect(page).to have_content "This page is currently being edited by " + exhibit_curator.to_s
+      end
+    end
+  end
 end

--- a/spec/views/spotlight/pages/edit.html.erb_spec.rb
+++ b/spec/views/spotlight/pages/edit.html.erb_spec.rb
@@ -17,5 +17,28 @@ module Spotlight
         assert_select "textarea#feature_page_content[name=?]", "feature_page[content]"
       end
     end
+
+    describe "locks" do
+      let(:lock) { Lock.create! on: page }
+
+      before do
+        assign(:lock, lock)
+      end
+
+      it "renders a lock" do
+        render
+
+        expect(rendered).to have_css '.alert-lock'
+      end
+
+
+      it "should not render an old lock" do
+        lock.created_at -= 1.day
+
+        render
+
+        expect(rendered).not_to have_css '.alert-lock'
+      end
+    end
   end
 end


### PR DESCRIPTION
If any other user (or the initial user, in a new tab) starts editing the page,
they should receive an alert that the page is being edited and to proceed with
caution.

![screen shot 2014-11-17 at 1 29 05 pm](https://cloud.githubusercontent.com/assets/111218/5078116/8cc51216-6e5e-11e4-9043-2773ce50dca0.png)

Fixes #364 
