### PR TITLE
Update to bootstrap_form 2.2.0.

### DIFF
--- a/app/assets/stylesheets/spotlight/_blacklight_configuration.css.scss
+++ b/app/assets/stylesheets/spotlight/_blacklight_configuration.css.scss
@@ -38,7 +38,7 @@
       margin-right: $padding-base-horizontal;
       padding-left: 0px;
       padding-bottom: $table-cell-padding;
-      padding-top: $padding-base-vertical + 1 + $table-cell-padding;
+      padding-top: 1 + $table-cell-padding;
       display: block;
     }
     input {

--- a/app/views/spotlight/catalog/_edit_default.html.erb
+++ b/app/views/spotlight/catalog/_edit_default.html.erb
@@ -3,13 +3,16 @@
   <%= f.fields_for :sidecar do |c| %>
     <%= c.fields_for :data do |d| %>
       <% current_exhibit.custom_fields.each do |field| %>
-        <%= d.text_field field.field, value: document.sidecar(current_exhibit).data[field.field], label: field.label %>
-        <% unless field.configured_to_display? %>
-          <p class="bg-warning help-block">
-            <%= t(:'.blank_field_warning_html',
-                  link: link_to(t(:'spotlight.curation.sidebar.metadata'), spotlight.exhibit_edit_metadata_path(current_exhibit))) %>
-          </p>
-        <% end %>
+        <div class="form-group">
+          <%= d.label field.field, field.label %>
+          <%= d.text_field_without_bootstrap field.field, value: document.sidecar(current_exhibit).data[field.field], class: 'form-control' %>
+          <% unless field.configured_to_display? %>
+            <p class="bg-warning help-block">
+              <%= t(:'.blank_field_warning_html',
+                    link: link_to(t(:'spotlight.curation.sidebar.metadata'), spotlight.exhibit_edit_metadata_path(current_exhibit))) %>
+            </p>
+          <% end %>
+        </div>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/spotlight/resources/csv/_form.html.erb
+++ b/app/views/spotlight/resources/csv/_form.html.erb
@@ -2,7 +2,10 @@
 <%= bootstrap_form_for [@resource.exhibit, @resource.becomes(Spotlight::Resources::Csv)], layout: :horizontal, label_col: 'col-md-3', control_col: 'col-sm-5 col-md-5', :html => {:multipart => true }  do |f| %>
 
   <div class="form-group">
-  <%= f.file_field :url, help: link_to(t('.template'), [:template, @resource.exhibit, @resource.becomes(Spotlight::Resources::Csv)]) %>
+  <%# bootstrap_form_for's file_field doesn't use any of the bootstrap 
+      goodness (bootstrap-ruby/rails-bootstrap-forms#49). Instead, we'll lie
+      about the field type and change the attribute ourselves. %>
+  <%= f.url_field :url, type: "file", help: link_to(t('.template'), [:template, @resource.exhibit, @resource.becomes(Spotlight::Resources::Csv)]) %>
   <%= f.hidden_field :url_cache %>
   </div>
   <div class="form-actions col-md-7 col-sm-7">

--- a/app/views/spotlight/searches/edit.html.erb
+++ b/app/views/spotlight/searches/edit.html.erb
@@ -8,7 +8,7 @@
       <%= f.hidden_field :featured_item_id, data: {:"featured-item-id" => true} %>
       <%= f.text_area :short_description %>
       <%= f.text_area :long_description, rows: 5 %>
-      <%= f.static_control nil, label: t(:".query_params") do %>
+      <%= f.static_control label: t(:".query_params") do %>
         <div class="well well-sm">
           <%= render_constraints(@search.query_params) %>
         </div>

--- a/blacklight-spotlight.gemspec
+++ b/blacklight-spotlight.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "carrierwave"
   s.add_dependency "carrierwave-crop"
   s.add_dependency "mini_magick"
-  s.add_dependency "bootstrap_form", "~> 2.1.0"
+  s.add_dependency "bootstrap_form", "~> 2.2.0"
   s.add_dependency "mail_form"
   s.add_dependency "acts-as-taggable-on", "3.1.0"
   s.add_dependency "friendly_id"


### PR DESCRIPTION
Use new *_without_bootstrap field helper to customize our form group.

Closes #767 
