### PR TITLE
Few more minor places where we reference a document's unique key as 'id'

### DIFF
--- a/app/helpers/spotlight/pages_helper.rb
+++ b/app/helpers/spotlight/pages_helper.rb
@@ -6,7 +6,7 @@ module Spotlight
     def item_grid_block_with_documents(block)
       block_objects = item_grid_block_objects(block)
       ids = item_grid_block_ids(block)
-      documents = get_solr_response_for_field_values("id", ids).last
+      documents = get_solr_response_for_field_values(blacklight_config.solr_document_model.unique_key, ids).last
       block_objects.each do |object|
         if (doc = documents.find{ |d| d[:id] == object[:id] }).present?
           object[:solr_document] = doc

--- a/app/models/concerns/spotlight/solr_document/atomic_updates.rb
+++ b/app/models/concerns/spotlight/solr_document/atomic_updates.rb
@@ -13,14 +13,22 @@ module Spotlight::SolrDocument::AtomicUpdates
 
     data.map do |doc|
       Hash[doc.map do |k,v|
-        val = if k == :id or k == "id"
+        val = if k.to_sym == unique_key_field.to_sym
           v
         else
           { set: v }
         end
 
         [k,val]
-      end] 
+      end]
     end.reject { |x| x.length <= 1 }
+  end
+
+  def unique_key_field
+    if respond_to?(:blacklight_config)
+      blacklight_config.solr_document_model.unique_key
+    else
+      'id'
+    end
   end
 end

--- a/app/models/spotlight/search.rb
+++ b/app/models/spotlight/search.rb
@@ -36,14 +36,14 @@ class Spotlight::Search < ActiveRecord::Base
   def images
     response = query_solr(query_params,
       rows: 1000,
-      fl: ['id', blacklight_config.index.title_field, blacklight_config.index.thumbnail_field],
+      fl: [blacklight_config.solr_document_model.unique_key, blacklight_config.index.title_field, blacklight_config.index.thumbnail_field],
       facet: false)
 
     Blacklight::SolrResponse.new(response, {}).docs.map do |result|
       doc = ::SolrDocument.new(result)
 
       [
-        doc.first('id'),
+        doc.first(blacklight_config.solr_document_model.unique_key),
         doc.first(blacklight_config.index.title_field),
         doc.first(blacklight_config.index.thumbnail_field)
       ]

--- a/app/models/spotlight/solr_document_sidecar.rb
+++ b/app/models/spotlight/solr_document_sidecar.rb
@@ -7,7 +7,7 @@ module Spotlight
     delegate :has_key?, to: :data
 
     def to_solr
-      { id: solr_document_id, visibility_field => public? }.merge(data_to_solr)
+      { blacklight_config.solr_document_model.unique_key.to_sym => solr_document_id, visibility_field => public? }.merge(data_to_solr)
     end
 
     def private!
@@ -22,6 +22,10 @@ module Spotlight
 
     def visibility_field
       Spotlight::SolrDocument.visibility_field(exhibit)
+    end
+
+    def blacklight_config
+      exhibit.blacklight_config
     end
 
     def data_to_solr

--- a/lib/tasks/spotlight_tasks.rake
+++ b/lib/tasks/spotlight_tasks.rake
@@ -55,8 +55,8 @@ namespace :spotlight do
       begin
         id = 'test123'
         field = "test_#{Spotlight::Engine.config.solr_fields.string_suffix}"
-        Blacklight.solr.add id: id, field => 'some-string'
-        Blacklight.solr.update data: [{id: id, field => { set: 'a-new-string' }}].to_json, headers: { 'Content-Type' => 'application/json' }
+        Blacklight.solr.add blacklight_config.solr_document_model.unique_key.to_sym => id, field => 'some-string'
+        Blacklight.solr.update data: [{blacklight_config.solr_document_model.unique_key => id, field => { set: 'a-new-string' }}].to_json, headers: { 'Content-Type' => 'application/json' }
         Blacklight.solr.delete_by_id id
         print " OK\n"
       rescue Exception => e


### PR DESCRIPTION
Not sure if all of these are necessary/wise specifically the stuff in AtomicUpdates since that is included in a SolrDocument AND in an ActiveRecord class.

Feel free to merge this into your work or just close it if we shouldn't update these refs as well.
