### PR TITLE
Fix tests.

### DIFF
--- a/spec/features/edit_search_fields_spec.rb
+++ b/spec/features/edit_search_fields_spec.rb
@@ -59,7 +59,7 @@ describe 'Search Administration', type: :feature do
         uncheck 'blacklight_configuration_sort_fields_title_enabled'
         uncheck 'blacklight_configuration_sort_fields_identifier_enabled'
 
-        find('#blacklight_configuration_sort_fields_type_weight').set('100')
+        find('#blacklight_configuration_sort_fields_type_weight', visible: false).set('100')
 
         click_button 'Save changes'
 

--- a/spec/views/spotlight/about_pages/index.html.erb_spec.rb
+++ b/spec/views/spotlight/about_pages/index.html.erb_spec.rb
@@ -48,9 +48,9 @@ describe 'spotlight/about_pages/index.html.erb', type: :view do
     expect(rendered).to have_selector '.panel-title', text: 'Title2'
 
     expect(rendered).to have_selector '.contacts_admin ol.dd-list li[data-id]', count: 2
-    expect(rendered).to have_selector '.contacts_admin ol.dd-list li input[data-property=weight]', count: 2
-    expect(rendered).to have_selector '.contacts_admin ol.dd-list li input#exhibit_contacts_attributes_0_id'
-    expect(rendered).to have_selector '.contacts_admin ol.dd-list li input#exhibit_contacts_attributes_1_id'
+    expect(rendered).to have_selector '.contacts_admin ol.dd-list li input[data-property=weight]', visible: false, count: 2
+    expect(rendered).to have_selector '.contacts_admin ol.dd-list li input#exhibit_contacts_attributes_0_id', visible: false
+    expect(rendered).to have_selector '.contacts_admin ol.dd-list li input#exhibit_contacts_attributes_1_id', visible: false
   end
 
   describe 'Save button' do

--- a/spec/views/spotlight/searches/_search.html.erb_spec.rb
+++ b/spec/views/spotlight/searches/_search.html.erb_spec.rb
@@ -31,6 +31,6 @@ describe 'spotlight/searches/_search.html.erb', type: :view do
     expect(rendered).to have_selector "li[data-id='99']"
     expect(rendered).to have_selector '.panel-heading .main .title', text: 'Title1'
     expect(rendered).to have_selector 'img[src="/some/image"]'
-    expect(rendered).to have_selector 'input[type=hidden][data-property=weight]'
+    expect(rendered).to have_selector 'input[type=hidden][data-property=weight]', visible: false
   end
 end


### PR DESCRIPTION
Looks like Capybara's default functionality is to hide invisible
elements. Proposing we go with it rather than turning off Capybara's
 #ignore_hidden_elements.