### PR TITLE
Add searchable options to appearances page.

### DIFF
--- a/app/controllers/spotlight/appearances_controller.rb
+++ b/app/controllers/spotlight/appearances_controller.rb
@@ -25,7 +25,7 @@ class Spotlight::AppearancesController < Spotlight::ApplicationController
   end
 
   def appearance_params
-    params.require(:appearance).permit(:default_per_page,
+    params.require(:appearance).permit(:default_per_page, :searchable,
       document_index_view_types: @appearance.view_type_options,
       sort_fields: @appearance.allowed_params,
       main_navigations: [:id, :label, :weight])

--- a/app/models/spotlight/home_page.rb
+++ b/app/models/spotlight/home_page.rb
@@ -10,6 +10,10 @@ module Spotlight
       display_title
     end
 
+    def display_sidebar?
+      exhibit.searchable?
+    end
+
     private
     def self.default_content_text
       "This is placeholder content for the exhibit homepage. Curators of this exhibit can edit this page to customize it for the exhibit."

--- a/app/views/shared/_exhibit_navbar.html.erb
+++ b/app/views/shared/_exhibit_navbar.html.erb
@@ -8,10 +8,11 @@
         <% end %>
       <% end %>
     </ul>
-
-    <div class="navbar-right col-sm-4 col-md-4"> 
-      <%= render_search_bar  %>
-    </div>
+    <% if !current_exhibit || current_exhibit.searchable? %>
+      <div class="navbar-right col-sm-4 col-md-4">
+        <%= render_search_bar  %>
+      </div>
+    <% end %>
   </div>
 </div>
 <div class="container">

--- a/app/views/spotlight/appearances/edit.html.erb
+++ b/app/views/spotlight/appearances/edit.html.erb
@@ -4,6 +4,10 @@
 
 <%= bootstrap_form_for @appearance, url: spotlight.exhibit_appearance_path(@exhibit), layout: :horizontal, label_col: 'col-md-3', control_col: 'col-sm-5' do |f| %>
   <%= field_set_tag do %>
+    <h3><%= t(:'.exhibit_style.heading') %></h3>
+    <%= f.check_box(:searchable, label: t(:'.exhibit_style.searchable.label')) %>
+  <% end %>
+  <%= field_set_tag do %>
     <h3><%= t(:'.main_navigation.menu') %></h3>
     <p class="instructions"><%= t(:'.main_navigation.help') %></p>
     <div class="panel-group dd main_navigation_admin col-sm-7" id="nested-navigation" data-behavior="nestable" data-max-depth="1">

--- a/app/views/spotlight/searches/index.html.erb
+++ b/app/views/spotlight/searches/index.html.erb
@@ -5,21 +5,31 @@
   
   <% if @searches.empty? %>
     <%= t :'.no_saved_searches' %>
+    <% unless @exhibit.searchable? %>
+      <p class="instructions alert-warning">
+        <%= t(:'.not_searchable_html', href: link_to(t(:'spotlight.administration.sidebar.appearance'), spotlight.edit_exhibit_appearance_path(@exhibit))) %>
+      </p>
+    <% end %>
   <% else %>
-      <p class="instructions"><%= t(:'.instructions') %></p>
-  <%= bootstrap_form_for @exhibit, url: update_all_exhibit_searches_path(@exhibit), layout: :horizontal, control_col: 'col-sm-10' do |f| %>
+    <p class="instructions"><%= t(:'.instructions') %></p>
+    <% unless @exhibit.searchable? %>
+      <p class="instructions alert-warning">
+        <%= t(:'.not_searchable_html', href: link_to(t(:'spotlight.administration.sidebar.appearance'), spotlight.edit_exhibit_appearance_path(@exhibit))) %>
+      </p>
+    <% end %>
+    <%= bootstrap_form_for @exhibit, url: update_all_exhibit_searches_path(@exhibit), layout: :horizontal, control_col: 'col-sm-10' do |f| %>
 
-    <div class="panel-group dd search_admin" id="nested-pages" data-behavior="nestable" data-max-depth="1">
-      <ol class="dd-list">
-      <%= f.fields_for :searches do |p| %>
-        <%= render partial: 'search', locals: { f: p} %>
-      <% end %>
-      </ol>
-    </div>
+      <div class="panel-group dd search_admin" id="nested-pages" data-behavior="nestable" data-max-depth="1">
+        <ol class="dd-list">
+          <%= f.fields_for :searches do |p| %>
+            <%= render partial: 'search', locals: { f: p} %>
+          <% end %>
+        </ol>
+      </div>
 
-    <div class="pull-right">
-      <%= submit_tag t(:'helpers.action.update_all'), class: "btn btn-primary" %>
-    </div>
-  <% end %>
+      <div class="pull-right">
+        <%= submit_tag t(:'helpers.action.update_all'), class: "btn btn-primary" %>
+      </div>
+    <% end %>
   <% end %>
 </div>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -111,6 +111,10 @@ en:
         header: Appearance
         document_index_view_types: Result page types
         default_per_page: Default results per page
+        exhibit_style:
+          heading: "Exhibit Style"
+          searchable:
+            label: "Searchable (offer searchbox and facet sidebar)"
         main_navigation:
           menu: Main Navigation Menu
           help: Click a menu item to change its display label. Drag and drop a menu item to change their order in the main navigation menu.
@@ -338,6 +342,7 @@ en:
         categories_header: "Browse Categories"
         instructions: "Use the Save search button on a search results page to create a new browse category. Select the categories you want to be displayed on the browse landing page. Drag and drop categories to change the order in which they appear on that page."
         no_saved_searches: "You can save search results while in curation mode to create browse categories, which will be displayed here."
+        not_searchable_html: "This exhibit is not currently searchable. To perform searches that can be saved as additional browse categories, an Administrator must temporarily turn on the Searchable option in the Exhibit Style section of the Administration > %{href} page."
       edit:
         header: "Edit Browse Category"
         title: "Curation - Browse"

--- a/db/migrate/20141205005902_add_layout_options_to_exhibit.rb
+++ b/db/migrate/20141205005902_add_layout_options_to_exhibit.rb
@@ -1,0 +1,6 @@
+class AddLayoutOptionsToExhibit < ActiveRecord::Migration
+  def change
+    add_column :spotlight_exhibits, :searchable, :boolean, default: true
+    add_column :spotlight_exhibits, :layout,     :string
+  end
+end

--- a/spec/features/update_appearance_spec.rb
+++ b/spec/features/update_appearance_spec.rb
@@ -11,6 +11,8 @@ describe "Update the appearance", :type => :feature do
       click_link "Appearance"
     end
 
+    uncheck "Searchable (offer searchbox and facet sidebar)"
+
     uncheck "List"
 
     choose "20"
@@ -27,6 +29,8 @@ describe "Update the appearance", :type => :feature do
     within "#sidebar" do
       click_link "Appearance"
     end
+
+    expect(field_labeled('Searchable (offer searchbox and facet sidebar)')).to_not be_checked
 
     expect(field_labeled('List')).to_not be_checked
     expect(field_labeled('Gallery')).to be_checked

--- a/spec/models/spotlight/appearance_spec.rb
+++ b/spec/models/spotlight/appearance_spec.rb
@@ -12,6 +12,22 @@ describe Spotlight::Appearance, :type => :model do
     expect(subject.send(:enable_sort_fields, ['title', 'type'])).to eq( { 'sort_title_ssi asc' => {show: true}, 'sort_type_ssi asc' => {show: true}})
   end
 
+  describe '#searchable' do
+    it 'should be delegated to the exhibit' do
+      expect(config.exhibit).to receive(:searchable)
+      subject.searchable
+    end
+  end
+
+  describe '#exhibit_params' do
+    it 'should include the searchable parameter' do
+      expect(subject.send(:exhibit_params, searchable: true)).to eq({searchable: true})
+    end
+    it 'should include the main_navigations_attribute parameter when main_navigations is present' do
+      expect(subject.send(:exhibit_params, searchable: false, main_navigations: {a: :a})[:main_navigations_attributes]).to eq([:a])
+    end
+  end
+
   describe "#sort_fields" do
     subject { Spotlight::Appearance.new(config).sort_fields }
     describe "when fields are set" do

--- a/spec/models/spotlight/home_page_spec.rb
+++ b/spec/models/spotlight/home_page_spec.rb
@@ -23,6 +23,16 @@ describe Spotlight::HomePage, :type => :model do
       expect(home_page.should_display_title?).to be_falsey
     end
   end
+  describe 'display_sidebar?' do
+    it 'should be true when the exhibit is searchable' do
+      home_page.exhibit.searchable = true
+      expect(home_page.display_sidebar?).to be_truthy
+    end
+    it 'should be false when the exhibit is not searchable' do
+      home_page.exhibit.searchable = false
+      expect(home_page.display_sidebar?).to be_falsey
+    end
+  end
   describe "content" do
     it "should include default text" do
       expect(home_page.content).to match /#{Spotlight::HomePage.default_content_text}/

--- a/spec/views/shared/_exhibit_navbar.html.erb_spec.rb
+++ b/spec/views/shared/_exhibit_navbar.html.erb_spec.rb
@@ -100,5 +100,16 @@ module Spotlight
       expect(response).to have_selector "li.active", text: "About"
     end
 
+    it 'should include the search bar when the exhibit is searchable' do
+      expect(current_exhibit).to receive(:searchable?).and_return(true)
+      render
+      expect(response).to have_content "Search Bar"
+    end
+
+    it 'should not include the search bar when the exhibit is searchable' do
+      expect(current_exhibit).to receive(:searchable?).and_return(false)
+      render
+      expect(response).to_not have_content "Search Bar"
+    end
   end
 end

--- a/spec/views/spotlight/searches/index.html.erb_spec.rb
+++ b/spec/views/spotlight/searches/index.html.erb_spec.rb
@@ -16,4 +16,13 @@ describe "spotlight/searches/index.html.erb", :type => :view do
       expect(rendered).to have_content "You can save search results"
     end
   end
+
+  describe 'When the exhibit is not searchable' do
+    it 'should display a warning' do
+      assign(:searches, [])
+      expect(exhibit).to receive(:searchable?).and_return(false)
+      render
+      expect(rendered).to have_css('.alert-warning', text: "This exhibit is not currently searchable. To perform searches that can be saved as additional browse categories, an Administrator must temporarily turn on the Searchable option in the Exhibit Style section of the Administration > Appearance page.")
+    end
+  end
 end


### PR DESCRIPTION
Closes #785 

Add warning to the Browse admin page when an exhibit is not searchable.

Remove facets and searchbox on home page if an exhibit is not searchable.
### Appearances page

![checkbox](https://cloud.githubusercontent.com/assets/96776/5324506/1cc8d3f4-7c90-11e4-9ba6-00e89320463f.png)
### Browse page warning

![browse-warning](https://cloud.githubusercontent.com/assets/96776/5324505/1cc891e6-7c90-11e4-9334-537da3a2bdbb.png)
### Home page

![home-page](https://cloud.githubusercontent.com/assets/96776/5324504/14300b7c-7c90-11e4-9699-90ab1c9ee3b5.png)
