### PR TITLE
Touch the exhibit's about pages when a contact is saved.

### DIFF
--- a/app/models/spotlight/contact.rb
+++ b/app/models/spotlight/contact.rb
@@ -11,9 +11,11 @@ class Spotlight::Contact < ActiveRecord::Base
 
   ## carrierwave-crop doesn't want to store the crop points. we do.
   # so instead of this:
-  #crop_uploaded :avatar  ## Add this
+  #crop_uploaded :avatar
   # we do this:
+  #recreate_avatar_versions if avatar.present?
   after_save do
+    touch_about_pages
     recreate_avatar_versions if avatar.present?
   end
 
@@ -31,5 +33,9 @@ class Spotlight::Contact < ActiveRecord::Base
   protected
   def should_generate_new_friendly_id?
     name_changed?
+  end
+
+  def touch_about_pages
+    exhibit.about_pages.map(&:touch)
   end
 end

--- a/spec/models/spotlight/contact_spec.rb
+++ b/spec/models/spotlight/contact_spec.rb
@@ -1,7 +1,10 @@
 require 'spec_helper'
 
 describe Spotlight::Contact, :type => :model do
-  
+  let(:exhibit) { stub_model(Spotlight::Exhibit) }
+  before do
+    subject.exhibit = exhibit
+  end
   context "#show_in_sidebar" do
     it "should be an attribute" do
       subject.show_in_sidebar = false
@@ -11,6 +14,16 @@ describe Spotlight::Contact, :type => :model do
     it "should be published by default" do
       subject.save
       expect(subject.show_in_sidebar).to be_truthy
+    end
+  end
+  context "touch_about_pages" do
+    let(:about_page) { stub_model(Spotlight::AboutPage) }
+    before do
+      exhibit.about_pages = [about_page]
+    end
+    it 'should touch about pages after save' do
+      expect(about_page).to receive(:touch)
+      subject.save
     end
   end
   context "#fields" do


### PR DESCRIPTION
Closes #777

This doesn't do anything about a page title  change not being reflected in the sidebar until the page itself is touched, but if we decide that's a good idea I think that would be a separate ticket.
