### PR TITLE
Ruby version management artifacts should be ignored by git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.ruby-version
+.ruby-*
 *.rbc
 *.sassc
 .sass-cache


### PR DESCRIPTION
`.ruby-version` and `.ruby-gemset` are the two files that are commonly used by RVM and rbenv. Ignore both.