### PR TITLE
Fail the build more quickly if Rubocop fails

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -110,4 +110,4 @@ namespace :spotlight do
   end
 end
 
-task default: [:ci, :rubocop]
+task default: [:rubocop, :ci]


### PR DESCRIPTION
Rubocop is much faster to run than the rest of the build, so put it on
the front end.  That way we use less time seeing if a build failed.