### PR TITLE
Override BlockControls initializer to split controls into separate divs.

### DIFF
--- a/app/assets/javascripts/spotlight/blocks/item_text_block.js
+++ b/app/assets/javascripts/spotlight/blocks/item_text_block.js
@@ -25,6 +25,8 @@ SirTrevor.Blocks.ItemText =  (function(){
 
     type: "item-text",
 
+    blockGroup: 'Exhibit item widgets',
+
     title: function() { return "Item + Text"; },
 
     icon_name: "item-text",

--- a/app/assets/javascripts/spotlight/blocks/multi_up_item_grid.js
+++ b/app/assets/javascripts/spotlight/blocks/multi_up_item_grid.js
@@ -29,6 +29,8 @@ SirTrevor.Blocks.MultiUpItemGrid =  (function(){
 
     title: function() { return "Multi-Up Item Grid"; },
 
+    blockGroup: 'Exhibit item widgets',
+
     icon_name: "multi-up-item-grid",
 
     inputFieldsCount: 5,

--- a/app/assets/javascripts/spotlight/blocks/search_result_block.js
+++ b/app/assets/javascripts/spotlight/blocks/search_result_block.js
@@ -10,6 +10,8 @@ SirTrevor.Blocks.SearchResults =  (function(){
 
   view_types_key: '[data-behavior="result-view-types"]',
 
+  blockGroup: 'Exhibit item widgets',
+
   description: "This widget displays a set of search results on a page. Specify a search result set by selecting an existing browse category. You can also select the view types that are available to the user when viewing the result set.",
 
   template: _.template([

--- a/app/assets/javascripts/spotlight/pages.js
+++ b/app/assets/javascripts/spotlight/pages.js
@@ -2,6 +2,33 @@
 // All this logic will automatically be available in application.js.
 Spotlight.onLoad(function(){
 
+  SirTrevor.BlockControls.prototype.initialize = function() {
+    var groups = {};
+    for(var block_type in this.available_types) {
+      if (SirTrevor.Blocks.hasOwnProperty(block_type)) {
+        var block_control = new SirTrevor.BlockControl(block_type, this.instance_scope);
+        if (block_control.can_be_rendered) {
+          var blockGroup = SirTrevor.Blocks[block_type].prototype.blockGroup;
+          groups[blockGroup] = groups[blockGroup] || [];
+          groups[blockGroup].push(block_control.render().$el);
+        }
+      }
+    }
+    for(groupKey in groups) {
+      var group   = groups[groupKey];
+      if(groupKey == 'undefined' || groupKey === undefined) {
+        groupKey = "Standard widgets";
+      }
+      var groupEl = $("<div class='st-controls-group'><div class='st-group-control-label'>" + groupKey + "</div></div>");
+      $.each(group, function(){
+        groupEl.append($(this));
+      });
+      this.$el.append(groupEl);
+    }
+
+    this.$el.delegate('.st-block-control', 'click', this.handleControlButtonClick);
+  };
+
   SirTrevor.setDefaults({
     uploadUrl: $('[data-attachment-endpoint]').data('attachment-endpoint')
   });

--- a/spec/features/javascript/block_controls_spec.rb
+++ b/spec/features/javascript/block_controls_spec.rb
@@ -1,0 +1,45 @@
+require "spec_helper"
+
+feature "Block controls" do
+  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:exhibit_curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }
+  before { login_as exhibit_curator }
+
+  scenario "should be split into separate sections", :js => true do
+    skip("Passing locally but Travis is throwing intermittent error because it doesn't seem to wait for form to be submitted.") if ENV["CI"]
+    # create page
+    visit spotlight.exhibit_home_page_path(exhibit, exhibit.home_page)
+    click_link exhibit_curator.email
+    within '#user-util-collapse .dropdown' do
+      click_link 'Dashboard'
+    end
+    click_link "Feature pages"
+
+    add_new_page_via_button("My New Feature Page")
+
+    expect(page).to have_css("h3", text: "My New Feature Page")
+
+    expect(page).to have_content("The feature page was created.")
+    within("li.dd-item") do
+      click_link "Edit"
+    end
+    # fill in title
+    fill_in "feature_page_title", :with => "Exhibit Title"
+    # click to add widget
+    find("[data-icon='add']").click
+
+    within('.st-block-controls') do
+      expect(page).to have_css(".st-controls-group", count: 2)
+      within(first('.st-controls-group')) do
+        expect(page).to have_content "Standard widgets"
+        expect(page).to have_css('a.st-block-control')
+      end
+      within(all('.st-controls-group').last) do
+        expect(page).to have_content "Exhibit item widgets"
+        expect(page).to have_css('a.st-block-control')
+      end
+    end
+
+
+  end
+end


### PR DESCRIPTION
Closes #639 

![widget-selection](https://cloud.githubusercontent.com/assets/96776/5133551/05ba6424-70bb-11e4-8c9e-97ac07ab26fc.png)
