### PR TITLE
Persist exhibit membership in the Sidecar

### DIFF
--- a/app/models/concerns/spotlight/ar_light.rb
+++ b/app/models/concerns/spotlight/ar_light.rb
@@ -66,6 +66,7 @@ module Spotlight
     def initialize(source_doc = {}, solr_response = nil)
       @association_cache = {}
       super
+      yield self if block_given?
     end
 
     # Returns true if +comparison_object+ is the same exact object, or +comparison_object+

--- a/app/models/concerns/spotlight/solr_document.rb
+++ b/app/models/concerns/spotlight/solr_document.rb
@@ -25,6 +25,12 @@ module Spotlight
     ##
     # Class-level methods
     module ClassMethods
+      def build_for_exhibit(id, exhibit)
+        new(unique_key => id) do |doc|
+          doc.sidecar(exhibit).save! # save is a nop if the sidecar isn't modified.
+        end
+      end
+
       def reindex(id)
         find(id).reindex
       rescue Blacklight::Exceptions::InvalidSolrID => e

--- a/app/models/spotlight/solr_document_sidecar.rb
+++ b/app/models/spotlight/solr_document_sidecar.rb
@@ -2,14 +2,17 @@ module Spotlight
   ##
   # Exhibit-specific metadata for indexed documents
   class SolrDocumentSidecar < ActiveRecord::Base
-    belongs_to :exhibit
-    belongs_to :document, polymorphic: true
+    belongs_to :exhibit, required: true
+    belongs_to :document, required: true, polymorphic: true
     serialize :data, Hash
 
     delegate :has_key?, :key?, to: :data
 
     def to_solr
-      { document.class.unique_key.to_sym => document.id, visibility_field => public? }.merge(data_to_solr)
+      { document.class.unique_key.to_sym => document.id,
+        visibility_field => public? }
+        .merge(data_to_solr)
+        .merge(exhibit.solr_data)
     end
 
     def private!

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -1,5 +1,6 @@
 describe SolrDocument, type: :model do
-  subject { described_class.new(id: 'abcd123') }
+  let(:document) { described_class.new(id: 'abcd123') }
+  subject { document }
   its(:to_key) { should == ['abcd123'] }
   its(:persisted?) { should be_truthy }
   before do
@@ -8,6 +9,16 @@ describe SolrDocument, type: :model do
 
   let(:exhibit) { FactoryGirl.create(:exhibit) }
   let(:exhibit_alt) { FactoryGirl.create(:exhibit) }
+
+  describe '.build_for_exhibit' do
+    let(:id) { '123abc' }
+    subject { described_class.build_for_exhibit(id, exhibit) }
+
+    it 'has a persisted sidecar' do
+      expect(subject.sidecars.first).to be_persisted
+      expect(subject.sidecars.first.exhibit).to eq exhibit
+    end
+  end
 
   it 'has tags on the exhibit' do
     expect(subject.tags_from(exhibit)).to be_empty

--- a/spec/services/spotlight/solr_document_builder_spec.rb
+++ b/spec/services/spotlight/solr_document_builder_spec.rb
@@ -13,10 +13,27 @@ describe Spotlight::SolrDocumentBuilder do
     it 'includes a reference to the resource' do
       expect(subject).to include spotlight_resource_id_ssim: resource.to_global_id.to_s
     end
+  end
 
-    it 'includes exhibit-specific data' do
-      allow(exhibit).to receive(:solr_data).and_return(exhibit_data: true)
-      expect(subject).to include exhibit_data: true
+  describe '#documents_to_index' do
+    context 'when the document belongs to more than one exhibit' do
+      let(:doc) { SolrDocument.new(id: 'abc123') }
+      let(:resource) { FactoryGirl.create(:resource) }
+      let(:resource_alt) { FactoryGirl.create(:resource) }
+      subject { resource.document_builder }
+
+      before do
+        allow(Spotlight::Engine.config).to receive(:filter_resources_by_exhibit).and_return(true)
+        allow(resource.document_builder).to receive(:to_solr).and_return(id: 'abc123')
+        allow(resource_alt.document_builder).to receive(:to_solr).and_return(id: 'abc123')
+        resource_alt.document_builder.documents_to_index.first
+      end
+
+      it 'has filter data for both exhibits' do
+        result = resource.document_builder.documents_to_index.first
+        expect(result).to include "spotlight_exhibit_slug_#{resource.exhibit.slug}_bsi"
+        expect(result).to include "spotlight_exhibit_slug_#{resource_alt.exhibit.slug}_bsi"
+      end
     end
   end
 end


### PR DESCRIPTION
This should allow items to be part of multiple exhibits.

Fixes https://github.com/sul-dlss/exhibits/issues/205.