### PR TITLE
ReadOnly has a different field name.

### DIFF
--- a/app/models/spotlight/custom_field.rb
+++ b/app/models/spotlight/custom_field.rb
@@ -17,7 +17,7 @@ module Spotlight
     end
 
     before_save do
-      update_field_name(field_name) if persisted? && field_type_changed?
+      update_field_name(field_name) if update_field_name?
     end
 
     def label=(label)
@@ -74,24 +74,11 @@ module Spotlight
     end
 
     def field_name
-      "#{field_slug}#{field_suffix}"
-    end
-
-    def field_slug
-      configuration['label'].parameterize
+      CustomFieldName.new(self).to_s
     end
 
     def solr_field_prefix
       document_model.solr_field_prefix(exhibit)
-    end
-
-    def field_suffix
-      case field_type
-      when 'vocab'
-        Spotlight::Engine.config.solr_fields.string_suffix
-      else
-        Spotlight::Engine.config.solr_fields.text_suffix
-      end
     end
 
     def view_types
@@ -134,6 +121,10 @@ module Spotlight
 
     def document_model
       blacklight_configuration.document_model
+    end
+
+    def update_field_name?
+      persisted? && (field_type_changed? || readonly_field_changed?)
     end
   end
 end

--- a/app/values/custom_field_name.rb
+++ b/app/values/custom_field_name.rb
@@ -1,0 +1,36 @@
+##
+# Value object for calculating a custom field name.
+class CustomFieldName
+  delegate :readonly_field?, :configuration, :field_type, to: :custom_field
+  attr_reader :custom_field
+  def initialize(custom_field)
+    @custom_field = custom_field
+  end
+
+  def to_s
+    "#{field_slug}#{field_suffix}"
+  end
+
+  private
+
+  def field_slug
+    "#{field_prefix}#{configuration['label'].parameterize}"
+  end
+
+  def field_prefix
+    if readonly_field?
+      'readonly_'
+    else
+      ''
+    end
+  end
+
+  def field_suffix
+    case field_type
+    when 'vocab'
+      Spotlight::Engine.config.solr_fields.string_suffix
+    else
+      Spotlight::Engine.config.solr_fields.text_suffix
+    end
+  end
+end

--- a/spec/models/spotlight/custom_field_spec.rb
+++ b/spec/models/spotlight/custom_field_spec.rb
@@ -69,6 +69,12 @@ describe Spotlight::CustomField, type: :model do
       subject.save
       expect(subject.field).to end_with Spotlight::Engine.config.solr_fields.string_suffix
     end
+
+    it 'begins with readonly if it is readonly' do
+      subject.readonly_field = true
+      subject.save
+      expect(subject.field).to start_with('readonly_')
+    end
   end
 
   describe '#solr_field' do


### PR DESCRIPTION
Allows imported fields to have the same label as a user-defined field,
but have its own content.