### PR TITLE
Blacklight gallery 0.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,9 +25,8 @@ gem 'sprockets', '2.11.0'
 gem 'sass', '~> 3.2.0'
 gem 'bootstrap-sass', ">= 3.1.1.1"
 
-gem 'blacklight-gallery', github: 'projectblacklight/blacklight-gallery'
+gem 'blacklight-gallery', '>= 0.1.1'
 gem 'sir-trevor-rails', github: 'sul-dlss/sir-trevor-rails'
-gem 'openseadragon', github: 'sul-dlss/openseadragon-rails'
 
 group :test do
   # Peg simplecov to < 0.8 until this is resolved:

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -5,9 +5,8 @@ class TestAppGenerator < Rails::Generators::Base
 
   def add_gems
     gem 'blacklight', ">= 5.4.0.rc1", "<6"
-    gem "blacklight-gallery", :github => 'projectblacklight/blacklight-gallery'
+    gem "blacklight-gallery", ">= 0.1.1"
     gem 'sir-trevor-rails', :github => 'sul-dlss/sir-trevor-rails'
-    gem 'openseadragon', :github => 'sul-dlss/openseadragon-rails'
     gem "jettywrapper"
     Bundler.with_clean_env do
       run "bundle install"

--- a/template.rb
+++ b/template.rb
@@ -1,8 +1,7 @@
 gem "blacklight"
-gem "blacklight-gallery", :github => 'projectblacklight/blacklight-gallery'
+gem "blacklight-gallery", ">= 0.1.1"
 gem "blacklight-spotlight", :github => 'sul-dlss/spotlight'
 gem 'sir-trevor-rails', :github => 'sul-dlss/sir-trevor-rails'
-gem 'openseadragon', :github => 'sul-dlss/openseadragon-rails'
 
 run "bundle install"
 


### PR DESCRIPTION
This should fix, among other things, the FilteredAsset exceptions we were getting from sprockets.
