### PR TITLE
Trigger known block javascript behaviors when previewing

### DIFF
--- a/app/assets/javascripts/spotlight/blocks/item_features_block.js
+++ b/app/assets/javascripts/spotlight/blocks/item_features_block.js
@@ -13,12 +13,21 @@ SirTrevor.Blocks.ItemFeatures =  (function(){
   });
 })();;
 
-Spotlight.onLoad(function(){
-  var indicators = $('.item-features .slideshow-indicators li');
-  indicators.each(function(){
-    $(this).on('click', function(){
-      indicators.removeClass("active");
-      $(this).addClass("active");
+
+(function($){
+  // Plugin definition
+  $.fn.featuredItemsCarousel = function(options) {
+    var indicators = $(this).find('.slideshow-indicators li');
+
+    indicators.each(function(){
+      $(this).on('click', function(){
+        indicators.removeClass("active");
+        $(this).addClass("active");
+      });
     });
+  };
+
+  Spotlight.onLoad(function(){
+    $('.item-features').featuredItemsCarousel();
   });
-});
+})(jQuery);

--- a/app/assets/javascripts/spotlight/pages.js
+++ b/app/assets/javascripts/spotlight/pages.js
@@ -108,8 +108,19 @@ function addPreviewToSirTrevorBlock(block){
         var widget_bar = $('<div class="st-block__ui" />').append(btn);
 
         $('<div class="preview clearfix st-block__inner">').append(preview).append(widget_bar).insertAfter(block.$inner);
-          block.$inner.hide();
+        block.$inner.hide();
+
+        // trigger js behaviors we know blocks can provide
+        $('[data-ride="carousel"]').each(function () {
+          var $carousel = $(this)
+          $carousel.carousel($carousel.data())
+        });
+
+        $('.slideshow-block').slideshowBlock();
+        $('.item-features').featuredItemsCarousel();
+        $('[data-embed-url]').oEmbed();
         }
+
       );
   });
 


### PR DESCRIPTION
This gets us part of the way on #737. I can't figure out how to trigger the `data-target` click-handlers, e.g. https://github.com/twbs/bootstrap-sass/blob/master/assets/javascripts/bootstrap/carousel.js#L211.
