### PR TITLE
Cleanup rspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 *.sassc
 .sass-cache
 capybara-*.html
-.rspec
 .rvmrc
 .ruby-version
 /.bundle

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--require spec_helper

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe ApplicationController, type: :controller do
   routes { Spotlight::Engine.routes }
   let(:exhibit) { FactoryGirl.create(:exhibit) }

--- a/spec/controllers/spotlight/about_pages_controller_spec.rb
+++ b/spec/controllers/spotlight/about_pages_controller_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::AboutPagesController, type: :controller do
   routes { Spotlight::Engine.routes }
   let(:valid_attributes) { { 'title' => 'MyString' } }

--- a/spec/controllers/spotlight/admin_users_controller_spec.rb
+++ b/spec/controllers/spotlight/admin_users_controller_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::AdminUsersController, type: :controller do
   routes { Spotlight::Engine.routes }
 

--- a/spec/controllers/spotlight/appearances_controller_spec.rb
+++ b/spec/controllers/spotlight/appearances_controller_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 describe Spotlight::AppearancesController, type: :controller do
   routes { Spotlight::Engine.routes }
   let(:exhibit) { FactoryGirl.create(:exhibit) }

--- a/spec/controllers/spotlight/application_controller_spec.rb
+++ b/spec/controllers/spotlight/application_controller_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::ApplicationController, type: :controller do
   routes { Spotlight::Engine.routes }
   let(:exhibit) { FactoryGirl.create(:exhibit) }

--- a/spec/controllers/spotlight/attachments_controller_spec.rb
+++ b/spec/controllers/spotlight/attachments_controller_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::AttachmentsController, type: :controller do
   routes { Spotlight::Engine.routes }
   let(:exhibit) { FactoryGirl.create(:exhibit) }

--- a/spec/controllers/spotlight/browse_controller_spec.rb
+++ b/spec/controllers/spotlight/browse_controller_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::BrowseController, type: :controller do
   routes { Spotlight::Engine.routes }
   let(:exhibit) { FactoryGirl.create(:exhibit) }

--- a/spec/controllers/spotlight/catalog_controller_spec.rb
+++ b/spec/controllers/spotlight/catalog_controller_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::CatalogController, type: :controller do
   routes { Spotlight::Engine.routes }
   let(:exhibit) { FactoryGirl.create(:exhibit) }

--- a/spec/controllers/spotlight/confirmations_controller_spec.rb
+++ b/spec/controllers/spotlight/confirmations_controller_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::ConfirmationsController, type: :controller do
   routes { Spotlight::Engine.routes }
   before do

--- a/spec/controllers/spotlight/contact_forms_controller_spec.rb
+++ b/spec/controllers/spotlight/contact_forms_controller_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::ContactFormsController, type: :controller do
   routes { Spotlight::Engine.routes }
   let(:exhibit) { FactoryGirl.create(:exhibit) }

--- a/spec/controllers/spotlight/contacts_controller_spec.rb
+++ b/spec/controllers/spotlight/contacts_controller_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::ContactsController, type: :controller do
   routes { Spotlight::Engine.routes }
   describe 'when not logged in' do

--- a/spec/controllers/spotlight/custom_fields_controller_spec.rb
+++ b/spec/controllers/spotlight/custom_fields_controller_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 describe Spotlight::CustomFieldsController, type: :controller do
   routes { Spotlight::Engine.routes }
   let(:exhibit) { FactoryGirl.create(:exhibit) }

--- a/spec/controllers/spotlight/dashboards_controller_spec.rb
+++ b/spec/controllers/spotlight/dashboards_controller_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe Spotlight::DashboardsController, type: :controller do
   routes { Spotlight::Engine.routes }

--- a/spec/controllers/spotlight/exhibits_controller_spec.rb
+++ b/spec/controllers/spotlight/exhibits_controller_spec.rb
@@ -1,5 +1,5 @@
-require 'spec_helper'
 require 'rack/test'
+
 describe Spotlight::ExhibitsController, type: :controller do
   routes { Spotlight::Engine.routes }
   let(:exhibit) { FactoryGirl.create(:exhibit) }

--- a/spec/controllers/spotlight/feature_pages_controller_spec.rb
+++ b/spec/controllers/spotlight/feature_pages_controller_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 describe Spotlight::FeaturePagesController, type: :controller do
   routes { Spotlight::Engine.routes }
 

--- a/spec/controllers/spotlight/filters_controller_spec.rb
+++ b/spec/controllers/spotlight/filters_controller_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::FiltersController do
   routes { Spotlight::Engine.routes }
 

--- a/spec/controllers/spotlight/home_pages_controller_spec.rb
+++ b/spec/controllers/spotlight/home_pages_controller_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::HomePagesController, type: :controller do
   routes { Spotlight::Engine.routes }
   let(:valid_attributes) { { 'title' => 'MyString' } }

--- a/spec/controllers/spotlight/metadata_configurations_controller_spec.rb
+++ b/spec/controllers/spotlight/metadata_configurations_controller_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 describe Spotlight::MetadataConfigurationsController, type: :controller do
   routes { Spotlight::Engine.routes }
   let(:exhibit) { FactoryGirl.create(:exhibit) }

--- a/spec/controllers/spotlight/resources_controller_spec.rb
+++ b/spec/controllers/spotlight/resources_controller_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::ResourcesController, type: :controller do
   routes { Spotlight::Engine.routes }
   let(:exhibit) { FactoryGirl.create(:exhibit) }

--- a/spec/controllers/spotlight/roles_controller_spec.rb
+++ b/spec/controllers/spotlight/roles_controller_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::RolesController, type: :controller do
   routes { Spotlight::Engine.routes }
   let(:exhibit) { FactoryGirl.create(:exhibit) }

--- a/spec/controllers/spotlight/search_configurations_controller_spec.rb
+++ b/spec/controllers/spotlight/search_configurations_controller_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 describe Spotlight::SearchConfigurationsController, type: :controller do
   routes { Spotlight::Engine.routes }
   let(:exhibit) { FactoryGirl.create(:exhibit) }

--- a/spec/controllers/spotlight/searches_controller_spec.rb
+++ b/spec/controllers/spotlight/searches_controller_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::SearchesController, type: :controller do
   routes { Spotlight::Engine.routes }
   let(:exhibit) { FactoryGirl.create(:exhibit) }

--- a/spec/controllers/spotlight/sites_controller_spec.rb
+++ b/spec/controllers/spotlight/sites_controller_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::SitesController, type: :controller do
   routes { Spotlight::Engine.routes }
 

--- a/spec/controllers/spotlight/solr_controller_spec.rb
+++ b/spec/controllers/spotlight/solr_controller_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::SolrController, type: :controller do
   routes { Spotlight::Engine.routes }
   let(:exhibit) { FactoryGirl.create(:exhibit) }

--- a/spec/controllers/spotlight/tags_controller_spec.rb
+++ b/spec/controllers/spotlight/tags_controller_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::TagsController, type: :controller do
   routes { Spotlight::Engine.routes }
   let(:exhibit) { FactoryGirl.create(:exhibit) }

--- a/spec/controllers/spotlight/versions_controller_spec.rb
+++ b/spec/controllers/spotlight/versions_controller_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::VersionsController, type: :controller do
   routes { Spotlight::Engine.routes }
 

--- a/spec/controllers/spotlight/view_configurations_controller_spec.rb
+++ b/spec/controllers/spotlight/view_configurations_controller_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 describe Spotlight::ViewConfigurationsController, type: :controller do
   routes { Spotlight::Engine.routes }
   let(:exhibit) { FactoryGirl.create(:exhibit) }

--- a/spec/features/about_page_spec.rb
+++ b/spec/features/about_page_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'About page', type: :feature do
   let(:exhibit) { FactoryGirl.create(:exhibit) }
   let(:exhibit_curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }

--- a/spec/features/add_contacts_spec.rb
+++ b/spec/features/add_contacts_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'Add a contact to an exhibit', type: :feature do
   let(:curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }
   let(:exhibit) { FactoryGirl.create(:exhibit) }

--- a/spec/features/add_custom_field_metadata_spec.rb
+++ b/spec/features/add_custom_field_metadata_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'Adding custom metadata field data', type: :feature do
   let(:exhibit) { FactoryGirl.create(:exhibit) }
   let(:admin) { FactoryGirl.create(:exhibit_admin, exhibit: exhibit) }

--- a/spec/features/add_items_spec.rb
+++ b/spec/features/add_items_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'Uploading a non-repository item', type: :feature do
   let!(:exhibit) { FactoryGirl.create(:exhibit) }
   let!(:custom_field) { FactoryGirl.create(:custom_field, exhibit: exhibit) }

--- a/spec/features/browse_category_admin_spec.rb
+++ b/spec/features/browse_category_admin_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'Browse Category Administration', type: :feature do
   let(:exhibit) { FactoryGirl.create(:exhibit) }
   let(:curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }

--- a/spec/features/browse_category_spec.rb
+++ b/spec/features/browse_category_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 feature 'Browse pages' do
   let(:exhibit) { FactoryGirl.create(:exhibit) }
 

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'Catalog', type: :feature do
   describe 'admin' do
     let(:exhibit) { FactoryGirl.create(:exhibit) }

--- a/spec/features/confirm_email_spec.rb
+++ b/spec/features/confirm_email_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'Confirming an email', type: :feature do
   let(:exhibit) { FactoryGirl.create(:exhibit) }
   let(:contact_email) { Spotlight::ContactEmail.create!(email: 'justin@example.com', exhibit: exhibit) }

--- a/spec/features/create_exhibit_spec.rb
+++ b/spec/features/create_exhibit_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'Create a new exhibit', type: :feature do
   let(:user) { FactoryGirl.create(:site_admin) }
   before do

--- a/spec/features/create_page_spec.rb
+++ b/spec/features/create_page_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'Creating a page', type: :feature do
   let(:exhibit) { FactoryGirl.create(:exhibit) }
   let(:exhibit_curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }

--- a/spec/features/curator_items.rb
+++ b/spec/features/curator_items.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'A curator can see the items page', type: :feature do
   let(:exhibit_curator) { FactoryGirl.create(:exhibit_curator) }
   let(:exhibit) { FactoryGirl.create(:exhibit) }
@@ -7,7 +5,6 @@ describe 'A curator can see the items page', type: :feature do
   it 'works' do
     login_as exhibit_curator
     visit spotlight.exhibit_dashboard_path(exhibit)
-
     expect(page).to have_content 'Items'
   end
 end

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'Dashboard', type: :feature do
   let(:exhibit) { FactoryGirl.create(:exhibit) }
   let(:admin) { FactoryGirl.create(:exhibit_admin, exhibit: exhibit) }

--- a/spec/features/edit_contact_spec.rb
+++ b/spec/features/edit_contact_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'Add a contact to an exhibit', type: :feature do
   let(:curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }
   let(:exhibit) { FactoryGirl.create(:exhibit) }
@@ -14,7 +12,6 @@ describe 'Add a contact to an exhibit', type: :feature do
     end
 
     click_button 'Save'
-
     expect(page).to have_content 'The contact was successfully updated.'
   end
 end

--- a/spec/features/edit_search_fields_spec.rb
+++ b/spec/features/edit_search_fields_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'Search Administration', type: :feature do
   let(:exhibit) { FactoryGirl.create(:exhibit) }
   let(:exhibit_admin) { FactoryGirl.create(:exhibit_admin, exhibit: exhibit) }

--- a/spec/features/exhibit_masthead_spec.rb
+++ b/spec/features/exhibit_masthead_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'Add and update the site masthead', type: :feature do
   let(:exhibit) { FactoryGirl.create(:exhibit) }
   let(:user) { FactoryGirl.create(:exhibit_admin, exhibit: exhibit) }

--- a/spec/features/exhibits/add_tags_spec.rb
+++ b/spec/features/exhibits/add_tags_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe 'Add tags to an item in an exhibit', type: :feature do
   let(:exhibit) { FactoryGirl.create(:exhibit) }

--- a/spec/features/exhibits/administration_spec.rb
+++ b/spec/features/exhibits/administration_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe 'Exhibit Administration', type: :feature do
   let(:exhibit) { FactoryGirl.create(:exhibit) }

--- a/spec/features/exhibits/custom_metadata_fields_spec.rb
+++ b/spec/features/exhibits/custom_metadata_fields_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe 'Adding custom metadata fields', type: :feature do
   let(:exhibit) { FactoryGirl.create(:exhibit) }

--- a/spec/features/exhibits/edit_metadata_fields_spec.rb
+++ b/spec/features/exhibits/edit_metadata_fields_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe 'Editing metadata fields', type: :feature do
   let(:exhibit) { FactoryGirl.create(:exhibit) }

--- a/spec/features/exhibits_index_spec.rb
+++ b/spec/features/exhibits_index_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'Exhibits index page', type: :feature do
   context 'with multiple exhibits' do
     let!(:exhibit) { FactoryGirl.create(:exhibit, title: 'Some Exhibit Title') }

--- a/spec/features/feature_page_spec.rb
+++ b/spec/features/feature_page_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'Feature page', type: :feature do
   let(:exhibit) { FactoryGirl.create(:exhibit) }
   let(:exhibit_curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 describe 'Home page', type: :feature do
   let(:exhibit) { FactoryGirl.create(:exhibit) }
   let(:exhibit_curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }

--- a/spec/features/import_exhibit_spec.rb
+++ b/spec/features/import_exhibit_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'tempfile'
 
 describe 'Allow exhibit admins to import and export content from an exhibit', type: :feature, js: true do

--- a/spec/features/item_admin_spec.rb
+++ b/spec/features/item_admin_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'Item Administration', type: :feature do
   let(:exhibit) { FactoryGirl.create(:exhibit) }
   let(:curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }

--- a/spec/features/javascript/about_page_admin_spec.rb
+++ b/spec/features/javascript/about_page_admin_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 feature 'About Pages Adminstration', js: true do
   let(:exhibit) { FactoryGirl.create(:exhibit) }
   let(:exhibit_curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }

--- a/spec/features/javascript/block_controls_spec.rb
+++ b/spec/features/javascript/block_controls_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 feature 'Block controls' do
   let(:exhibit) { FactoryGirl.create(:exhibit) }
   let(:exhibit_curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }

--- a/spec/features/javascript/edit_in_place_spec.rb
+++ b/spec/features/javascript/edit_in_place_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'Edit in place', type: :feature, js: true do
   let(:exhibit) { FactoryGirl.create(:exhibit) }
   let(:admin) { FactoryGirl.create(:exhibit_admin, exhibit: exhibit) }

--- a/spec/features/javascript/feature_page_admin_spec.rb
+++ b/spec/features/javascript/feature_page_admin_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 feature 'Feature Pages Adminstration', js: true do
   let(:exhibit) { FactoryGirl.create(:exhibit) }
   let(:exhibit_curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }

--- a/spec/features/javascript/home_page_edit_spec.rb
+++ b/spec/features/javascript/home_page_edit_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 feature 'Editing the Home Page', js: true do
   let(:exhibit) { FactoryGirl.create(:exhibit) }
   let(:admin) { FactoryGirl.create(:exhibit_admin, exhibit: exhibit) }

--- a/spec/features/javascript/metadata_admin_spec.rb
+++ b/spec/features/javascript/metadata_admin_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 feature 'Metadata Administration', js: true do
   let(:exhibit) { FactoryGirl.create(:exhibit) }
   let(:admin) { FactoryGirl.create(:exhibit_admin, exhibit: exhibit) }

--- a/spec/features/javascript/multi_image_select_spec.rb
+++ b/spec/features/javascript/multi_image_select_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'Multi image selector', type: :feature, js: true do
   let(:exhibit) { FactoryGirl.create(:exhibit) }
   let(:exhibit_curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }

--- a/spec/features/javascript/preview_block_spec.rb
+++ b/spec/features/javascript/preview_block_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 feature 'Block preview' do
   let(:exhibit) { FactoryGirl.create(:exhibit) }
   let(:exhibit_curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }

--- a/spec/features/javascript/reindex_monitor_spec.rb
+++ b/spec/features/javascript/reindex_monitor_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 feature 'Reindex Monitor', js: true do
   let(:resources) do
     [FactoryGirl.create(:resource, updated_at: Time.zone.now, index_status: 1)]

--- a/spec/features/javascript/roles_admin_spec.rb
+++ b/spec/features/javascript/roles_admin_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'Roles Admin', type: :feature, js: true do
   let(:exhibit) { FactoryGirl.create(:exhibit) }
   let(:exhibit_admin) { FactoryGirl.create(:exhibit_admin, exhibit: exhibit) }

--- a/spec/features/javascript/rule_block_spec.rb
+++ b/spec/features/javascript/rule_block_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'Horizontal rule block', type: :feature, js: true do
   let(:exhibit) { FactoryGirl.create(:exhibit) }
   let(:exhibit_curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }

--- a/spec/features/javascript/search_config_admin_spec.rb
+++ b/spec/features/javascript/search_config_admin_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 feature 'Search Configuration Administration', js: true do
   let(:exhibit) { FactoryGirl.create(:exhibit) }
   let(:user) { FactoryGirl.create(:exhibit_admin, exhibit: exhibit) }

--- a/spec/features/javascript/search_context_spec.rb
+++ b/spec/features/javascript/search_context_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 feature 'Search contexts' do
   let(:exhibit) { FactoryGirl.create(:exhibit) }
   let(:exhibit_curator) { FactoryGirl.create(:exhibit_curator, exhibit: exhibit) }

--- a/spec/features/main_navigation_spec.rb
+++ b/spec/features/main_navigation_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'Main navigation labels are settable', type: :feature do
   let!(:exhibit) { FactoryGirl.create(:exhibit) }
   let!(:about) { FactoryGirl.create(:about_page, exhibit: exhibit, published: true) }

--- a/spec/features/metadata_admin_spec.rb
+++ b/spec/features/metadata_admin_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'Metadata Administration', type: :feature do
   let(:exhibit) { FactoryGirl.create(:exhibit) }
   let(:user) { FactoryGirl.create(:exhibit_admin, exhibit: exhibit) }

--- a/spec/features/report_a_problem_spec.rb
+++ b/spec/features/report_a_problem_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'Report a Problem', type: :feature do
   let!(:exhibit) { FactoryGirl.create(:exhibit) }
   it 'does not have a header link' do

--- a/spec/features/site_admin_management_spec.rb
+++ b/spec/features/site_admin_management_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'Site admin management', js: true do
   let(:user) { FactoryGirl.create(:site_admin) }
   let(:existing_user) { FactoryGirl.create(:exhibit_visitor) }

--- a/spec/features/site_masthead_spec.rb
+++ b/spec/features/site_masthead_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'Add and update the site masthead', type: :feature do
   let(:user) { FactoryGirl.create(:site_admin) }
 
@@ -60,9 +58,7 @@ describe 'Add and update the site masthead', type: :feature do
     end
 
     click_button 'Save changes'
-
     expect(page).to have_content('The site was successfully updated.')
-
     expect(page).to have_css('.image-masthead .background-container')
   end
   it 'does not display an uploaded masthead if configured to not display' do
@@ -77,9 +73,7 @@ describe 'Add and update the site masthead', type: :feature do
     end
 
     click_button 'Save changes'
-
     expect(page).to have_content('The site was successfully updated.')
-
     expect(page).to_not have_css('.image-masthead .background-container')
   end
 end

--- a/spec/features/slideshow_spec.rb
+++ b/spec/features/slideshow_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'Slideshow', type: :feature, js: true do
   let(:exhibit) { FactoryGirl.create(:exhibit) }
   let(:user) { FactoryGirl.create(:exhibit_admin, exhibit: exhibit) }

--- a/spec/features/tags_admin_spec.rb
+++ b/spec/features/tags_admin_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'Tags Administration', type: :feature do
   let(:exhibit) { FactoryGirl.create(:exhibit) }
   let!(:tagging) { FactoryGirl.create(:tagging, tagger: exhibit) }

--- a/spec/features/user_admin_spec.rb
+++ b/spec/features/user_admin_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'User Administration', type: :feature do
   let!(:exhibit) { FactoryGirl.create(:exhibit) }
   let!(:user) { FactoryGirl.create(:exhibit_admin, exhibit: exhibit) }

--- a/spec/helpers/spotlight/application_helper_spec.rb
+++ b/spec/helpers/spotlight/application_helper_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe Spotlight::ApplicationHelper, type: :helper do
   describe '#application_name' do

--- a/spec/helpers/spotlight/browse_helper_spec.rb
+++ b/spec/helpers/spotlight/browse_helper_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe Spotlight::BrowseHelper, type: :helper do
   it 'defaults to the gallery' do

--- a/spec/helpers/spotlight/crud_link_helpers_spec.rb
+++ b/spec/helpers/spotlight/crud_link_helpers_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 module Spotlight
   describe CrudLinkHelpers, type: :helper do

--- a/spec/helpers/spotlight/jcrop_helper_spec.rb
+++ b/spec/helpers/spotlight/jcrop_helper_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe Spotlight::JcropHelper do
   describe '.default_thumbnail_jcrop_options' do

--- a/spec/helpers/spotlight/main_app_helpers_spec.rb
+++ b/spec/helpers/spotlight/main_app_helpers_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe Spotlight::MainAppHelpers, type: :helper do
   describe '#show_contact_form?' do

--- a/spec/helpers/spotlight/navbar_helper_spec.rb
+++ b/spec/helpers/spotlight/navbar_helper_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 module Spotlight
   describe NavbarHelper, type: :helper do

--- a/spec/helpers/spotlight/pages_helper_spec.rb
+++ b/spec/helpers/spotlight/pages_helper_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 module Spotlight
   describe PagesHelper, type: :helper do

--- a/spec/helpers/spotlight/roles_helper_spec.rb
+++ b/spec/helpers/spotlight/roles_helper_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe Spotlight::RolesHelper, type: :helper do
   it 'is a list of options' do

--- a/spec/helpers/spotlight/search_configurations_helper_spec.rb
+++ b/spec/helpers/spotlight/search_configurations_helper_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe Spotlight::SearchConfigurationsHelper, type: :helper do
   describe '#translate_sort_fields' do

--- a/spec/helpers/spotlight/title_helper_spec.rb
+++ b/spec/helpers/spotlight/title_helper_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe Spotlight::TitleHelper, type: :helper do
   before do

--- a/spec/jobs/spotlight/default_thumbnail_job_spec.rb
+++ b/spec/jobs/spotlight/default_thumbnail_job_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe Spotlight::DefaultThumbnailJob do
   let(:thumbnailable) { double('Thumbnailable') }

--- a/spec/jobs/spotlight/reindex_job_spec.rb
+++ b/spec/jobs/spotlight/reindex_job_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe Spotlight::ReindexJob do
   let(:exhibit) { FactoryGirl.create(:exhibit) }

--- a/spec/jobs/spotlight/rename_sidecar_field_job_spec.rb
+++ b/spec/jobs/spotlight/rename_sidecar_field_job_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe Spotlight::RenameSidecarFieldJob do
   let(:exhibit) { FactoryGirl.create(:exhibit) }

--- a/spec/lib/spotlight/controller_spec.rb
+++ b/spec/lib/spotlight/controller_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe Spotlight::Controller do
   class MockController < ActionController::Base

--- a/spec/mailers/spotlight/indexing_complete_mailer_spec.rb
+++ b/spec/mailers/spotlight/indexing_complete_mailer_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe Spotlight::IndexingCompleteMailer do
   let(:user) { double(email: 'test@example.com') }

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe SolrDocument, type: :model do
   subject { described_class.new(id: 'abcd123') }
   its(:to_key) { should == ['abcd123'] }

--- a/spec/models/spotlight/ability_spec.rb
+++ b/spec/models/spotlight/ability_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'cancan/matchers'
 
 describe Spotlight::Ability, type: :model do

--- a/spec/models/spotlight/about_page_spec.rb
+++ b/spec/models/spotlight/about_page_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::AboutPage, type: :model do
   let(:page) { described_class.create! exhibit: FactoryGirl.create(:exhibit) }
   it { is_expected.not_to be_feature_page }

--- a/spec/models/spotlight/access_controls_enforcement_search_builder_spec.rb
+++ b/spec/models/spotlight/access_controls_enforcement_search_builder_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::AccessControlsEnforcementSearchBuilder do
   class MockSearchBuilder < Blacklight::SearchBuilder
     attr_reader :blacklight_params, :scope

--- a/spec/models/spotlight/blacklight_configuration_spec.rb
+++ b/spec/models/spotlight/blacklight_configuration_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::BlacklightConfiguration, type: :model do
   subject { described_class.new }
   let(:blacklight_config) { Blacklight::Configuration.new }

--- a/spec/models/spotlight/contact_email_spec.rb
+++ b/spec/models/spotlight/contact_email_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::ContactEmail, type: :model do
   let(:exhibit) { FactoryGirl.create(:exhibit) }
   subject { described_class.new(exhibit: exhibit) }

--- a/spec/models/spotlight/contact_form_spec.rb
+++ b/spec/models/spotlight/contact_form_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::ContactForm do
   subject { described_class.new(name: 'Root', email: 'user@example.com').tap { |c| c.current_exhibit = exhibit } }
   let(:exhibit) { FactoryGirl.create(:exhibit) }

--- a/spec/models/spotlight/contact_spec.rb
+++ b/spec/models/spotlight/contact_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::Contact, type: :model do
   context '#show_in_sidebar' do
     it 'is an attribute' do

--- a/spec/models/spotlight/custom_field_spec.rb
+++ b/spec/models/spotlight/custom_field_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 describe Spotlight::CustomField, type: :model do
   describe '#label' do

--- a/spec/models/spotlight/default_thumbnailable_concern_spec.rb
+++ b/spec/models/spotlight/default_thumbnailable_concern_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::DefaultThumbnailable do
   let(:test_class) { Class.new }
   subject { test_class.new }

--- a/spec/models/spotlight/exhibit_spec.rb
+++ b/spec/models/spotlight/exhibit_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::Exhibit, type: :model do
   subject { FactoryGirl.build(:exhibit, title: 'Sample') }
 

--- a/spec/models/spotlight/feature_page_spec.rb
+++ b/spec/models/spotlight/feature_page_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::FeaturePage, type: :model do
   let(:exhibit) { FactoryGirl.create(:exhibit) }
   describe 'default_scope' do

--- a/spec/models/spotlight/featured_image_spec.rb
+++ b/spec/models/spotlight/featured_image_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::FeaturedImage do
   context 'with an uploaded resource' do
     subject { described_class.new }

--- a/spec/models/spotlight/field_metadata_spec.rb
+++ b/spec/models/spotlight/field_metadata_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::FieldMetadata do
   let(:exhibit) { FactoryGirl.create(:exhibit) }
   let(:repository) { double }

--- a/spec/models/spotlight/filter_spec.rb
+++ b/spec/models/spotlight/filter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::Filter do
   context 'with a simple string field' do
     subject { described_class.new(field: 'x', value: 'y') }

--- a/spec/models/spotlight/home_page_spec.rb
+++ b/spec/models/spotlight/home_page_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::HomePage, type: :model do
   let(:home_page) { FactoryGirl.create(:home_page) }
   it { is_expected.not_to be_feature_page }

--- a/spec/models/spotlight/image_derivatives_spec.rb
+++ b/spec/models/spotlight/image_derivatives_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 class TestSpotlightImageDerivatives
   include Spotlight::ImageDerivatives
 end

--- a/spec/models/spotlight/main_navigation_spec.rb
+++ b/spec/models/spotlight/main_navigation_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::MainNavigation, type: :model do
   before do
     subject.exhibit = FactoryGirl.create(:exhibit)

--- a/spec/models/spotlight/masthead_spec.rb
+++ b/spec/models/spotlight/masthead_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::Masthead, type: :model do
   describe '#masthead_exists?' do
     let(:masthead) { stub_model(described_class) }

--- a/spec/models/spotlight/page_spec.rb
+++ b/spec/models/spotlight/page_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::Page, type: :model do
   let(:exhibit) { FactoryGirl.create(:exhibit) }
   let!(:parent_page) { Spotlight::FeaturePage.create! exhibit: exhibit, published: true }

--- a/spec/models/spotlight/reindex_progress_spec.rb
+++ b/spec/models/spotlight/reindex_progress_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::ReindexProgress, type: :model do
   let(:start_time) { 20.minutes.ago }
   let(:finish_time) { 5.minutes.ago }

--- a/spec/models/spotlight/resource_spec.rb
+++ b/spec/models/spotlight/resource_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::Resource, type: :model do
   before do
     allow_any_instance_of(described_class).to receive(:update_index)

--- a/spec/models/spotlight/role_spec.rb
+++ b/spec/models/spotlight/role_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::Role, type: :model do
   describe 'validations' do
     subject { described_class.new(args) }

--- a/spec/models/spotlight/search_spec.rb
+++ b/spec/models/spotlight/search_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::Search, type: :model do
   let(:exhibit) { FactoryGirl.create(:exhibit) }
 

--- a/spec/models/spotlight/site_spec.rb
+++ b/spec/models/spotlight/site_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::Site do
   describe '.instance' do
     it 'is a singleton' do

--- a/spec/models/spotlight/sitemap_spec.rb
+++ b/spec/models/spotlight/sitemap_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'sitemap_generator'
 
 describe Spotlight::Sitemap do

--- a/spec/models/spotlight/solr_document_sidecar_spec.rb
+++ b/spec/models/spotlight/solr_document_sidecar_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::SolrDocumentSidecar, type: :model do
   let(:exhibit) { FactoryGirl.create(:exhibit) }
   before do

--- a/spec/models/spotlight/user_spec.rb
+++ b/spec/models/spotlight/user_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::User do
   subject { Class.new }
   before { subject.extend described_class }

--- a/spec/routing/spotlight/exhibit_catalog_spec.rb
+++ b/spec/routing/spotlight/exhibit_catalog_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 
 module Spotlight
   describe 'Catalog controller', type: :routing do

--- a/spec/routing/spotlight/pages_routing_spec.rb
+++ b/spec/routing/spotlight/pages_routing_spec.rb
@@ -1,44 +1,40 @@
-require 'spec_helper'
+describe 'FeaturePagesController and AboutPagesController', type: :routing do
+  describe 'routing' do
+    routes { Spotlight::Engine.routes }
 
-module Spotlight
-  describe 'FeaturePagesController and AboutPagesController', type: :routing do
-    describe 'routing' do
-      routes { Spotlight::Engine.routes }
+    it 'routes to #index' do
+      expect(get('/1/feature')).to route_to('spotlight/feature_pages#index', exhibit_id: '1')
+      expect(get('/1/about')).to route_to('spotlight/about_pages#index', exhibit_id: '1')
+    end
 
-      it 'routes to #index' do
-        expect(get('/1/feature')).to route_to('spotlight/feature_pages#index', exhibit_id: '1')
-        expect(get('/1/about')).to route_to('spotlight/about_pages#index', exhibit_id: '1')
-      end
+    it 'routes to #new' do
+      expect(get('/1/feature/new')).to route_to('spotlight/feature_pages#new', exhibit_id: '1')
+      expect(get('/1/about/new')).to route_to('spotlight/about_pages#new', exhibit_id: '1')
+    end
 
-      it 'routes to #new' do
-        expect(get('/1/feature/new')).to route_to('spotlight/feature_pages#new', exhibit_id: '1')
-        expect(get('/1/about/new')).to route_to('spotlight/about_pages#new', exhibit_id: '1')
-      end
+    it 'routes to #show' do
+      expect(get('/1/feature/2')).to route_to('spotlight/feature_pages#show', id: '2', exhibit_id: '1')
+      expect(get('/1/about/2')).to route_to('spotlight/about_pages#show', id: '2', exhibit_id: '1')
+    end
 
-      it 'routes to #show' do
-        expect(get('/1/feature/2')).to route_to('spotlight/feature_pages#show', id: '2', exhibit_id: '1')
-        expect(get('/1/about/2')).to route_to('spotlight/about_pages#show', id: '2', exhibit_id: '1')
-      end
+    it 'routes to #edit' do
+      expect(get('/1/feature/2/edit')).to route_to('spotlight/feature_pages#edit', id: '2', exhibit_id: '1')
+      expect(get('/1/about/2/edit')).to route_to('spotlight/about_pages#edit', id: '2', exhibit_id: '1')
+    end
 
-      it 'routes to #edit' do
-        expect(get('/1/feature/2/edit')).to route_to('spotlight/feature_pages#edit', id: '2', exhibit_id: '1')
-        expect(get('/1/about/2/edit')).to route_to('spotlight/about_pages#edit', id: '2', exhibit_id: '1')
-      end
+    it 'routes to #create' do
+      expect(post('/1/feature')).to route_to('spotlight/feature_pages#create', exhibit_id: '1')
+      expect(post('/1/about')).to route_to('spotlight/about_pages#create', exhibit_id: '1')
+    end
 
-      it 'routes to #create' do
-        expect(post('/1/feature')).to route_to('spotlight/feature_pages#create', exhibit_id: '1')
-        expect(post('/1/about')).to route_to('spotlight/about_pages#create', exhibit_id: '1')
-      end
+    it 'routes to #update' do
+      expect(put('/1/feature/2')).to route_to('spotlight/feature_pages#update', id: '2', exhibit_id: '1')
+      expect(put('/1/about/2')).to route_to('spotlight/about_pages#update', id: '2', exhibit_id: '1')
+    end
 
-      it 'routes to #update' do
-        expect(put('/1/feature/2')).to route_to('spotlight/feature_pages#update', id: '2', exhibit_id: '1')
-        expect(put('/1/about/2')).to route_to('spotlight/about_pages#update', id: '2', exhibit_id: '1')
-      end
-
-      it 'routes to #destroy' do
-        expect(delete('/1/feature/2')).to route_to('spotlight/feature_pages#destroy', id: '2', exhibit_id: '1')
-        expect(delete('/1/about/2')).to route_to('spotlight/about_pages#destroy', id: '2', exhibit_id: '1')
-      end
+    it 'routes to #destroy' do
+      expect(delete('/1/feature/2')).to route_to('spotlight/feature_pages#destroy', id: '2', exhibit_id: '1')
+      expect(delete('/1/about/2')).to route_to('spotlight/about_pages#destroy', id: '2', exhibit_id: '1')
     end
   end
 end

--- a/spec/serializers/spotlight/exhibit_export_serializer_spec.rb
+++ b/spec/serializers/spotlight/exhibit_export_serializer_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Spotlight::ExhibitExportSerializer do
   let!(:source_exhibit) { FactoryGirl.create(:exhibit) }
 

--- a/spec/uploaders/spotlight/item_uploader_spec.rb
+++ b/spec/uploaders/spotlight/item_uploader_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'carrierwave/test/matchers'
 
 describe Spotlight::ItemUploader do

--- a/spec/views/_user_util_links.html.erb_spec.rb
+++ b/spec/views/_user_util_links.html.erb_spec.rb
@@ -1,89 +1,85 @@
-require 'spec_helper'
+describe '_user_util_links', type: :view do
+  let(:current_exhibit) { FactoryGirl.create(:exhibit) }
+  before do
+    allow(view).to receive(:blacklight_config).and_return(Blacklight::Configuration.new)
+    allow(view).to receive(:current_user).and_return(current_user)
+    allow(view).to receive(:current_exhibit).and_return(current_exhibit)
+    allow(view).to receive_messages(show_contact_form?: true)
+  end
 
-module Spotlight
-  describe '_user_util_links', type: :view do
-    let(:current_exhibit) { FactoryGirl.create(:exhibit) }
+  describe 'when user is not logged in' do
+    let(:current_user) { nil }
+    it 'renders the links' do
+      render
+      expect(rendered).to have_link 'Sign in'
+      expect(rendered).to have_link 'Feedback'
+    end
+  end
+
+  describe 'when show_contact_form is false' do
+    let(:current_user) { nil }
     before do
-      allow(view).to receive(:blacklight_config).and_return(Blacklight::Configuration.new)
-      allow(view).to receive(:current_user).and_return(current_user)
-      allow(view).to receive(:current_exhibit).and_return(current_exhibit)
-      allow(view).to receive_messages(show_contact_form?: true)
+      allow(view).to receive_messages(show_contact_form?: false)
     end
-
-    describe 'when user is not logged in' do
-      let(:current_user) { nil }
-      it 'renders the links' do
-        render
-        expect(rendered).to have_link 'Sign in'
-        expect(rendered).to have_link 'Feedback'
-      end
+    it 'does not render the feedback link' do
+      render
+      expect(rendered).to_not have_link 'Feedback'
     end
+  end
 
-    describe 'when show_contact_form is false' do
-      let(:current_user) { nil }
-      before do
-        allow(view).to receive_messages(show_contact_form?: false)
-      end
-
-      it 'does not render the feedback link' do
-        render
-        expect(rendered).to_not have_link 'Feedback'
-      end
+  describe 'when user is logged in' do
+    let(:current_user) { Spotlight::Engine.user_class.new }
+    it 'renders the links' do
+      render
+      expect(rendered).to have_link 'Feedback'
+      expect(rendered).to_not have_link 'Dashboard'
+      expect(rendered).to have_link 'Sign out'
     end
+  end
 
-    describe 'when user is logged in' do
-      let(:current_user) { Spotlight::Engine.user_class.new }
-      it 'renders the links' do
-        render
-        expect(rendered).to have_link 'Feedback'
-        expect(rendered).to_not have_link 'Dashboard'
-        expect(rendered).to have_link 'Sign out'
-      end
+  describe 'when user is a curator' do
+    let(:current_user) { Spotlight::Engine.user_class.new }
+    before do
+      allow(view).to receive(:can?).with(:update, current_exhibit).and_return(false)
+      allow(view).to receive(:can?).with(:create, Spotlight::Exhibit).and_return(false)
+      allow(view).to receive(:can?).with(:curate, current_exhibit).and_return(true)
     end
+    it 'renders the links' do
+      render
+      expect(rendered).to have_link 'Feedback'
+      expect(rendered).to have_link 'Dashboard'
+      expect(rendered).to have_link 'Sign out'
+    end
+  end
 
-    describe 'when user is a curator' do
-      let(:current_user) { Spotlight::Engine.user_class.new }
-      before do
-        allow(view).to receive(:can?).with(:update, current_exhibit).and_return(false)
-        allow(view).to receive(:can?).with(:create, Spotlight::Exhibit).and_return(false)
-        allow(view).to receive(:can?).with(:curate, current_exhibit).and_return(true)
-      end
-      it 'renders the links' do
-        render
-        expect(rendered).to have_link 'Feedback'
-        expect(rendered).to have_link 'Dashboard'
-        expect(rendered).to have_link 'Sign out'
-      end
+  describe 'when user is an admin' do
+    let(:current_user) { Spotlight::Engine.user_class.new }
+    before do
+      allow(view).to receive(:can?).with(:update, current_exhibit).and_return(true)
+      allow(view).to receive(:can?).with(:create, Spotlight::Exhibit).and_return(false)
+      allow(view).to receive(:can?).with(:curate, current_exhibit).and_return(true)
     end
-    describe 'when user is an admin' do
-      let(:current_user) { Spotlight::Engine.user_class.new }
-      before do
-        allow(view).to receive(:can?).with(:update, current_exhibit).and_return(true)
-        allow(view).to receive(:can?).with(:create, Spotlight::Exhibit).and_return(false)
-        allow(view).to receive(:can?).with(:curate, current_exhibit).and_return(true)
-      end
-      it 'renders the links' do
-        render
-        expect(rendered).to have_link 'Feedback'
-        expect(rendered).to have_link 'Dashboard'
-        expect(rendered).to have_link 'Sign out'
-      end
+    it 'renders the links' do
+      render
+      expect(rendered).to have_link 'Feedback'
+      expect(rendered).to have_link 'Dashboard'
+      expect(rendered).to have_link 'Sign out'
     end
+  end
 
-    describe 'when user is a site-wide admin' do
-      let(:current_user) { Spotlight::Engine.user_class.new }
-      before do
-        allow(view).to receive(:can?).with(:update, current_exhibit).and_return(true)
-        allow(view).to receive(:can?).with(:create, Spotlight::Exhibit).and_return(true)
-        allow(view).to receive(:can?).with(:curate, current_exhibit).and_return(true)
-      end
-      it 'renders the links' do
-        render
-        expect(rendered).to have_link 'Feedback'
-        expect(rendered).to have_link 'Dashboard'
-        expect(rendered).to have_link 'Create Exhibit'
-        expect(rendered).to have_link 'Sign out'
-      end
+  describe 'when user is a site-wide admin' do
+    let(:current_user) { Spotlight::Engine.user_class.new }
+    before do
+      allow(view).to receive(:can?).with(:update, current_exhibit).and_return(true)
+      allow(view).to receive(:can?).with(:create, Spotlight::Exhibit).and_return(true)
+      allow(view).to receive(:can?).with(:curate, current_exhibit).and_return(true)
+    end
+    it 'renders the links' do
+      render
+      expect(rendered).to have_link 'Feedback'
+      expect(rendered).to have_link 'Dashboard'
+      expect(rendered).to have_link 'Create Exhibit'
+      expect(rendered).to have_link 'Sign out'
     end
   end
 end

--- a/spec/views/shared/_analytics.html.erb_spec.rb
+++ b/spec/views/shared/_analytics.html.erb_spec.rb
@@ -1,17 +1,12 @@
-require 'spec_helper'
-
-module Spotlight
-  describe 'shared/_analytics', type: :view do
-    it 'is empty without Google Analytics configured' do
-      render
-      expect(rendered).to be_empty
-    end
-
-    it 'renders the GA script tag if the web property id is configured' do
-      allow(Spotlight::Engine.config).to receive(:ga_web_property_id).and_return('XYZ-234')
-      render
-      expect(rendered).to have_selector 'script', visible: false
-      expect(rendered).to have_content 'XYZ-234'
-    end
+describe 'shared/_analytics', type: :view do
+  it 'is empty without Google Analytics configured' do
+    render
+    expect(rendered).to be_empty
+  end
+  it 'renders the GA script tag if the web property id is configured' do
+    allow(Spotlight::Engine.config).to receive(:ga_web_property_id).and_return('XYZ-234')
+    render
+    expect(rendered).to have_selector 'script', visible: false
+    expect(rendered).to have_content 'XYZ-234'
   end
 end

--- a/spec/views/shared/_exhibit_navbar.html.erb_spec.rb
+++ b/spec/views/shared/_exhibit_navbar.html.erb_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'shared/_exhibit_navbar', type: :view do
   let(:current_exhibit) { FactoryGirl.create(:exhibit) }
   let(:feature_page) { FactoryGirl.create(:feature_page, exhibit: current_exhibit) }

--- a/spec/views/shared/_footer.html.erb_spec.rb
+++ b/spec/views/shared/_footer.html.erb_spec.rb
@@ -1,24 +1,20 @@
-require 'spec_helper'
+describe 'shared/_footer', type: :view do
+  let(:current_exhibit) { double(title: 'Some title', subtitle: 'Subtitle') }
 
-module Spotlight
-  describe 'shared/_footer', type: :view do
-    let(:current_exhibit) { double(title: 'Some title', subtitle: 'Subtitle') }
+  before do
+    allow(view).to receive_messages(current_exhibit: current_exhibit)
+  end
 
-    before do
-      allow(view).to receive_messages(current_exhibit: current_exhibit)
-    end
+  it 'includes analytics reporting' do
+    stub_template 'shared/_analytics.html.erb' => 'analytics'
+    render
+    expect(rendered).to have_content 'analytics'
+  end
 
-    it 'includes analytics reporting' do
-      stub_template 'shared/_analytics.html.erb' => 'analytics'
-      render
-      expect(rendered).to have_content 'analytics'
-    end
-
-    it 'displays social media links' do
-      render
-      expect(rendered).to have_selector('footer .social-share-button a.ssb-icon[title="Twitter"]')
-      expect(rendered).to have_selector('footer .social-share-button a.ssb-icon[title="Facebook"]')
-      expect(rendered).to have_selector('footer .social-share-button a.ssb-icon[title="Google+"]')
-    end
+  it 'displays social media links' do
+    render
+    expect(rendered).to have_selector('footer .social-share-button a.ssb-icon[title="Twitter"]')
+    expect(rendered).to have_selector('footer .social-share-button a.ssb-icon[title="Facebook"]')
+    expect(rendered).to have_selector('footer .social-share-button a.ssb-icon[title="Google+"]')
   end
 end

--- a/spec/views/shared/_header_navbar.html.erb_spec.rb
+++ b/spec/views/shared/_header_navbar.html.erb_spec.rb
@@ -1,14 +1,9 @@
-require 'spec_helper'
-
-module Spotlight
-  describe 'shared/_header_navbar', type: :view do
-    before do
-      stub_template '_user_util_links.html.erb' => 'links'
-    end
-
-    it 'has nav links' do
-      render
-      expect(rendered).to have_selector '#user-util-collapse', text: 'links'
-    end
+describe 'shared/_header_navbar', type: :view do
+  before do
+    stub_template '_user_util_links.html.erb' => 'links'
+  end
+  it 'has nav links' do
+    render
+    expect(rendered).to have_selector '#user-util-collapse', text: 'links'
   end
 end

--- a/spec/views/shared/_masthead.html.erb_spec.rb
+++ b/spec/views/shared/_masthead.html.erb_spec.rb
@@ -1,12 +1,9 @@
-require 'spec_helper'
-
 describe 'shared/_masthead', type: :view do
   let(:exhibit) { FactoryGirl.create(:exhibit, subtitle: 'Some exhibit') }
   let(:masthead) { nil }
 
   before do
     stub_template 'shared/_exhibit_navbar.html.erb' => 'navbar'
-
     allow(view).to receive_messages(current_exhibit: exhibit,
                                     current_masthead: masthead,
                                     resource_masthead?: false)
@@ -14,7 +11,6 @@ describe 'shared/_masthead', type: :view do
 
   it 'has the site title and subtitle' do
     render
-
     expect(rendered).to have_selector '.h1', text: exhibit.title
     expect(rendered).to have_selector 'small', text: exhibit.subtitle
   end
@@ -23,17 +19,14 @@ describe 'shared/_masthead', type: :view do
     before do
       exhibit.update(subtitle: nil)
     end
-
     it 'does not include the subtitle' do
       render
-
       expect(rendered).not_to have_selector 'small'
     end
   end
 
   it 'includes a navbar' do
     render
-
     expect(rendered).to have_content 'navbar'
   end
 
@@ -47,16 +40,13 @@ describe 'shared/_masthead', type: :view do
 
     it 'adds a class to the masthead' do
       render
-
       expect(rendered).to have_selector '.masthead.image-masthead'
     end
 
     it 'has a background image' do
       render
-
       expect(rendered).to have_selector '.background-container'
       expect(rendered).to have_selector '.background-container-gradient'
-
       expect(rendered).to match(/background-image: url\('#{masthead.image.cropped.url}'\)/)
     end
   end
@@ -70,13 +60,10 @@ describe 'shared/_masthead', type: :view do
 
     it 'adds a class to the masthead' do
       render
-
       expect(rendered).to have_selector '.masthead.resource-masthead'
     end
-
     it 'puts the navbar before the title' do
       render
-
       expect(rendered.index('navbar')).to be < rendered.index(exhibit.title)
     end
   end


### PR DESCRIPTION
Don't ignore `.rspec` file, use it to good effect:
- color!  :
- require spec_helper in one place instead of 100

Also moved specs out of totally unnecessary anti-pattern of being composed in the Spotlight module.  Handful of other whitespace cleanups.  Number of tests passing is unchanged.