### PR TITLE
Extract Solr document building from the resource

### DIFF
--- a/app/models/concerns/spotlight/resources/open_graph.rb
+++ b/app/models/concerns/spotlight/resources/open_graph.rb
@@ -23,10 +23,6 @@ module Spotlight
           ["#{k.parameterize('_')}_tesim", v]
         end]
       end
-
-      def to_solr
-        super.merge(opengraph_properties)
-      end
     end
   end
 end

--- a/app/services/spotlight/solr_document_builder.rb
+++ b/app/services/spotlight/solr_document_builder.rb
@@ -1,0 +1,67 @@
+module Spotlight
+  # Creates solr documents for the documents in a resource
+  class SolrDocumentBuilder
+    def initialize(resource)
+      @resource = resource
+    end
+
+    attr_reader :resource
+    delegate :exhibit, :document_model, to: :resource
+
+    ##
+    # @return an enumerator of all the indexable documents for this resource
+    def documents_to_index
+      data = to_solr
+      return [] if data.blank?
+      data &&= [data] if data.is_a? Hash
+
+      return to_enum(:documents_to_index) { data.size } unless block_given?
+
+      data.lazy.reject(&:blank?).each do |doc|
+        yield doc.reverse_merge(existing_solr_doc_hash(doc[unique_key]) || {})
+      end
+    end
+
+    protected
+
+    ##
+    # @abstract
+    # Convert this resource into zero-to-many new solr documents. The data here
+    # should be merged into the resource-specific {#to_solr} data.
+    #
+    # @return [Hash] a single solr document hash
+    # @return [Enumerator<Hash>] multiple solr document hashes. This can be a
+    #   simple array, or an lazy enumerator
+    def to_solr
+      (exhibit_specific_solr_data || {}).merge(spotlight_resource_metadata_for_solr || {})
+    end
+
+    private
+
+    ##
+    # Get any exhibit-specific metadata stored in e.g. sidecars, tags, etc
+    # This needs the generated solr document
+    def existing_solr_doc_hash(id)
+      document_model.new(unique_key => id).to_solr if document_model && id.present?
+    end
+
+    def unique_key
+      if document_model
+        document_model.unique_key.to_sym
+      else
+        :id
+      end
+    end
+
+    def exhibit_specific_solr_data
+      exhibit.solr_data if exhibit
+    end
+
+    def spotlight_resource_metadata_for_solr
+      {
+        Spotlight::Engine.config.resource_global_id_field => (resource.to_global_id.to_s if resource.persisted?),
+        document_model.resource_type_field => resource.class.to_s.tableize
+      }
+    end
+  end
+end

--- a/app/services/spotlight/upload_solr_document_builder.rb
+++ b/app/services/spotlight/upload_solr_document_builder.rb
@@ -1,0 +1,48 @@
+module Spotlight
+  # Creates solr documents for the uploaded documents in a resource
+  class UploadSolrDocumentBuilder < SolrDocumentBuilder
+    delegate :compound_id, to: :resource
+
+    def to_solr
+      resource.store_url! # so that #url doesn't return the tmp directory
+
+      solr_hash = super
+
+      add_default_solr_fields solr_hash
+
+      add_image_dimensions solr_hash
+
+      add_file_versions solr_hash
+
+      add_sidecar_fields solr_hash
+
+      solr_hash
+    end
+
+    private
+
+    def add_default_solr_fields(solr_hash)
+      solr_hash[exhibit.blacklight_config.document_model.unique_key.to_sym] = compound_id
+    end
+
+    def add_image_dimensions(solr_hash)
+      dimensions = ::MiniMagick::Image.open(resource.url.file.file)[:dimensions]
+      solr_hash[:spotlight_full_image_width_ssm] = dimensions.first
+      solr_hash[:spotlight_full_image_height_ssm] = dimensions.last
+    end
+
+    def add_file_versions(solr_hash)
+      resource.spotlight_image_derivatives.each do |config|
+        solr_hash[config[:field]] = if config[:version]
+                                      resource.url.send(config[:version]).url
+                                    else
+                                      resource.url.url
+                                    end
+      end
+    end
+
+    def add_sidecar_fields(solr_hash)
+      solr_hash.merge! resource.sidecar.to_solr
+    end
+  end
+end

--- a/spec/models/spotlight/resource_spec.rb
+++ b/spec/models/spotlight/resource_spec.rb
@@ -4,21 +4,6 @@ describe Spotlight::Resource, type: :model do
   end
   let(:exhibit) { FactoryGirl.create(:exhibit) }
 
-  describe '#to_solr' do
-    before do
-      allow(subject).to receive(:exhibit).and_return(exhibit)
-      allow(subject).to receive_messages(type: 'Spotlight::Resource::Something', id: 15, persisted?: true)
-    end
-    it 'includes a reference to the resource' do
-      expect(subject.to_solr).to include spotlight_resource_id_ssim: subject.to_global_id.to_s
-    end
-
-    it 'includes exhibit-specific data' do
-      allow(exhibit).to receive(:solr_data).and_return(exhibit_data: true)
-      expect(subject.to_solr).to include exhibit_data: true
-    end
-  end
-
   describe '#reindex' do
     context 'with a provider that generates ids' do
       subject do
@@ -31,7 +16,7 @@ describe Spotlight::Resource, type: :model do
         SolrDocument.new(id: 123).sidecars.create!(exhibit: exhibit, data: { document_data: true })
         allow(subject).to receive_messages(to_global_id: '')
 
-        allow(subject).to receive(:to_solr).and_return(solr_response)
+        allow(subject.document_builder).to receive(:to_solr).and_return(solr_response)
       end
 
       it 'includes exhibit document-specific data' do

--- a/spec/models/spotlight/resources/open_graph_spec.rb
+++ b/spec/models/spotlight/resources/open_graph_spec.rb
@@ -1,7 +1,12 @@
-
 describe Spotlight::Resources::OpenGraph, type: :model do
+  class TestDocBuilder < Spotlight::SolrDocumentBuilder
+    def to_solr
+      super.merge(resource.opengraph_properties)
+    end
+  end
+
   class TestResource < Spotlight::Resource
-    include Spotlight::Resources::Web
+    self.document_builder_class = TestDocBuilder
     include Spotlight::Resources::OpenGraph
   end
 
@@ -14,7 +19,7 @@ describe Spotlight::Resources::OpenGraph, type: :model do
       allow(subject).to receive_messages id: 15, opengraph_properties: {}, exhibit: exhibit, persisted?: true
     end
 
-    let(:solr_doc) { subject.to_solr }
+    let(:solr_doc) { subject.document_builder.to_solr }
 
     it 'includes this record id' do
       expect(solr_doc).to include spotlight_resource_id_ssim: subject.to_global_id.to_s

--- a/spec/models/spotlight/resources/upload_spec.rb
+++ b/spec/models/spotlight/resources/upload_spec.rb
@@ -2,9 +2,8 @@
 describe Spotlight::Resources::Upload, type: :model do
   let!(:exhibit) { FactoryGirl.create :exhibit }
   let!(:custom_field) { FactoryGirl.create :custom_field, exhibit: exhibit }
-  before do
-    subject.exhibit = exhibit
-  end
+  let(:resource) { described_class.new(exhibit: exhibit) }
+  let(:doc_builder) { resource.document_builder }
 
   let(:configured_fields) { [title_field] + described_class.fields(exhibit) }
   let(:title_field) { OpenStruct.new(field_name: 'configured_title_field') }
@@ -19,22 +18,23 @@ describe Spotlight::Resources::Upload, type: :model do
   end
 
   before do
-    allow(subject).to receive(:configured_fields).and_return configured_fields
+    allow(resource).to receive(:configured_fields).and_return configured_fields
     allow(described_class).to receive(:fields).and_return configured_fields
 
-    allow(subject.send(:blacklight_solr)).to receive(:update)
+    allow(resource.send(:blacklight_solr)).to receive(:update)
     allow(Spotlight::Engine.config).to receive(:upload_title_field).and_return(title_field)
-    subject.data = upload_data
-    subject.url = File.open(File.join(FIXTURES_PATH, '800x600.png'))
-    subject.save
+    resource.data = upload_data
+    resource.url = File.open(File.join(FIXTURES_PATH, '800x600.png'))
+    resource.save
   end
 
   context 'with a custom upload title field' do
     let(:title_field) { OpenStruct.new(field_name: 'configured_title_field', solr_field: :some_other_field) }
+    subject { doc_builder.to_solr }
 
     describe '#to_solr' do
       it 'stores the title field in the provided solr field' do
-        expect(subject.to_solr[:some_other_field]).to eq 'Title Data'
+        expect(subject[:some_other_field]).to eq 'Title Data'
       end
     end
   end
@@ -51,42 +51,46 @@ describe Spotlight::Resources::Upload, type: :model do
     end
 
     describe '#to_solr' do
+      subject { doc_builder.to_solr }
+
       it 'maps a single uploaded field to multiple solr fields' do
-        expect(subject.to_solr['a']).to eq 'value'
-        expect(subject.to_solr['b']).to eq 'value'
+        expect(subject['a']).to eq 'value'
+        expect(subject['b']).to eq 'value'
       end
     end
   end
 
   describe '#to_solr' do
+    subject { doc_builder.to_solr }
+
     it 'has the exhibit id and the upload id as the solr id' do
-      expect(subject.to_solr[:id]).to eq "#{subject.exhibit.id}-#{subject.id}"
+      expect(subject[:id]).to eq "#{resource.exhibit.id}-#{resource.id}"
     end
 
     it 'has a title field using the exhibit specific blacklight_config' do
-      expect(subject.to_solr['configured_title_field']).to eq 'Title Data'
+      expect(subject['configured_title_field']).to eq 'Title Data'
     end
 
     it 'has the other additional configured fields' do
-      expect(subject.to_solr[:spotlight_upload_description_tesim]).to eq 'Description Data'
-      expect(subject.to_solr[:spotlight_upload_attribution_tesim]).to eq 'Attribution Data'
-      expect(subject.to_solr[:spotlight_upload_date_tesim]).to eq 'Date Data'
+      expect(subject[:spotlight_upload_description_tesim]).to eq 'Description Data'
+      expect(subject[:spotlight_upload_attribution_tesim]).to eq 'Attribution Data'
+      expect(subject[:spotlight_upload_date_tesim]).to eq 'Date Data'
     end
 
     it 'has a spotlight_resource_type field' do
-      expect(subject.to_solr[:spotlight_resource_type_ssim]).to eq 'spotlight/resources/uploads'
+      expect(subject[:spotlight_resource_type_ssim]).to eq 'spotlight/resources/uploads'
     end
     it 'has the various image fields' do
-      expect(subject.to_solr).to have_key Spotlight::Engine.config.full_image_field
-      expect(subject.to_solr).to have_key Spotlight::Engine.config.thumbnail_field
-      expect(subject.to_solr).to have_key Spotlight::Engine.config.square_image_field
+      expect(subject).to have_key Spotlight::Engine.config.full_image_field
+      expect(subject).to have_key Spotlight::Engine.config.thumbnail_field
+      expect(subject).to have_key Spotlight::Engine.config.square_image_field
     end
     it 'has the full image dimensions fields' do
-      expect(subject.to_solr[:spotlight_full_image_height_ssm]).to eq 600
-      expect(subject.to_solr[:spotlight_full_image_width_ssm]).to eq 800
+      expect(subject[:spotlight_full_image_height_ssm]).to eq 600
+      expect(subject[:spotlight_full_image_width_ssm]).to eq 800
     end
     it 'has fields representing exhibit specific custom fields' do
-      expect(subject.to_solr[custom_field.solr_field]).to eq 'Custom Field Data'
+      expect(subject[custom_field.solr_field]).to eq 'Custom Field Data'
     end
   end
 end

--- a/spec/services/spotlight/solr_document_builder_spec.rb
+++ b/spec/services/spotlight/solr_document_builder_spec.rb
@@ -1,0 +1,22 @@
+describe Spotlight::SolrDocumentBuilder do
+  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:doc_builder) { described_class.new(resource) }
+  let(:resource) { Spotlight::Resource.new }
+
+  describe '#to_solr' do
+    subject { doc_builder.send(:to_solr) }
+
+    before do
+      allow(resource).to receive(:exhibit).and_return(exhibit)
+      allow(resource).to receive_messages(type: 'Spotlight::Resource::Something', id: 15, persisted?: true)
+    end
+    it 'includes a reference to the resource' do
+      expect(subject).to include spotlight_resource_id_ssim: resource.to_global_id.to_s
+    end
+
+    it 'includes exhibit-specific data' do
+      allow(exhibit).to receive(:solr_data).and_return(exhibit_data: true)
+      expect(subject).to include exhibit_data: true
+    end
+  end
+end


### PR DESCRIPTION
This positions us to run indexing for a document independent of a single
exhibit.

This would require changes to `spotlight-dor-resources`.

https://github.com/sul-dlss/spotlight-dor-resources/blob/master/app/models/spotlight/resources/dor_harvester.rb#L18