### PR TITLE
Invalidate page and fragment caches when the exhibit changes

### DIFF
--- a/app/controllers/spotlight/pages_controller.rb
+++ b/app/controllers/spotlight/pages_controller.rb
@@ -17,7 +17,7 @@ module Spotlight
 
     # GET /pages/1
     def show
-      fresh_when(@page)
+      fresh_when([@page.exhibit, @page])
     end
 
     def preview

--- a/app/views/spotlight/about_pages/_sidebar.html.erb
+++ b/app/views/spotlight/about_pages/_sidebar.html.erb
@@ -1,4 +1,4 @@
-<% cache_unless current_user, @page do %>
+<% cache_unless current_user, [current_exhibit, @page] do %>
 <div id="sidebar" class="col-md-3" role="complementary">
   <h4><%= current_exhibit.main_navigations.about.label_or_default %></h4>
   <ul class="nav sidenav">

--- a/app/views/spotlight/feature_pages/_sidebar.html.erb
+++ b/app/views/spotlight/feature_pages/_sidebar.html.erb
@@ -1,4 +1,4 @@
-<% cache_unless current_user, @page do %>
+<% cache_unless current_user, [current_exhibit, @page] do %>
 <div id="sidebar" class="col-md-3" role="complementary">
   <ol class="nav sidenav">
     <% @exhibit.feature_pages.published.at_top_level.each do |feature_section| %>


### PR DESCRIPTION
(i.e. when anything touches the exhibit, like creating and removing pages and contacts)
