### PR TITLE
Add active search constraints display to the browse category's edit screen

### DIFF
--- a/app/assets/stylesheets/spotlight/_exhibit_admin.css.scss
+++ b/app/assets/stylesheets/spotlight/_exhibit_admin.css.scss
@@ -53,3 +53,15 @@
     }
   }
 }
+
+#edit-search {
+  .remove {
+    display: none;
+  }
+
+  .constraint-value {
+     @include border-right-radius($border-radius-small);
+  }
+
+  .form-control-static { display: none; }
+}

--- a/app/views/spotlight/searches/edit.html.erb
+++ b/app/views/spotlight/searches/edit.html.erb
@@ -1,13 +1,18 @@
 <%= render 'spotlight/shared/curation_sidebar' %>
 <div id="content" class="col-md-9">
   <%= curation_page_title %>
-  <%= bootstrap_form_for [@search.exhibit, @search], layout: :horizontal, label_col: 'col-md-2', control_col: 'col-sm-5', data: {:'autocomplete-url'=> spotlight.autocomplete_exhibit_search_path(@search.exhibit, @search, format: "json")}, html: {id: 'edit-search'} do |f| %>
+  <%= bootstrap_form_for [@search.exhibit, @search], layout: :horizontal, label_col: 'col-md-2', control_col: 'col-sm-7', data: {:'autocomplete-url'=> spotlight.autocomplete_exhibit_search_path(@search.exhibit, @search, format: "json")}, html: {id: 'edit-search'} do |f| %>
     <div class="row">
-      <%= f.text_field :title %>
-      <%= f.text_field :featured_item_id, value: (presenter(@search.featured_item).document_heading if @search.featured_item), data: {:"featured-item-typeahead" => true, :id_field => "[data-featured-item-id]" }, id: "featured-item-title" %>
+      <%= f.text_field :title, control_col: "col-sm-5" %>
+      <%= f.text_field :featured_item_id, control_col: "col-sm-5", value: (presenter(@search.featured_item).document_heading if @search.featured_item), data: {:"featured-item-typeahead" => true, :id_field => "[data-featured-item-id]" }, id: "featured-item-title" %>
       <%= f.hidden_field :featured_item_id, data: {:"featured-item-id" => true} %>
       <%= f.text_area :short_description %>
-      <%= f.text_area :long_description %>
+      <%= f.text_area :long_description, rows: 5 %>
+      <%= f.static_control nil, label: t(:".query_params") do %>
+        <div class="well well-sm">
+          <%= render_constraints(@search.query_params) %>
+        </div>
+      <% end unless @search.query_params.blank? %>
       <div class="form-actions">
         <div class="primary-actions">
           <%= cancel_link @search,exhibit_searches_path(@exhibit), class: 'btn btn-link' %>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -336,6 +336,7 @@ en:
       edit:
         header: "Edit Browse Category"
         title: "Curation - Browse"
+        query_params: "Active search constraints"
       search:
         item_count:
           one: "%{count} item"

--- a/spec/features/browse_category_admin_spec.rb
+++ b/spec/features/browse_category_admin_spec.rb
@@ -3,14 +3,12 @@ require "spec_helper"
 describe "Browse Category Administration", :type => :feature do
   let(:exhibit) { FactoryGirl.create(:exhibit) }
   let(:curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }
-  let(:search) { exhibit.searches.first }
+  let!(:search) { FactoryGirl.create(:search, exhibit: exhibit, query_params: { f: { "genre_ssim" => ["Value"]}}) }
   before { login_as curator }
   describe "index" do
     it "should have searches" do
       visit spotlight.exhibit_searches_path(exhibit)
-      within(".panel .search") do
-        expect(page).to have_css(".title", text: search.title)
-      end
+      expect(page).to have_css(".panel .search .title", text: search.title)
     end
   end
   describe "edit" do
@@ -18,6 +16,10 @@ describe "Browse Category Administration", :type => :feature do
       visit spotlight.edit_exhibit_search_path(exhibit, search)
       expect(page).to have_css("h1 small", text: "Edit Browse Category")
       expect(find_field("search_title").value).to eq search.title
+      within ".appliedFilter" do
+        expect(page).to have_content "Genre"
+        expect(page).to have_content "Value"
+      end
     end
   end
   describe "destroy" do

--- a/spec/views/spotlight/searches/_search.html.erb_spec.rb
+++ b/spec/views/spotlight/searches/_search.html.erb_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe "spotlight/searches/_search.html.erb", :type => :view do
   
   let(:search) { stub_model(Spotlight::Search, exhibit: FactoryGirl.create(:exhibit),
-        id: 99, title: "Title1", short_description: "MyText") }
+        id: 99, title: "Title1", short_description: "MyText", query_params: { f: { genre_ssim: ["xyz"]}}) }
   before do
     allow(view).to receive(:edit_search_path).and_return("/edit")
     allow(view).to receive(:search_path).and_return("/search")

--- a/spec/views/spotlight/searches/edit.html.erb_spec.rb
+++ b/spec/views/spotlight/searches/edit.html.erb_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe "spotlight/searches/edit.html.erb", :type => :view do
+  
+  let(:blacklight_config) do
+    Blacklight::Configuration.new do |config|
+      config.add_facet_field :some_field
+    end
+  end
+  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:search) { stub_model(Spotlight::Search, exhibit: exhibit,
+        id: 99, title: "Title1", short_description: "MyText", query_params: { f: { "some_field" => ["xyz"]}}) }
+  before do
+    allow(view).to receive(:search_action_path).and_return("/search")
+    allow(view).to receive(:exhibit_search_path).and_return("/search")
+    allow(view).to receive(:exhibit_searches_path).and_return("/searches")
+    allow(view).to receive(:blacklight_config).and_return(blacklight_config)
+    assign(:exhibit, exhibit)
+    assign(:search, search)
+    allow(view).to receive(:current_exhibit).and_return(exhibit)
+  end
+
+  it "renders active search constraints" do
+    render
+    expect(rendered).to have_selector '.appliedFilter .constraint-value'
+    expect(rendered).to have_selector '.appliedFilter .constraint-value .filterName', text: "Some Field"
+    expect(rendered).to have_selector '.appliedFilter .constraint-value .filterValue', text: "xyz"
+  end
+end


### PR DESCRIPTION
![screen shot 2014-11-25 at 2 26 41 pm](https://cloud.githubusercontent.com/assets/111218/5193163/e6631480-74b2-11e4-8c84-ff322bfcaf09.png)

Fixes #716
