### PR TITLE
The autocomplete json uses the document's show title, so we need to ensure it's in the field list.

### DIFF
--- a/app/models/spotlight/blacklight_configuration.rb
+++ b/app/models/spotlight/blacklight_configuration.rb
@@ -58,7 +58,7 @@ module Spotlight
         config.show.merge! show unless show.blank?
         config.index.merge! index unless index.blank?
 
-        config.default_autocomplete_solr_params[:fl] = "id #{config.index.title_field} #{config.index.thumbnail_field}"
+        config.default_autocomplete_solr_params[:fl] = "id #{config.view_config(:show).title_field} #{config.view_config(:show).thumbnail_field}"
 
         config.default_solr_params = config.default_solr_params.merge(default_solr_params)
 

--- a/spec/models/spotlight/blacklight_configuration_spec.rb
+++ b/spec/models/spotlight/blacklight_configuration_spec.rb
@@ -322,6 +322,17 @@ describe Spotlight::BlacklightConfiguration, :type => :model do
     end
   end
 
+  describe "default_autocomplete_solr_params" do
+    it "should include all the fields we need to render the autocomplete widget" do
+      blacklight_config.show.title_field = "some_field"
+      blacklight_config.show.thumbnail_field = "some_thumbnail"
+      expect(subject.blacklight_config.default_autocomplete_solr_params).to have_key :fl
+      expect(subject.blacklight_config.default_autocomplete_solr_params[:fl]).to include "id"
+      expect(subject.blacklight_config.default_autocomplete_solr_params[:fl]).to include "some_field"
+      expect(subject.blacklight_config.default_autocomplete_solr_params[:fl]).to include "some_thumbnail"
+    end
+  end
+
   describe "show" do
     it "should have show view configuration" do
       expect(subject.show).to be_empty


### PR DESCRIPTION
Fixes #760 
