### PR TITLE
Display a warning for fields that are not configured to be displayed...

### DIFF
--- a/app/assets/stylesheets/spotlight/_catalog.css.scss
+++ b/app/assets/stylesheets/spotlight/_catalog.css.scss
@@ -45,6 +45,10 @@ form.edit_solr_document {
   .bootstrap-tagsinput {
     display: block;
   }
+  .bg-warning.help-block {
+    font-size: 0.9em;
+    padding: 3px 6px;
+  }
 }
 
 .bootstrap-tagsinput {

--- a/app/models/spotlight/custom_field.rb
+++ b/app/models/spotlight/custom_field.rb
@@ -32,9 +32,25 @@ module Spotlight
       configuration["short_description"]
     end
 
+    def configured_to_display?
+      if index_fields_config["enabled"]
+        view_types.any? do |view|
+          index_fields_config[view.to_s]
+        end
+      end
+    end
+
     protected
     def field_name
       "#{Spotlight::Engine.config.solr_fields.prefix}exhibit_#{self.exhibit.to_param}_#{label.parameterize}#{Spotlight::Engine.config.solr_fields.text_suffix}"
+    end
+
+    def view_types
+      [:show] + exhibit.blacklight_configuration.blacklight_config.view.keys
+    end
+
+    def index_fields_config
+      exhibit.blacklight_configuration[:index_fields][field]
     end
 
     def should_generate_new_friendly_id?

--- a/app/views/spotlight/catalog/_edit_default.html.erb
+++ b/app/views/spotlight/catalog/_edit_default.html.erb
@@ -4,6 +4,12 @@
     <%= c.fields_for :data do |d| %>
       <% current_exhibit.custom_fields.each do |field| %>
         <%= d.text_field field.field, value: document.sidecar(current_exhibit).data[field.field], label: field.label %>
+        <% unless field.configured_to_display? %>
+          <p class="bg-warning help-block">
+            <%= t(:'.blank_field_warning_html',
+                  link: link_to(t(:'spotlight.curation.sidebar.metadata'), spotlight.exhibit_edit_metadata_path(current_exhibit))) %>
+          </p>
+        <% end %>
       <% end %>
     <% end %>
   <% end %>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -164,6 +164,8 @@ en:
     catalog:
       breadcrumb:
         index: 'Search Results'
+      edit_default:
+        blank_field_warning_html: "This field is currently hidden on all pages. You can make it visible on the Curation &gt; %{link} page."
       facets:
         exhibit_visibility:
           label: "Item Visibility"

--- a/spec/models/spotlight/custom_field_spec.rb
+++ b/spec/models/spotlight/custom_field_spec.rb
@@ -66,4 +66,42 @@ describe Spotlight::CustomField, :type => :model do
     end
   end
 
+  describe '#configured_to_display?' do
+    let(:exhibit) { FactoryGirl.create(:exhibit) }
+    before do
+      exhibit.blacklight_configuration.blacklight_config.view = {view_name: {}}
+      subject.exhibit = exhibit
+      subject.label = "Label"
+      subject.field = 'foo_tesim'
+    end
+    it 'should be truthy when a view has been configured true' do
+      exhibit.blacklight_configuration.index_fields['foo_tesim'] =
+        Blacklight::Configuration::IndexField.new(label: "Label", enabled: true, view_name: true)
+      subject.save
+
+      expect(subject).to be_configured_to_display
+    end
+    it 'should be truthey for show views when enabled' do
+      exhibit.blacklight_configuration.index_fields['foo_tesim'] =
+        Blacklight::Configuration::IndexField.new(label: "Label", enabled: true, show: true)
+      subject.save
+
+      expect(subject).to be_configured_to_display
+    end
+    it 'should be falsey when a few has not been configured true' do
+      exhibit.blacklight_configuration.index_fields['foo_tesim'] =
+        Blacklight::Configuration::IndexField.new(label: "Label", enabled: true, view_name: false)
+      subject.save
+
+      expect(subject).to_not be_configured_to_display
+    end
+    it 'should be falsey when the field is not enabled' do
+      exhibit.blacklight_configuration.index_fields['foo_tesim'] =
+        Blacklight::Configuration::IndexField.new(label: "Label", enabled: false, view_name: false)
+      subject.save
+
+      expect(subject).to_not be_configured_to_display
+    end
+  end
+
 end


### PR DESCRIPTION
...anywhere.

Closes #258 

We will need to move the warning into the field group once we update bootstrap-forms.

![screen shot 2014-12-01 at 7 17 00 pm](https://cloud.githubusercontent.com/assets/96776/5257509/bc494f3a-798e-11e4-9a6b-90cf643ab0ef.png)
