### PR TITLE
Bump devise_invitable to support Devise 4+

### DIFF
--- a/blacklight-spotlight.gemspec
+++ b/blacklight-spotlight.gemspec
@@ -35,7 +35,7 @@ these collections.)
   s.add_dependency 'blacklight-gallery', '>= 0.3.0'
   s.add_dependency 'blacklight-oembed', '>= 0.0.3'
   s.add_dependency 'devise', '>= 3.0'
-  s.add_dependency 'devise_invitable', '~> 1.5'
+  s.add_dependency 'devise_invitable', '~> 1.6'
   s.add_dependency 'roar-rails'
   s.add_dependency 'faraday'
   s.add_dependency 'faraday_middleware'


### PR DESCRIPTION
See:
https://github.com/plataformatec/devise/issues/4045#issuecomment-215854347

This affects our gem spotlight-dor-resources, among others.