### PR TITLE
Add spotlight:import task to import exhibits from the command line

### DIFF
--- a/lib/tasks/spotlight_tasks.rake
+++ b/lib/tasks/spotlight_tasks.rake
@@ -31,6 +31,13 @@ namespace :spotlight do
     puts "Exhibit created."
   end
 
+  desc "Import an exhibit"
+  task import: :environment do
+    exhibit = Spotlight::Exhibit.create title: "Imported Exhibit"
+    exhibit.import(JSON.parse(STDIN.read))
+    puts Spotlight::ExhibitExportSerializer.new(exhibit).to_json
+  end
+
   def prompt_password
     begin
       system "stty -echo"


### PR DESCRIPTION
Fixes #818 
