### PR TITLE
Remove unneccessary module namespacing from specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.sassc
 .sass-cache
 capybara-*.html
+.byebug_history
 .rvmrc
 .ruby-version
 /.bundle

--- a/spec/helpers/spotlight/application_helper_spec.rb
+++ b/spec/helpers/spotlight/application_helper_spec.rb
@@ -1,4 +1,3 @@
-
 describe Spotlight::ApplicationHelper, type: :helper do
   describe '#application_name' do
     let(:site) { Spotlight::Site.instance }
@@ -77,6 +76,7 @@ describe Spotlight::ApplicationHelper, type: :helper do
       end
     end
   end
+
   describe 'render_document_class' do
     let(:current_exhibit) { FactoryGirl.create(:exhibit) }
     let(:document) { SolrDocument.new(some_field: 'Some data') }
@@ -133,13 +133,8 @@ describe Spotlight::ApplicationHelper, type: :helper do
   end
 
   describe '#uploaded_field_label' do
-    let :field do
-      OpenStruct.new field_name: 'x'
-    end
-
-    let :blacklight_config do
-      Blacklight::Configuration.new
-    end
+    let(:field) { OpenStruct.new field_name: 'x' }
+    let(:blacklight_config) { Blacklight::Configuration.new }
 
     before do
       allow(helper).to receive_messages(blacklight_config: blacklight_config)
@@ -157,9 +152,7 @@ describe Spotlight::ApplicationHelper, type: :helper do
   end
 
   describe '#available_view_fields' do
-    let :blacklight_config do
-      Blacklight::Configuration.new
-    end
+    let(:blacklight_config) { Blacklight::Configuration.new }
 
     before do
       allow(helper).to receive_message_chain(:current_exhibit, :blacklight_configuration, default_blacklight_config: blacklight_config)

--- a/spec/helpers/spotlight/browse_helper_spec.rb
+++ b/spec/helpers/spotlight/browse_helper_spec.rb
@@ -1,4 +1,3 @@
-
 describe Spotlight::BrowseHelper, type: :helper do
   it 'defaults to the gallery' do
     allow(helper).to receive_messages(blacklight_config: double(view: { gallery: true }))

--- a/spec/helpers/spotlight/crud_link_helpers_spec.rb
+++ b/spec/helpers/spotlight/crud_link_helpers_spec.rb
@@ -1,132 +1,129 @@
+describe Spotlight::CrudLinkHelpers, type: :helper do
+  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:some_model) { Spotlight::FeaturePage.create! exhibit: exhibit }
+  describe '#cancel_link' do
+    it 'is a model-specific cancel link' do
+      expect(helper).to receive(:action_default_value).with(:my_model, :cancel).and_return 'Cancel'
+      expect(helper.cancel_link(:my_model, '#')).to have_link 'Cancel', href: '#'
+    end
+  end
 
-module Spotlight
-  describe CrudLinkHelpers, type: :helper do
-    let(:exhibit) { FactoryGirl.create(:exhibit) }
+  describe '#exhibit_view_link' do
+    before do
+      allow(helper).to receive_messages action_default_value: 'View'
+    end
+
+    it 'is a model-specific view link' do
+      expect(helper).to receive(:action_default_value).with(some_model, :view).and_return 'View'
+      expect(helper.exhibit_view_link(some_model)).to have_link 'View', href: spotlight.exhibit_feature_page_path(some_model.exhibit, some_model)
+    end
+
+    it 'accepts an explicit link' do
+      expect(helper.exhibit_view_link(some_model, '#')).to have_link 'View', href: '#'
+    end
+
+    it 'accepts link_to options' do
+      expect(helper.exhibit_view_link(some_model, '#', class: 'btn')).to have_selector 'a.btn'
+    end
+  end
+
+  describe '#exhibit_create_link' do
+    let(:some_model) { Spotlight::FeaturePage.new }
+    before do
+      allow(helper).to receive_messages(current_exhibit: exhibit)
+      allow(helper).to receive_messages action_default_value: 'Create'
+    end
+
+    it 'is a model-specific view link' do
+      expect(helper).to receive(:action_default_value).with(some_model).and_return 'Create'
+      expect(helper.exhibit_create_link(some_model)).to have_link 'Create', href: spotlight.new_exhibit_feature_page_path(exhibit)
+    end
+
+    it 'accepts an explicit link' do
+      expect(helper.exhibit_create_link(some_model, '#')).to have_link 'Create', href: '#'
+    end
+
+    it 'accepts link_to options' do
+      expect(helper.exhibit_create_link(some_model, '#', class: 'btn')).to have_selector 'a.btn'
+    end
+  end
+
+  describe '#exhibit_edit_link' do
     let(:some_model) { Spotlight::FeaturePage.create! exhibit: exhibit }
-    describe '#cancel_link' do
-      it 'is a model-specific cancel link' do
-        expect(helper).to receive(:action_default_value).with(:my_model, :cancel).and_return 'Cancel'
-        expect(helper.cancel_link(:my_model, '#')).to have_link 'Cancel', href: '#'
-      end
+    before do
+      allow(helper).to receive_messages(current_exhibit: exhibit)
+      allow(helper).to receive_messages action_default_value: 'Edit'
     end
 
-    describe '#exhibit_view_link' do
-      before do
-        allow(helper).to receive_messages action_default_value: 'View'
-      end
-
-      it 'is a model-specific view link' do
-        expect(helper).to receive(:action_default_value).with(some_model, :view).and_return 'View'
-        expect(helper.exhibit_view_link(some_model)).to have_link 'View', href: spotlight.exhibit_feature_page_path(some_model.exhibit, some_model)
-      end
-
-      it 'accepts an explicit link' do
-        expect(helper.exhibit_view_link(some_model, '#')).to have_link 'View', href: '#'
-      end
-
-      it 'accepts link_to options' do
-        expect(helper.exhibit_view_link(some_model, '#', class: 'btn')).to have_selector 'a.btn'
-      end
+    it 'is a model-specific edit link' do
+      expect(helper).to receive(:action_default_value).with(some_model).and_return 'Edit'
+      expect(helper.exhibit_edit_link(some_model)).to have_link 'Edit', href: spotlight.edit_exhibit_feature_page_path(exhibit, some_model)
     end
 
-    describe '#exhibit_create_link' do
-      let(:some_model) { Spotlight::FeaturePage.new }
-      before do
-        allow(helper).to receive_messages(current_exhibit: exhibit)
-        allow(helper).to receive_messages action_default_value: 'Create'
-      end
-
-      it 'is a model-specific view link' do
-        expect(helper).to receive(:action_default_value).with(some_model).and_return 'Create'
-        expect(helper.exhibit_create_link(some_model)).to have_link 'Create', href: spotlight.new_exhibit_feature_page_path(exhibit)
-      end
-
-      it 'accepts an explicit link' do
-        expect(helper.exhibit_create_link(some_model, '#')).to have_link 'Create', href: '#'
-      end
-
-      it 'accepts link_to options' do
-        expect(helper.exhibit_create_link(some_model, '#', class: 'btn')).to have_selector 'a.btn'
-      end
+    it 'accepts an explicit link' do
+      expect(helper.exhibit_edit_link(some_model, '#')).to have_link 'Edit', href: '#'
     end
 
-    describe '#exhibit_edit_link' do
-      let(:some_model) { Spotlight::FeaturePage.create! exhibit: exhibit }
-      before do
-        allow(helper).to receive_messages(current_exhibit: exhibit)
-        allow(helper).to receive_messages action_default_value: 'Edit'
-      end
+    it 'accepts link_to options' do
+      expect(helper.exhibit_edit_link(some_model, '#', class: 'btn')).to have_selector 'a.btn'
+    end
+  end
 
-      it 'is a model-specific edit link' do
-        expect(helper).to receive(:action_default_value).with(some_model).and_return 'Edit'
-        expect(helper.exhibit_edit_link(some_model)).to have_link 'Edit', href: spotlight.edit_exhibit_feature_page_path(exhibit, some_model)
-      end
-
-      it 'accepts an explicit link' do
-        expect(helper.exhibit_edit_link(some_model, '#')).to have_link 'Edit', href: '#'
-      end
-
-      it 'accepts link_to options' do
-        expect(helper.exhibit_edit_link(some_model, '#', class: 'btn')).to have_selector 'a.btn'
-      end
+  describe '#exhibit_delete_link' do
+    before do
+      allow(helper).to receive_messages action_default_value: 'Delete'
     end
 
-    describe '#exhibit_delete_link' do
-      before do
-        allow(helper).to receive_messages action_default_value: 'Delete'
-      end
-
-      it 'is a model-specific view link' do
-        expect(helper).to receive(:action_default_value).with(some_model, :destroy).and_return 'Delete'
-        expect(helper.exhibit_delete_link(some_model)).to have_link 'Delete', href: spotlight.exhibit_feature_page_path(some_model.exhibit, some_model)
-      end
-
-      it 'accepts an explicit link' do
-        expect(helper.exhibit_delete_link(some_model, '#')).to have_link 'Delete', href: '#'
-      end
-
-      it 'accepts link_to options' do
-        expect(helper.exhibit_delete_link(some_model, '#', class: 'btn')).to have_selector 'a.btn'
-      end
+    it 'is a model-specific view link' do
+      expect(helper).to receive(:action_default_value).with(some_model, :destroy).and_return 'Delete'
+      expect(helper.exhibit_delete_link(some_model)).to have_link 'Delete', href: spotlight.exhibit_feature_page_path(some_model.exhibit, some_model)
     end
 
-    describe '#action_label' do
-      it 'returns the label for an action on a model' do
-        some_model = double
-        expect(helper).to receive(:action_default_value).with(some_model, :action).and_return 'xyz'
-        expect(helper.action_label(some_model, :action)).to eq 'xyz'
-      end
+    it 'accepts an explicit link' do
+      expect(helper.exhibit_delete_link(some_model, '#')).to have_link 'Delete', href: '#'
     end
 
-    describe '#action_default_value' do
-      it 'attempts i18n lookups for models' do
-        expect(I18n).to receive(:t).with(:'helpers.action.spotlight/feature_page.edit',
-                                         model: some_model.class.model_name.human,
-                                         default: [:'helpers.action.edit', 'Edit Feature page'])
-        expect(helper.send(:action_default_value, some_model))
-      end
+    it 'accepts link_to options' do
+      expect(helper.exhibit_delete_link(some_model, '#', class: 'btn')).to have_selector 'a.btn'
+    end
+  end
 
-      it 'attempts i18n lookups for unpersisted models' do
-        some_model = Spotlight::FeaturePage.new
-        expect(I18n).to receive(:t).with(:'helpers.action.spotlight/feature_page.create',
-                                         model: some_model.class.model_name.human,
-                                         default: [:'helpers.action.create', 'Create Feature page'])
-        expect(helper.send(:action_default_value, some_model))
-      end
+  describe '#action_label' do
+    it 'returns the label for an action on a model' do
+      some_model = double
+      expect(helper).to receive(:action_default_value).with(some_model, :action).and_return 'xyz'
+      expect(helper.action_label(some_model, :action)).to eq 'xyz'
+    end
+  end
 
-      it 'attempts i18n lookups for models with an explicit action' do
-        expect(I18n).to receive(:t).with(:'helpers.action.spotlight/feature_page.custom_action',
-                                         model: some_model.class.model_name.human,
-                                         default: [:'helpers.action.custom_action', 'Custom action Feature page'])
-        expect(helper.send(:action_default_value, some_model, :custom_action))
-      end
+  describe '#action_default_value' do
+    it 'attempts i18n lookups for models' do
+      expect(I18n).to receive(:t).with(:'helpers.action.spotlight/feature_page.edit',
+                                       model: some_model.class.model_name.human,
+                                       default: [:'helpers.action.edit', 'Edit Feature page'])
+      expect(helper.send(:action_default_value, some_model))
+    end
 
-      it 'attempts i18n lookups for symbols' do
-        expect(I18n).to receive(:t).with(:'helpers.action.my_thing.custom_action',
-                                         model: :my_thing,
-                                         default: [:'helpers.action.custom_action', 'Custom action my_thing'])
-        expect(helper.send(:action_default_value, :my_thing, :custom_action))
-      end
+    it 'attempts i18n lookups for unpersisted models' do
+      some_model = Spotlight::FeaturePage.new
+      expect(I18n).to receive(:t).with(:'helpers.action.spotlight/feature_page.create',
+                                       model: some_model.class.model_name.human,
+                                       default: [:'helpers.action.create', 'Create Feature page'])
+      expect(helper.send(:action_default_value, some_model))
+    end
+
+    it 'attempts i18n lookups for models with an explicit action' do
+      expect(I18n).to receive(:t).with(:'helpers.action.spotlight/feature_page.custom_action',
+                                       model: some_model.class.model_name.human,
+                                       default: [:'helpers.action.custom_action', 'Custom action Feature page'])
+      expect(helper.send(:action_default_value, some_model, :custom_action))
+    end
+
+    it 'attempts i18n lookups for symbols' do
+      expect(I18n).to receive(:t).with(:'helpers.action.my_thing.custom_action',
+                                       model: :my_thing,
+                                       default: [:'helpers.action.custom_action', 'Custom action my_thing'])
+      expect(helper.send(:action_default_value, :my_thing, :custom_action))
     end
   end
 end

--- a/spec/helpers/spotlight/jcrop_helper_spec.rb
+++ b/spec/helpers/spotlight/jcrop_helper_spec.rb
@@ -1,4 +1,3 @@
-
 describe Spotlight::JcropHelper do
   describe '.default_thumbnail_jcrop_options' do
     it 'produces a 4:3 aspect ratio by default' do

--- a/spec/helpers/spotlight/navbar_helper_spec.rb
+++ b/spec/helpers/spotlight/navbar_helper_spec.rb
@@ -1,22 +1,19 @@
-
-module Spotlight
-  describe NavbarHelper, type: :helper do
-    describe '#should_render_search_bar?' do
-      before do
-        allow(helper).to receive_messages(current_exhibit: nil)
-        allow(helper).to receive_messages(exhibit_masthead?: true)
-      end
-      it 'returns false when there is no exhibit context' do
-        expect(helper.should_render_spotlight_search_bar?).to be_falsey
-      end
-      it 'returns true if searchable' do
-        allow(helper).to receive_messages(current_exhibit: double(searchable?: true))
-        expect(helper.should_render_spotlight_search_bar?).to be_truthy
-      end
-      it 'returns false if currently under an "Exhibity" browse category' do
-        allow(helper).to receive_messages(exhibit_masthead?: false)
-        expect(helper.should_render_spotlight_search_bar?).to be_falsey
-      end
+describe Spotlight::NavbarHelper, type: :helper do
+  describe '#should_render_search_bar?' do
+    before do
+      allow(helper).to receive_messages(current_exhibit: nil)
+      allow(helper).to receive_messages(exhibit_masthead?: true)
+    end
+    it 'returns false when there is no exhibit context' do
+      expect(helper.should_render_spotlight_search_bar?).to be_falsey
+    end
+    it 'returns true if searchable' do
+      allow(helper).to receive_messages(current_exhibit: double(searchable?: true))
+      expect(helper.should_render_spotlight_search_bar?).to be_truthy
+    end
+    it 'returns false if currently under an "Exhibity" browse category' do
+      allow(helper).to receive_messages(exhibit_masthead?: false)
+      expect(helper.should_render_spotlight_search_bar?).to be_falsey
     end
   end
 end

--- a/spec/helpers/spotlight/pages_helper_spec.rb
+++ b/spec/helpers/spotlight/pages_helper_spec.rb
@@ -1,95 +1,93 @@
+describe Spotlight::PagesHelper, type: :helper do
+  let(:blacklight_config) { Blacklight::Configuration.new { |config| config.show.title_field = :abc } }
+  let(:titled_document) { blacklight_config.document_model.new(abc: 'value') }
+  let(:untitled_document) { blacklight_config.document_model.new(id: '1234') }
+  let!(:current_exhibit) { FactoryGirl.create(:exhibit) }
+  let!(:home_page) { current_exhibit.home_page }
+  let!(:search) { FactoryGirl.create(:search, exhibit: current_exhibit, query_params: { 'q' => 'query' }, published: true) }
 
-module Spotlight
-  describe PagesHelper, type: :helper do
-    let(:blacklight_config) { Blacklight::Configuration.new { |config| config.show.title_field = :abc } }
-    let(:titled_document) { blacklight_config.document_model.new(abc: 'value') }
-    let(:untitled_document) { blacklight_config.document_model.new(id: '1234') }
-    let!(:current_exhibit) { FactoryGirl.create(:exhibit) }
-    let!(:home_page) { current_exhibit.home_page }
-    let!(:search) { FactoryGirl.create(:search, exhibit: current_exhibit, query_params: { 'q' => 'query' }, published: true) }
+  before(:each) do
+    allow(helper).to receive_messages(blacklight_config: blacklight_config)
+  end
 
-    before(:each) do
-      allow(helper).to receive_messages(blacklight_config: blacklight_config)
+  describe 'available_index_fields' do
+    before do
+      blacklight_config.index.title_field = :title_field
+      blacklight_config.add_index_field 'x', label: 'X'
     end
 
-    describe 'available_index_fields' do
-      before do
-        blacklight_config.index.title_field = :title_field
-        blacklight_config.add_index_field 'x', label: 'X'
-      end
-
-      it 'lists the configured index fields' do
-        expect(helper.available_index_fields).to include key: 'x', label: 'X'
-      end
-
-      it 'adds the title field if necessary' do
-        expect(helper.available_index_fields).to include key: :title_field, label: 'Title'
-      end
+    it 'lists the configured index fields' do
+      expect(helper.available_index_fields).to include key: 'x', label: 'X'
     end
 
-    describe 'disable_save_pages_button?' do
-      it 'returns true if there are no pages and we are on the about pages page' do
-        expect(helper).to receive(:page_collection_name).and_return('about_pages')
-        assign(:pages, [])
-        expect(helper.disable_save_pages_button?).to be_truthy
-      end
-      it 'returns false if there are about pages' do
-        expect(helper).to receive(:page_collection_name).and_return('about_pages')
-        assign(:pages, [{}])
-        expect(helper.disable_save_pages_button?).to be_falsey
-      end
-      it 'returns false if on the feature pages page' do
-        expect(helper).to receive(:page_collection_name).and_return('feature_pages')
-        assign(:pages, [])
-        expect(helper.disable_save_pages_button?).to be_falsey
-      end
+    it 'adds the title field if necessary' do
+      expect(helper.available_index_fields).to include key: :title_field, label: 'Title'
     end
-    describe 'get_search_widget_search_results' do
-      let(:good) do
-        content = { type: 'xyz', data: { 'item' => { search.slug => { id: search.slug, display: 'true' } } } }
-        SirTrevorRails::Blocks::SearchResultsBlock.new(content, home_page)
-      end
+  end
 
-      let(:bad) do
-        content = { type: 'xyz', data: { 'item' => { 'garbage' => { id: 'missing', display: 'true' } } } }
-        SirTrevorRails::Blocks::SearchResultsBlock.new(content, home_page)
-      end
+  describe 'disable_save_pages_button?' do
+    it 'returns true if there are no pages and we are on the about pages page' do
+      expect(helper).to receive(:page_collection_name).and_return('about_pages')
+      assign(:pages, [])
+      expect(helper.disable_save_pages_button?).to be_truthy
+    end
+    it 'returns false if there are about pages' do
+      expect(helper).to receive(:page_collection_name).and_return('about_pages')
+      assign(:pages, [{}])
+      expect(helper.disable_save_pages_button?).to be_falsey
+    end
+    it 'returns false if on the feature pages page' do
+      expect(helper).to receive(:page_collection_name).and_return('feature_pages')
+      assign(:pages, [])
+      expect(helper.disable_save_pages_button?).to be_falsey
+    end
+  end
 
-      let(:search_result) { [double('response'), double('documents')] }
-
-      it 'returns the results for a given search browse category' do
-        expect(helper).to receive(:search_results).with('q' => 'query').and_return(search_result)
-        expect(helper.get_search_widget_search_results(good)).to eq search_result
-      end
-      it "returns an empty array when requesting a search that doesn't exist" do
-        expect(helper.get_search_widget_search_results(bad)).to be_empty
-      end
+  describe 'get_search_widget_search_results' do
+    let(:good) do
+      content = { type: 'xyz', data: { 'item' => { search.slug => { id: search.slug, display: 'true' } } } }
+      SirTrevorRails::Blocks::SearchResultsBlock.new(content, home_page)
     end
 
-    describe 'nestable helpers' do
-      describe 'nestable data attributes' do
-        it 'returns the appropriate attributes for feature pages' do
-          expect(helper.nestable_data_attributes('feature_pages')).to eq "data-max-depth='2' data-expand-btn-HTML='' data-collapse-btn-HTML=''"
-        end
-        it 'returns the appropriate attributes for about pages' do
-          expect(helper.nestable_data_attributes('about_pages')).to eq "data-max-depth='1'"
-        end
-        it 'returns a blank string if the type is not valid' do
-          expect(helper.nestable_data_attributes('something_else')).to eq ''
-        end
+    let(:bad) do
+      content = { type: 'xyz', data: { 'item' => { 'garbage' => { id: 'missing', display: 'true' } } } }
+      SirTrevorRails::Blocks::SearchResultsBlock.new(content, home_page)
+    end
+
+    let(:search_result) { [double('response'), double('documents')] }
+
+    it 'returns the results for a given search browse category' do
+      expect(helper).to receive(:search_results).with('q' => 'query').and_return(search_result)
+      expect(helper.get_search_widget_search_results(good)).to eq search_result
+    end
+    it "returns an empty array when requesting a search that doesn't exist" do
+      expect(helper.get_search_widget_search_results(bad)).to be_empty
+    end
+  end
+
+  describe 'nestable helpers' do
+    describe 'nestable data attributes' do
+      it 'returns the appropriate attributes for feature pages' do
+        expect(helper.nestable_data_attributes('feature_pages')).to eq "data-max-depth='2' data-expand-btn-HTML='' data-collapse-btn-HTML=''"
       end
-      describe 'nestable data attributes hash' do
-        it 'returns the appropriate hash for feature pages' do
-          expect(helper.nestable_data_attributes_hash('feature_pages')).to eq('data-max-depth' => '2',
-                                                                              'data-expand-btn-HTML' => '',
-                                                                              'data-collapse-btn-HTML' => '')
-        end
-        it 'returns the appropriate hash for about pages' do
-          expect(helper.nestable_data_attributes_hash('about_pages')).to eq 'data-max-depth' => '1'
-        end
-        it 'returns an empty hash if the type is not valid' do
-          expect(helper.nestable_data_attributes_hash('something_else')).to eq({})
-        end
+      it 'returns the appropriate attributes for about pages' do
+        expect(helper.nestable_data_attributes('about_pages')).to eq "data-max-depth='1'"
+      end
+      it 'returns a blank string if the type is not valid' do
+        expect(helper.nestable_data_attributes('something_else')).to eq ''
+      end
+    end
+    describe 'nestable data attributes hash' do
+      it 'returns the appropriate hash for feature pages' do
+        expect(helper.nestable_data_attributes_hash('feature_pages')).to eq('data-max-depth' => '2',
+                                                                            'data-expand-btn-HTML' => '',
+                                                                            'data-collapse-btn-HTML' => '')
+      end
+      it 'returns the appropriate hash for about pages' do
+        expect(helper.nestable_data_attributes_hash('about_pages')).to eq 'data-max-depth' => '1'
+      end
+      it 'returns an empty hash if the type is not valid' do
+        expect(helper.nestable_data_attributes_hash('something_else')).to eq({})
       end
     end
   end

--- a/spec/helpers/spotlight/roles_helper_spec.rb
+++ b/spec/helpers/spotlight/roles_helper_spec.rb
@@ -1,4 +1,3 @@
-
 describe Spotlight::RolesHelper, type: :helper do
   it 'is a list of options' do
     expect(helper.roles_for_select).to eq('Admin' => 'admin', 'Curator' => 'curator')

--- a/spec/helpers/spotlight/search_configurations_helper_spec.rb
+++ b/spec/helpers/spotlight/search_configurations_helper_spec.rb
@@ -1,4 +1,3 @@
-
 describe Spotlight::SearchConfigurationsHelper, type: :helper do
   describe '#translate_sort_fields' do
     let(:sort_config) do
@@ -11,7 +10,6 @@ describe Spotlight::SearchConfigurationsHelper, type: :helper do
 
     it 'humanizes untranslatable sort fields' do
       sort_config.sort = 'some_other_field desc'
-
       expect(translate_sort_fields(sort_config)).to eq 'some other field descending'
     end
 

--- a/spec/helpers/spotlight/title_helper_spec.rb
+++ b/spec/helpers/spotlight/title_helper_spec.rb
@@ -1,4 +1,3 @@
-
 describe Spotlight::TitleHelper, type: :helper do
   before do
     allow(helper).to receive_messages(application_name: 'Application')

--- a/spec/routing/spotlight/exhibit_catalog_spec.rb
+++ b/spec/routing/spotlight/exhibit_catalog_spec.rb
@@ -1,12 +1,9 @@
+describe 'Catalog controller', type: :routing do
+  describe 'routing' do
+    routes { Spotlight::Engine.routes }
 
-module Spotlight
-  describe 'Catalog controller', type: :routing do
-    describe 'routing' do
-      routes { Spotlight::Engine.routes }
-
-      it 'routes to #edit' do
-        expect(get('/1/catalog/dq287tq6352/edit')).to route_to('spotlight/catalog#edit', exhibit_id: '1', id: 'dq287tq6352')
-      end
+    it 'routes to #edit' do
+      expect(get('/1/catalog/dq287tq6352/edit')).to route_to('spotlight/catalog#edit', exhibit_id: '1', id: 'dq287tq6352')
     end
   end
 end

--- a/spec/views/spotlight/catalog/admin.html.erb_spec.rb
+++ b/spec/views/spotlight/catalog/admin.html.erb_spec.rb
@@ -1,38 +1,35 @@
+describe 'spotlight/catalog/admin.html.erb', type: :view do
+  let(:exhibit) { stub_model(Spotlight::Exhibit) }
+  let(:blacklight_config) { CatalogController.blacklight_config }
+  before do
+    allow(view).to receive(:blacklight_config).and_return(blacklight_config)
+    allow(exhibit).to receive(:blacklight_config).and_return(blacklight_config)
+    allow(view).to receive(:spotlight_page_path_for).and_return(nil)
+    allow(view).to receive(:current_exhibit).and_return(exhibit)
+    allow(view).to receive(:new_exhibit_resource_path).and_return('')
+    allow(view).to receive(:reindex_all_exhibit_resources_path).and_return('')
+    allow(view).to receive(:monitor_exhibit_resources_path).and_return('')
+    assign(:exhibit, exhibit)
+    assign(:response, [])
+    stub_template '_search_header.html.erb' => 'header'
+    stub_template '_zero_results.html.erb' => 'nuffin'
+    stub_template '_results_pagination.html.erb' => '0'
+    allow(view).to receive(:can?).and_return(true)
+  end
+  it 'renders the sidebar' do
+    render
+    expect(rendered).to have_link 'Browse'
+  end
 
-module Spotlight
-  describe 'spotlight/catalog/admin.html.erb', type: :view do
-    let(:exhibit) { stub_model(Spotlight::Exhibit) }
-    let(:blacklight_config) { CatalogController.blacklight_config }
-    before do
-      allow(view).to receive(:blacklight_config).and_return(blacklight_config)
-      allow(exhibit).to receive(:blacklight_config).and_return(blacklight_config)
-      allow(view).to receive(:spotlight_page_path_for).and_return(nil)
-      allow(view).to receive(:current_exhibit).and_return(exhibit)
-      allow(view).to receive(:new_exhibit_resource_path).and_return('')
-      allow(view).to receive(:reindex_all_exhibit_resources_path).and_return('')
-      allow(view).to receive(:monitor_exhibit_resources_path).and_return('')
-      assign(:exhibit, exhibit)
-      assign(:response, [])
-      stub_template '_search_header.html.erb' => 'header'
-      stub_template '_zero_results.html.erb' => 'nuffin'
-      stub_template '_results_pagination.html.erb' => '0'
-      allow(view).to receive(:can?).and_return(true)
-    end
-    it 'renders the sidebar' do
-      render
-      expect(rendered).to have_link 'Browse'
-    end
+  it "renders the 'add items' link if any repository sources are configured" do
+    allow(Spotlight::Engine.config).to receive(:resource_partials).and_return(['a'])
+    render
+    expect(rendered).to have_link 'Add items'
+  end
 
-    it "renders the 'add items' link if any repository sources are configured" do
-      allow(Spotlight::Engine.config).to receive(:resource_partials).and_return(['a'])
-      render
-      expect(rendered).to have_link 'Add items'
-    end
-
-    it "does not render the 'add items' link if no repository sources are configured" do
-      allow(Spotlight::Engine.config).to receive(:resource_partials).and_return([])
-      render
-      expect(rendered).not_to have_link 'Add items'
-    end
+  it "does not render the 'add items' link if no repository sources are configured" do
+    allow(Spotlight::Engine.config).to receive(:resource_partials).and_return([])
+    render
+    expect(rendered).not_to have_link 'Add items'
   end
 end

--- a/spec/views/spotlight/exhibits/edit.html.erb_spec.rb
+++ b/spec/views/spotlight/exhibits/edit.html.erb_spec.rb
@@ -1,24 +1,23 @@
+describe 'spotlight/exhibits/edit', type: :view do
+  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  before do
+    assign(:exhibit, exhibit)
+    allow(view).to receive_messages(
+      current_exhibit: exhibit,
+      can?: true,
+      import_exhibit_path:  '/',
+      get_exhibit_path:     '/',
+      exhibit_filters_path: '/'
+    )
+  end
 
-module Spotlight
-  describe 'spotlight/exhibits/edit', type: :view do
-    let(:exhibit) { FactoryGirl.create(:exhibit) }
-    before do
-      assign(:exhibit, exhibit)
-      allow(view).to receive_messages(current_exhibit: exhibit)
-      allow(view).to receive_messages(can?: true)
-      allow(view).to receive_messages(import_exhibit_path: '/')
-      allow(view).to receive_messages(get_exhibit_path: '/')
-      allow(view).to receive_messages(exhibit_filters_path: '/')
-    end
+  it 'renders the edit page form' do
+    render
 
-    it 'renders the edit page form' do
-      render
-
-      expect(rendered).to have_selector "form[action=\"#{spotlight.exhibit_path(exhibit)}\"]"
-      expect(rendered).to have_selector '.callout.callout-danger.row'
-      expect(rendered).to have_content 'This action is irreversible'
-      expect(rendered).to have_link 'Export data', href: spotlight.import_exhibit_path(exhibit)
-      expect(rendered).to have_button 'Import data'
-    end
+    expect(rendered).to have_selector "form[action=\"#{spotlight.exhibit_path(exhibit)}\"]"
+    expect(rendered).to have_selector '.callout.callout-danger.row'
+    expect(rendered).to have_content 'This action is irreversible'
+    expect(rendered).to have_link 'Export data', href: spotlight.import_exhibit_path(exhibit)
+    expect(rendered).to have_button 'Import data'
   end
 end

--- a/spec/views/spotlight/exhibits/index.html.erb_spec.rb
+++ b/spec/views/spotlight/exhibits/index.html.erb_spec.rb
@@ -1,141 +1,138 @@
+describe 'spotlight/exhibits/index', type: :view do
+  let(:exhibits) { Spotlight::Exhibit.none }
+  let(:published_exhibits) { exhibits.published.page(1) }
 
-module Spotlight
-  describe 'spotlight/exhibits/index', type: :view do
-    let(:exhibits) { Spotlight::Exhibit.none }
-    let(:published_exhibits) { exhibits.published.page(1) }
+  let(:ability) { ::Ability.new(user) }
+  let(:user) { Spotlight::Engine.user_class.new }
 
-    let(:ability) { ::Ability.new(user) }
-    let(:user) { Spotlight::Engine.user_class.new }
+  before do
+    assign(:exhibits, exhibits)
+    assign(:published_exhibits, published_exhibits)
+    allow(view).to receive_messages(exhibits_path: '/', exhibit_path: '/', current_user: user, current_ability: ability)
+  end
 
-    before do
-      assign(:exhibits, exhibits)
-      assign(:published_exhibits, published_exhibits)
-      allow(view).to receive_messages(exhibits_path: '/', exhibit_path: '/', current_user: user, current_ability: ability)
+  context 'with published exhibits' do
+    let!(:exhibit_a) { FactoryGirl.create(:exhibit, published: true) }
+    let!(:exhibit_b) { FactoryGirl.create(:exhibit, published: true) }
+    let!(:exhibit_c) { FactoryGirl.create(:exhibit, published: false) }
+
+    let(:exhibits) { Spotlight::Exhibit.all }
+
+    it 'renders the published exhibits' do
+      render
+
+      expect(rendered).to have_selector('.exhibit-card', count: 2)
+      expect(rendered).to have_text exhibit_a.title
+      expect(rendered).to have_text exhibit_b.title
+      expect(rendered).not_to have_text exhibit_c.title
+
+      expect(rendered).not_to include 'Private exhibits'
     end
 
-    context 'with published exhibits' do
-      let!(:exhibit_a) { FactoryGirl.create(:exhibit, published: true) }
-      let!(:exhibit_b) { FactoryGirl.create(:exhibit, published: true) }
-      let!(:exhibit_c) { FactoryGirl.create(:exhibit, published: false) }
+    it 'does not include the tab bar' do
+      render
 
-      let(:exhibits) { Spotlight::Exhibit.all }
+      expect(rendered).not_to have_selector '.nav-tabs'
+    end
 
-      it 'renders the published exhibits' do
+    it 'does not include tags controls' do
+      render
+
+      expect(rendered).not_to have_selector '.tags'
+    end
+
+    it 'does not include pagination controls' do
+      render
+
+      expect(rendered).not_to have_selector '.pager'
+    end
+
+    context 'with tagged exhibits' do
+      before do
+        exhibit_a.tag_list = ['a']
+        exhibit_b.tag_list = ['a']
+        exhibit_c.tag_list = ['b']
+
+        exhibit_a.save
+        exhibit_b.save
+        exhibit_c.save
+      end
+
+      it 'filters by tags' do
         render
 
-        expect(rendered).to have_selector('.exhibit-card', count: 2)
-        expect(rendered).to have_text exhibit_a.title
-        expect(rendered).to have_text exhibit_b.title
-        expect(rendered).not_to have_text exhibit_c.title
-
-        expect(rendered).not_to include 'Private exhibits'
-      end
-
-      it 'does not include the tab bar' do
-        render
-
-        expect(rendered).not_to have_selector '.nav-tabs'
-      end
-
-      it 'does not include tags controls' do
-        render
-
-        expect(rendered).not_to have_selector '.tags'
-      end
-
-      it 'does not include pagination controls' do
-        render
-
-        expect(rendered).not_to have_selector '.pager'
-      end
-
-      context 'with tagged exhibits' do
-        before do
-          exhibit_a.tag_list = ['a']
-          exhibit_b.tag_list = ['a']
-          exhibit_c.tag_list = ['b']
-
-          exhibit_a.save
-          exhibit_b.save
-          exhibit_c.save
-        end
-
-        it 'filters by tags' do
-          render
-
-          expect(rendered).to have_link 'All'
-          expect(rendered).to have_link 'a'
-          expect(rendered).to have_link 'b'
-        end
-      end
-
-      context 'with paginated exhibits' do
-        let(:published_exhibits) { exhibits.published.page(1).per(1) }
-
-        it 'renders pagination controls' do
-          render
-
-          expect(rendered).to have_selector '.pager'
-          expect(rendered).to have_link 'Next', href: '/?page=2'
-        end
-      end
-
-      context 'with an exhibit admin' do
-        let(:user) { FactoryGirl.create(:exhibit_admin) }
-
-        it 'includes a tab with the exhibits curated by the user' do
-          render
-
-          expect(rendered).to have_selector '.nav-tabs'
-          expect(rendered).to have_link 'Your exhibits'
-          expect(rendered).to have_text user.exhibits.first.title
-        end
-
-        it 'does not include a tab for unpublished exhibits' do
-          render
-
-          expect(rendered).to have_selector '.nav-tabs'
-          expect(rendered).not_to have_link 'Unpublished exhibits'
-        end
-      end
-
-      context 'with a site admin' do
-        let(:user) { FactoryGirl.create(:site_admin) }
-
-        before do
-          allow(view).to receive_messages(can?: true, new_exhibit_path: '/exhibits/new')
-        end
-
-        it 'includes a tab with unpublished exhibits' do
-          render
-
-          expect(rendered).to have_selector '.nav-tabs'
-          expect(rendered).to have_link 'Unpublished exhibits'
-          expect(rendered).to have_text exhibit_c.title
-        end
+        expect(rendered).to have_link 'All'
+        expect(rendered).to have_link 'a'
+        expect(rendered).to have_link 'b'
       end
     end
 
-    context 'with an authorized user' do
-      let(:user) { FactoryGirl.build(:site_admin) }
+    context 'with paginated exhibits' do
+      let(:published_exhibits) { exhibits.published.page(1).per(1) }
+
+      it 'renders pagination controls' do
+        render
+
+        expect(rendered).to have_selector '.pager'
+        expect(rendered).to have_link 'Next', href: '/?page=2'
+      end
+    end
+
+    context 'with an exhibit admin' do
+      let(:user) { FactoryGirl.create(:exhibit_admin) }
+
+      it 'includes a tab with the exhibits curated by the user' do
+        render
+
+        expect(rendered).to have_selector '.nav-tabs'
+        expect(rendered).to have_link 'Your exhibits'
+        expect(rendered).to have_text user.exhibits.first.title
+      end
+
+      it 'does not include a tab for unpublished exhibits' do
+        render
+
+        expect(rendered).to have_selector '.nav-tabs'
+        expect(rendered).not_to have_link 'Unpublished exhibits'
+      end
+    end
+
+    context 'with a site admin' do
+      let(:user) { FactoryGirl.create(:site_admin) }
 
       before do
-        allow(view).to receive_messages(can?: true,
-                                        new_exhibit_path: '/exhibits/new')
+        allow(view).to receive_messages(can?: true, new_exhibit_path: '/exhibits/new')
       end
 
-      it 'gives instructions for getting started' do
+      it 'includes a tab with unpublished exhibits' do
         render
 
-        expect(rendered).to include 'Welcome to Spotlight!'
-        expect(rendered).to have_link 'Create Exhibit', href: '/exhibits/new'
+        expect(rendered).to have_selector '.nav-tabs'
+        expect(rendered).to have_link 'Unpublished exhibits'
+        expect(rendered).to have_text exhibit_c.title
       end
+    end
+  end
 
-      it 'has a sidebar with a button to create a new exhibit' do
-        render
+  context 'with an authorized user' do
+    let(:user) { FactoryGirl.build(:site_admin) }
 
-        expect(rendered).to have_selector 'aside .btn', text: 'Create a new exhibit'
-      end
+    before do
+      allow(view).to receive_messages(can?: true,
+                                      new_exhibit_path: '/exhibits/new')
+    end
+
+    it 'gives instructions for getting started' do
+      render
+
+      expect(rendered).to include 'Welcome to Spotlight!'
+      expect(rendered).to have_link 'Create Exhibit', href: '/exhibits/new'
+    end
+
+    it 'has a sidebar with a button to create a new exhibit' do
+      render
+
+      expect(rendered).to have_selector 'aside .btn', text: 'Create a new exhibit'
     end
   end
 end

--- a/spec/views/spotlight/metadata_configurations/_metadata_field.html.erb_spec.rb
+++ b/spec/views/spotlight/metadata_configurations/_metadata_field.html.erb_spec.rb
@@ -1,26 +1,23 @@
+describe 'spotlight/metadata_configurations/_metadata_field', type: :view do
+  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:p) { 'spotlight/metadata_configurations/metadata_field.html.erb' }
+  before do
+    assign(:exhibit, exhibit)
+    assign(:blacklight_configuration, exhibit.blacklight_configuration)
+    allow(view).to receive_messages(
+      current_exhibit: exhibit,
+      blacklight_config: exhibit.blacklight_configuration,
+      available_view_fields: { some_view_type: 1, another_view_type: 2 },
+      select_deselect_button: nil
+    )
+  end
 
-module Spotlight
-  describe 'spotlight/metadata_configurations/_metadata_field', type: :view do
-    let(:exhibit) { FactoryGirl.create(:exhibit) }
-    let(:p) { 'spotlight/metadata_configurations/metadata_field.html.erb' }
-    before do
-      assign(:exhibit, exhibit)
-      assign(:blacklight_configuration, exhibit.blacklight_configuration)
-      allow(view).to receive_messages(
-        current_exhibit: exhibit,
-        blacklight_config: exhibit.blacklight_configuration,
-        available_view_fields: { some_view_type: 1, another_view_type: 2 },
-        select_deselect_button: nil
-      )
-    end
+  let(:facet_field) { Blacklight::Configuration::FacetField.new }
+  let(:builder) { ActionView::Helpers::FormBuilder.new 'z', nil, view, {} }
 
-    let(:facet_field) { Blacklight::Configuration::FacetField.new }
-    let(:builder) { ActionView::Helpers::FormBuilder.new 'z', nil, view, {} }
-
-    it 'uses the index_field_label helper to render the label' do
-      allow(view).to receive(:index_field_label).with(nil, 'some_key').and_return 'Some label'
-      render partial: p, locals: { key: 'some_key', config: facet_field, f: builder }
-      expect(rendered).to have_selector '.field-label', text: 'Some label'
-    end
+  it 'uses the index_field_label helper to render the label' do
+    allow(view).to receive(:index_field_label).with(nil, 'some_key').and_return 'Some label'
+    render partial: p, locals: { key: 'some_key', config: facet_field, f: builder }
+    expect(rendered).to have_selector '.field-label', text: 'Some label'
   end
 end

--- a/spec/views/spotlight/metadata_configurations/edit.html.erb_spec.rb
+++ b/spec/views/spotlight/metadata_configurations/edit.html.erb_spec.rb
@@ -1,22 +1,19 @@
+describe 'spotlight/metadata_configurations/edit', type: :view do
+  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  before do
+    assign(:exhibit, exhibit)
+    assign(:blacklight_configuration, exhibit.blacklight_configuration)
+    allow(view).to receive_messages(
+      current_exhibit: exhibit,
+      blacklight_config: exhibit.blacklight_configuration,
+      available_view_fields: { some_view_type: 1, another_view_type: 2 },
+      select_deselect_button: nil
+    )
+  end
 
-module Spotlight
-  describe 'spotlight/metadata_configurations/edit', type: :view do
-    let(:exhibit) { FactoryGirl.create(:exhibit) }
-    before do
-      assign(:exhibit, exhibit)
-      assign(:blacklight_configuration, exhibit.blacklight_configuration)
-      allow(view).to receive_messages(
-        current_exhibit: exhibit,
-        blacklight_config: exhibit.blacklight_configuration,
-        available_view_fields: { some_view_type: 1, another_view_type: 2 },
-        select_deselect_button: nil
-      )
-    end
-
-    it 'has columns for the available view types' do
-      render
-      expect(rendered).to have_selector 'th', text: 'Some View Type'
-      expect(rendered).to have_selector 'th', text: 'Another View Type'
-    end
+  it 'has columns for the available view types' do
+    render
+    expect(rendered).to have_selector 'th', text: 'Some View Type'
+    expect(rendered).to have_selector 'th', text: 'Another View Type'
   end
 end

--- a/spec/views/spotlight/pages/edit.html.erb_spec.rb
+++ b/spec/views/spotlight/pages/edit.html.erb_spec.rb
@@ -1,67 +1,64 @@
+describe 'spotlight/pages/edit', type: :view do
+  let(:exhibit) { stub_model(Spotlight::Exhibit) }
+  let(:page) { stub_model(Spotlight::FeaturePage, exhibit: exhibit) }
+  before do
+    assign(:page, page)
+    allow(view).to receive_messages(default_thumbnail_jcrop_options: {}, available_index_fields: [], available_view_fields: [])
+  end
 
-module Spotlight
-  describe 'spotlight/pages/edit', type: :view do
-    let(:exhibit) { stub_model(Exhibit) }
-    let(:page) { stub_model(FeaturePage, exhibit: exhibit) }
+  it 'renders the edit page form' do
+    render
+
+    # Run the generator again with the --webrat flag if you want to use webrat matchers
+    assert_select 'form[action=?][method=?]', spotlight.exhibit_feature_page_path(page.exhibit, page), 'post' do
+      assert_select 'input#feature_page_title[name=?]', 'feature_page[title]'
+      assert_select 'textarea#feature_page_content[name=?]', 'feature_page[content]'
+    end
+  end
+
+  describe 'locks' do
+    let(:lock) { Spotlight::Lock.create! on: page }
+
     before do
-      assign(:page, page)
-      allow(view).to receive_messages(default_thumbnail_jcrop_options: {}, available_index_fields: [], available_view_fields: [])
+      page.lock = lock
     end
 
-    it 'renders the edit page form' do
+    it 'renders a lock' do
       render
 
-      # Run the generator again with the --webrat flag if you want to use webrat matchers
-      assert_select 'form[action=?][method=?]', spotlight.exhibit_feature_page_path(page.exhibit, page), 'post' do
-        assert_select 'input#feature_page_title[name=?]', 'feature_page[title]'
-        assert_select 'textarea#feature_page_content[name=?]', 'feature_page[content]'
-      end
+      expect(rendered).to have_css '.alert-lock'
     end
 
-    describe 'locks' do
-      let(:lock) { Lock.create! on: page }
+    it 'does not render an old lock' do
+      lock.created_at -= 1.day
 
-      before do
-        page.lock = lock
-      end
+      render
 
-      it 'renders a lock' do
-        render
+      expect(rendered).not_to have_css '.alert-lock'
+    end
 
-        expect(rendered).to have_css '.alert-lock'
-      end
+    it 'does not render a lock held by the current session' do
+      lock.current_session!
 
-      it 'does not render an old lock' do
-        lock.created_at -= 1.day
+      render
 
-        render
+      expect(rendered).not_to have_css '.alert-lock'
+    end
 
-        expect(rendered).not_to have_css '.alert-lock'
-      end
+    it 'attaches a data-lock attribute to the cancel button' do
+      lock.current_session!
 
-      it 'does not render a lock held by the current session' do
-        lock.current_session!
+      render
 
-        render
+      expect(rendered).to have_link 'Cancel'
+      expect(rendered).to have_css "a[data-lock=\"#{url_for([spotlight, page.exhibit, lock])}\"]", text: 'Cancel'
+    end
 
-        expect(rendered).not_to have_css '.alert-lock'
-      end
+    it "does not have data-lock attribute if the lock doesn't belong to this session" do
+      render
 
-      it 'attaches a data-lock attribute to the cancel button' do
-        lock.current_session!
-
-        render
-
-        expect(rendered).to have_link 'Cancel'
-        expect(rendered).to have_css "a[data-lock=\"#{url_for([spotlight, page.exhibit, lock])}\"]", text: 'Cancel'
-      end
-
-      it "does not have data-lock attribute if the lock doesn't belong to this session" do
-        render
-
-        expect(rendered).to have_link 'Cancel'
-        expect(rendered).not_to have_css 'a[data-lock]', text: 'Cancel'
-      end
+      expect(rendered).to have_link 'Cancel'
+      expect(rendered).not_to have_css 'a[data-lock]', text: 'Cancel'
     end
   end
 end

--- a/spec/views/spotlight/pages/new.html.erb_spec.rb
+++ b/spec/views/spotlight/pages/new.html.erb_spec.rb
@@ -1,20 +1,17 @@
+describe 'spotlight/pages/new', type: :view do
+  let(:exhibit) { stub_model(Spotlight::Exhibit) }
+  before do
+    assign(:page, stub_model(Spotlight::FeaturePage, exhibit: exhibit).as_new_record)
+    allow(view).to receive_messages(default_thumbnail_jcrop_options: {}, available_index_fields: [], available_view_fields: [])
+  end
 
-module Spotlight
-  describe 'spotlight/pages/new', type: :view do
-    let(:exhibit) { stub_model(Exhibit) }
-    before do
-      assign(:page, stub_model(FeaturePage, exhibit: exhibit).as_new_record)
-      allow(view).to receive_messages(default_thumbnail_jcrop_options: {}, available_index_fields: [], available_view_fields: [])
-    end
+  it 'renders new page form' do
+    render
 
-    it 'renders new page form' do
-      render
-
-      # Run the generator again with the --webrat flag if you want to use webrat matchers
-      assert_select 'form[action=?][method=?]', spotlight.exhibit_feature_pages_path(exhibit), 'post' do
-        assert_select 'input#feature_page_title[name=?]', 'feature_page[title]'
-        assert_select 'textarea#feature_page_content[name=?]', 'feature_page[content]'
-      end
+    # Run the generator again with the --webrat flag if you want to use webrat matchers
+    assert_select 'form[action=?][method=?]', spotlight.exhibit_feature_pages_path(exhibit), 'post' do
+      assert_select 'input#feature_page_title[name=?]', 'feature_page[title]'
+      assert_select 'textarea#feature_page_content[name=?]', 'feature_page[content]'
     end
   end
 end

--- a/spec/views/spotlight/pages/show.html.erb_spec.rb
+++ b/spec/views/spotlight/pages/show.html.erb_spec.rb
@@ -1,62 +1,60 @@
+describe 'spotlight/pages/show', type: :view do
+  let(:exhibit) { stub_model(Spotlight::Exhibit) }
+  let(:page) do
+    stub_model(Spotlight::FeaturePage,
+               exhibit: exhibit,
+               title: 'Title',
+               content: '[]')
+  end
+  before(:each) do
+    allow(view).to receive(:current_exhibit).and_return(exhibit)
+    assign(:page, page)
+    stub_template 'spotlight/pages/_sidebar.html.erb' => 'Sidebar'
+  end
 
-module Spotlight
-  describe 'spotlight/pages/show', type: :view do
-    let(:exhibit) { stub_model(Exhibit) }
-    let(:page) do
-      stub_model(FeaturePage,
-                 exhibit: exhibit,
-                 title: 'Title',
-                 content: '[]')
-    end
-    before(:each) do
-      allow(view).to receive(:current_exhibit).and_return(exhibit)
-      assign(:page, page)
-      stub_template 'spotlight/pages/_sidebar.html.erb' => 'Sidebar'
-    end
+  it 'renders the title as a heading' do
+    render
+    expect(rendered).to have_css('.page-title', text: page.title)
+  end
 
-    it 'renders the title as a heading' do
-      render
-      expect(rendered).to have_css('.page-title', text: page.title)
-    end
-    it 'does not render an empty heading' do
-      allow(page).to receive_messages(title: nil)
-      render
-      expect(rendered).to_not have_css('.page-title')
-    end
+  it 'does not render an empty heading' do
+    allow(page).to receive_messages(title: nil)
+    render
+    expect(rendered).to_not have_css('.page-title')
+  end
 
-    it 'injects the page title into the html title' do
-      expect(view).to receive(:set_html_page_title)
-      render
-    end
+  it 'injects the page title into the html title' do
+    expect(view).to receive(:set_html_page_title)
+    render
+  end
 
-    it 'does not include the page title' do
-      allow(page).to receive_messages(should_display_title?: false)
-      expect(view).to_not receive(:set_html_page_title)
-      render
-    end
+  it 'does not include the page title' do
+    allow(page).to receive_messages(should_display_title?: false)
+    expect(view).to_not receive(:set_html_page_title)
+    render
+  end
 
-    it 'renders attributes in <p>' do
-      render
-      expect(rendered).to match(/Title/)
-    end
+  it 'renders attributes in <p>' do
+    render
+    expect(rendered).to match(/Title/)
+  end
 
-    it 'renders the sidebar' do
-      page.display_sidebar = true
-      render
-      expect(rendered).to match('Sidebar')
-    end
+  it 'renders the sidebar' do
+    page.display_sidebar = true
+    render
+    expect(rendered).to match('Sidebar')
+  end
 
-    it 'does not render the sidebar if the page has it disabled' do
-      allow(page).to receive_messages(display_sidebar?: false)
-      render
-      expect(rendered).to_not match('Sidebar')
-    end
+  it 'does not render the sidebar if the page has it disabled' do
+    allow(page).to receive_messages(display_sidebar?: false)
+    render
+    expect(rendered).to_not match('Sidebar')
+  end
 
-    it 'renders an empty partial if the page has no content' do
-      allow(page).to receive_messages(content?: false)
-      stub_template 'spotlight/pages/_empty.html.erb' => 'Empty message'
-      render
-      expect(rendered).to have_content('Empty message')
-    end
+  it 'renders an empty partial if the page has no content' do
+    allow(page).to receive_messages(content?: false)
+    stub_template 'spotlight/pages/_empty.html.erb' => 'Empty message'
+    render
+    expect(rendered).to have_content('Empty message')
   end
 end

--- a/spec/views/spotlight/roles/index.html.erb_spec.rb
+++ b/spec/views/spotlight/roles/index.html.erb_spec.rb
@@ -1,30 +1,26 @@
+describe 'spotlight/roles/index', type: :view do
+  let(:user) { stub_model(Spotlight::Engine.user_class, email: 'jane@example.com') }
+  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:admin_role) { FactoryGirl.create(:role, role: 'admin', user: user, resource: exhibit) }
+  let(:roles) { [admin_role] }
 
-module Spotlight
-  describe 'spotlight/roles/index', type: :view do
-    let(:user) { stub_model(Spotlight::Engine.user_class, email: 'jane@example.com') }
+  before do
+    assign(:exhibit, exhibit)
+    allow(view).to receive(:current_exhibit).and_return(exhibit)
+    allow(exhibit).to receive(:roles).and_return roles
+  end
 
-    let(:exhibit) { FactoryGirl.create(:exhibit) }
-    let(:admin_role) { FactoryGirl.create(:role, role: 'admin', user: user, resource: exhibit) }
-    let(:roles) { [admin_role] }
+  it 'renders the index page form' do
+    render
 
-    before do
-      assign(:exhibit, exhibit)
-      allow(view).to receive(:current_exhibit).and_return(exhibit)
-      allow(exhibit).to receive(:roles).and_return roles
-    end
-
-    it 'renders the index page form' do
-      render
-
-      action = spotlight.update_all_exhibit_roles_path(exhibit)
-      assert_select "form[action='#{action}'][method='post']" do
-        assert_select "tr[data-show-for='#{admin_role.id}']"
-        assert_select "tr[data-edit-for='#{admin_role.id}']"
-        assert_select "input[type='submit'][data-behavior='destroy-user'][data-target='#{admin_role.id}']"
-        assert_select "input[type='hidden'][data-destroy-for='#{admin_role.id}']"
-        assert_select "a[data-behavior='cancel-edit']"
-        assert_select "input[type='submit'][value='Save changes']"
-      end
+    action = spotlight.update_all_exhibit_roles_path(exhibit)
+    assert_select "form[action='#{action}'][method='post']" do
+      assert_select "tr[data-show-for='#{admin_role.id}']"
+      assert_select "tr[data-edit-for='#{admin_role.id}']"
+      assert_select "input[type='submit'][data-behavior='destroy-user'][data-target='#{admin_role.id}']"
+      assert_select "input[type='hidden'][data-destroy-for='#{admin_role.id}']"
+      assert_select "a[data-behavior='cancel-edit']"
+      assert_select "input[type='submit'][value='Save changes']"
     end
   end
 end

--- a/spec/views/spotlight/search_configurations/_facet_metadata.html.erb_spec.rb
+++ b/spec/views/spotlight/search_configurations/_facet_metadata.html.erb_spec.rb
@@ -1,34 +1,31 @@
+describe 'spotlight/search_configurations/_facet_metadata', type: :view do
+  before do
+    render partial: 'spotlight/search_configurations/facet_metadata', locals: { metadata: metadata }
+  end
 
-module Spotlight
-  describe 'spotlight/search_configurations/_facet_metadata', type: :view do
-    before do
-      render partial: 'spotlight/search_configurations/facet_metadata', locals: { metadata: metadata }
+  context 'with a facet without any documents' do
+    let(:metadata) { { document_count: 0 } }
+
+    it 'shows there are no documents' do
+      expect(rendered).to have_content '0 items'
     end
+  end
 
-    context 'with a facet without any documents' do
-      let(:metadata) { { document_count: 0 } }
+  context 'with a facet with a small number of values' do
+    let(:metadata) { { document_count: 1, value_count: 3, terms: %w(a b c) } }
 
-      it 'shows there are no documents' do
-        expect(rendered).to have_content '0 items'
-      end
+    it 'shows the number of unique values' do
+      expect(rendered).to have_content '1 item'
+      expect(rendered).to have_content '3 unique values'
+      expect(rendered).to have_selector '.btn-with-tooltip'
     end
+  end
 
-    context 'with a facet with a small number of values' do
-      let(:metadata) { { document_count: 1, value_count: 3, terms: %w(a b c) } }
+  context 'with a facet with a large number of values' do
+    let(:metadata) { { document_count: 1, value_count: 21, terms: %w() } }
 
-      it 'shows the number of unique values' do
-        expect(rendered).to have_content '1 item'
-        expect(rendered).to have_content '3 unique values'
-        expect(rendered).to have_selector '.btn-with-tooltip'
-      end
-    end
-
-    context 'with a facet with a large number of values' do
-      let(:metadata) { { document_count: 1, value_count: 21, terms: %w() } }
-
-      it 'shows there are many unique values' do
-        expect(rendered).to have_content '20+ unique values'
-      end
+    it 'shows there are many unique values' do
+      expect(rendered).to have_content '20+ unique values'
     end
   end
 end

--- a/spec/views/spotlight/search_configurations/_search_fields.html.erb_spec.rb
+++ b/spec/views/spotlight/search_configurations/_search_fields.html.erb_spec.rb
@@ -1,53 +1,40 @@
-
-module Spotlight
-  describe 'spotlight/search_configurations/_search_fields', type: :view do
-    let(:exhibit) { FactoryGirl.create(:exhibit) }
-    before do
-      assign(:exhibit, exhibit)
-      assign(:blacklight_configuration, exhibit.blacklight_configuration)
-      allow(view).to receive_messages(current_exhibit: exhibit)
-
-      exhibit.blacklight_config.add_search_field 'some_hidden_field', include_in_simple_select: false
+describe 'spotlight/search_configurations/_search_fields', type: :view do
+  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:f) do
+    form_helper = nil
+    controller.view_context.bootstrap_form_for(exhibit.blacklight_configuration, url: '/update') do |f|
+      form_helper = f
     end
+    form_helper
+  end
 
-    let(:f) do
-      form_helper = nil
-      controller.view_context.bootstrap_form_for(exhibit.blacklight_configuration, url: '/update') do |f|
-        form_helper = f
-      end
+  before do
+    assign(:exhibit, exhibit)
+    assign(:blacklight_configuration, exhibit.blacklight_configuration)
+    allow(view).to receive_messages(current_exhibit: exhibit)
+    exhibit.blacklight_config.add_search_field 'some_hidden_field', include_in_simple_select: false
+    render partial: 'spotlight/search_configurations/search_fields', locals: { f: f }
+  end
 
-      form_helper
-    end
+  it 'has a fieldset with an appropriate legend' do
+    expect(rendered).to have_selector 'fieldset legend', text: 'Field-based search'
+  end
 
-    it 'has a fieldset with an appropriate legend' do
-      render partial: 'spotlight/search_configurations/search_fields', locals: { f: f }
+  it 'has a checkbox to enable or disable fielded search' do
+    expect(rendered).to have_selector 'input[data-behavior="enable-feature"][data-target="#search_fields"]'
+  end
 
-      expect(rendered).to have_selector 'fieldset legend', text: 'Field-based search'
-    end
+  it 'has a read-only "everything" search option' do
+    expect(rendered).to have_selector "input[name='blacklight_configuration[search_fields][all_fields][enabled]'][data-readonly='true']"
+  end
 
-    it 'has a checkbox to enable or disable fielded search' do
-      render partial: 'spotlight/search_configurations/search_fields', locals: { f: f }
+  it 'has search options for available search fields' do
+    expect(rendered).to have_selector "input[name='blacklight_configuration[search_fields][title][enabled]']"
+    expect(rendered).to have_selector "input[name='blacklight_configuration[search_fields][author][enabled]']"
+  end
 
-      expect(rendered).to have_selector 'input[data-behavior="enable-feature"][data-target="#search_fields"]'
-    end
-
-    it 'has a read-only "everything" search option' do
-      render partial: 'spotlight/search_configurations/search_fields', locals: { f: f }
-      expect(rendered).to have_selector "input[name='blacklight_configuration[search_fields][all_fields][enabled]'][data-readonly='true']"
-    end
-
-    it 'has search options for available search fields' do
-      render partial: 'spotlight/search_configurations/search_fields', locals: { f: f }
-
-      expect(rendered).to have_selector "input[name='blacklight_configuration[search_fields][title][enabled]']"
-      expect(rendered).to have_selector "input[name='blacklight_configuration[search_fields][author][enabled]']"
-    end
-
-    it 'excludes search options that do not show up in the search dropdown' do
-      render partial: 'spotlight/search_configurations/search_fields', locals: { f: f }
-
-      expect(rendered).not_to have_selector "input[name='blacklight_configuration[search_fields][autocomplete][enabled]']"
-      expect(rendered).not_to have_selector "input[name='blacklight_configuration[search_fields][some_hidden_field][enabled]']"
-    end
+  it 'excludes search options that do not show up in the search dropdown' do
+    expect(rendered).not_to have_selector "input[name='blacklight_configuration[search_fields][autocomplete][enabled]']"
+    expect(rendered).not_to have_selector "input[name='blacklight_configuration[search_fields][some_hidden_field][enabled]']"
   end
 end

--- a/spec/views/spotlight/search_configurations/_sort.html.erb_spec.rb
+++ b/spec/views/spotlight/search_configurations/_sort.html.erb_spec.rb
@@ -1,28 +1,24 @@
+describe 'spotlight/search_configurations/_sort', type: :view do
+  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  before do
+    assign(:exhibit, exhibit)
+    assign(:blacklight_configuration, exhibit.blacklight_configuration)
+    allow(view).to receive_messages(
+      current_exhibit: exhibit,
+      translate_sort_fields: ''
+    )
+  end
 
-module Spotlight
-  describe 'spotlight/search_configurations/_sort', type: :view do
-    let(:exhibit) { FactoryGirl.create(:exhibit) }
-    before do
-      assign(:exhibit, exhibit)
-      assign(:blacklight_configuration, exhibit.blacklight_configuration)
-      allow(view).to receive_messages(
-        current_exhibit: exhibit,
-        translate_sort_fields: ''
-      )
+  let(:f) do
+    form_helper = nil
+    controller.view_context.bootstrap_form_for(exhibit.blacklight_configuration, url: '/update') do |f|
+      form_helper = f
     end
+    form_helper
+  end
 
-    let(:f) do
-      form_helper = nil
-      controller.view_context.bootstrap_form_for(exhibit.blacklight_configuration, url: '/update') do |f|
-        form_helper = f
-      end
-
-      form_helper
-    end
-
-    it 'has a disabled relevance sort option' do
-      render partial: 'spotlight/search_configurations/sort', locals: { f: f }
-      expect(rendered).to have_selector "input[name='blacklight_configuration[sort_fields][relevance][enable]'][disabled='disabled']"
-    end
+  it 'has a disabled relevance sort option' do
+    render partial: 'spotlight/search_configurations/sort', locals: { f: f }
+    expect(rendered).to have_selector "input[name='blacklight_configuration[sort_fields][relevance][enable]'][disabled='disabled']"
   end
 end

--- a/spec/views/spotlight/sites/edit_exhibits.html.erb_spec.rb
+++ b/spec/views/spotlight/sites/edit_exhibits.html.erb_spec.rb
@@ -1,28 +1,23 @@
+describe 'spotlight/sites/edit_exhibits', type: :view do
+  let!(:exhibit_a) { FactoryGirl.create(:exhibit) }
+  let!(:exhibit_b) { FactoryGirl.create(:exhibit) }
 
-module Spotlight
-  describe 'spotlight/sites/edit_exhibits', type: :view do
-    let!(:exhibit_a) { FactoryGirl.create(:exhibit) }
-    let!(:exhibit_b) { FactoryGirl.create(:exhibit) }
+  before do
+    assign(:site, Spotlight::Site.instance)
+    allow(view).to receive_messages(exhibit_path: nil)
+  end
 
-    before do
-      assign(:site, Spotlight::Site.instance)
-      allow(view).to receive_messages(exhibit_path: nil)
-    end
+  it 'has columns for the exhibit data' do
+    render
+    expect(rendered).to have_selector 'th', text: 'Title'
+    expect(rendered).to have_selector 'th', text: 'Published?'
+    expect(rendered).to have_selector 'th', text: 'Requested by'
+    expect(rendered).to have_selector 'th', text: 'Created at'
+    expect(rendered).to have_selector 'th', text: 'Updated at'
+  end
 
-    it 'has columns for the exhibit data' do
-      render
-
-      expect(rendered).to have_selector 'th', text: 'Title'
-      expect(rendered).to have_selector 'th', text: 'Published?'
-      expect(rendered).to have_selector 'th', text: 'Requested by'
-      expect(rendered).to have_selector 'th', text: 'Created at'
-      expect(rendered).to have_selector 'th', text: 'Updated at'
-    end
-
-    it 'has draggable rows for each exhibit' do
-      render
-
-      expect(rendered).to have_selector 'tr .dd-handle', count: 2
-    end
+  it 'has draggable rows for each exhibit' do
+    render
+    expect(rendered).to have_selector 'tr .dd-handle', count: 2
   end
 end


### PR DESCRIPTION
The only adjustment required was to fully qualify `Spotlight::Xxx` in a few mocks/let statements.

While this appears to change many lines, the difference is almost entirely whitespace.  