### PR TITLE
Generate list of email addresses of current site administrators, exhibit administrators, and exhibit curators

### DIFF
--- a/app/assets/javascripts/spotlight/application.js
+++ b/app/assets/javascripts/spotlight/application.js
@@ -22,5 +22,6 @@
 //= require bootstrap/carousel
 //= require bootstrap-tagsinput
 //= require jquery.serializejson
+//= require clipboard
 
 //= require_tree .

--- a/app/assets/javascripts/spotlight/copy_email_addresses.js
+++ b/app/assets/javascripts/spotlight/copy_email_addresses.js
@@ -1,0 +1,9 @@
+(function($) {
+    $.fn.copyEmailAddresses = function( options ) {
+        var clip = new Clipboard('.copy-email-addresses');
+    };
+})( jQuery );
+
+Spotlight.onLoad(function() {
+    $('.copy-email-addresses').copyEmailAddresses();
+});

--- a/app/models/concerns/spotlight/user.rb
+++ b/app/models/concerns/spotlight/user.rb
@@ -7,6 +7,8 @@ module Spotlight
       has_many :roles, class_name: 'Spotlight::Role', dependent: :destroy
       has_many :exhibits, class_name: 'Spotlight::Exhibit', through: :roles, source: 'resource', source_type: 'Spotlight::Exhibit'
 
+      scope :with_roles, -> { where(id: Spotlight::Role.uniq.pluck(:user_id)) }
+
       before_create :add_default_roles
     end
 

--- a/app/views/spotlight/admin_users/index.html.erb
+++ b/app/views/spotlight/admin_users/index.html.erb
@@ -50,6 +50,16 @@
       </div>
     </div>
   <% end %>
+
+  <p class="instructions"><%= t :'.all_users' %></p>
+  <div id="all_users" class="well well-sm">
+      <div class='btn-toolbar pull-right'>
+          <button class="btn btn-xs btn-default copy-email-addresses" data-clipboard-target="#all_users">
+              Copy
+          </button>
+      </div>
+      <%= Spotlight::Engine.user_class.with_roles.pluck(:email).sort.join(', ') %>
+  </div>
 </div>
 
 <aside class="col-md-3">

--- a/blacklight-spotlight.gemspec
+++ b/blacklight-spotlight.gemspec
@@ -48,6 +48,7 @@ these collections.)
   s.add_dependency 'oauth2'
   s.add_dependency 'paper_trail', '~> 5.0'
   s.add_dependency 'openseadragon'
+  s.add_dependency 'clipboard-rails', '~> 1.5'
 
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'rspec-rails', '~> 3.1'

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -136,6 +136,8 @@ en:
         section: Manage exhibits
         page_title: Manage administrators
         instructions: Existing exhibits administrators
+        all_users: Administrators and curators of all exhibits
+        copy: Copy
         add: Add new administrator
         destroy: Remove from role
         save: Add role

--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -10,6 +10,7 @@ require 'autoprefixer-rails'
 require 'friendly_id'
 require 'tophat'
 require 'paper_trail'
+require 'clipboard/rails'
 
 module Spotlight
   ##

--- a/spec/features/site_admin_management_spec.rb
+++ b/spec/features/site_admin_management_spec.rb
@@ -1,6 +1,8 @@
 describe 'Site admin management', js: true do
   let(:user) { FactoryGirl.create(:site_admin) }
-  let(:existing_user) { FactoryGirl.create(:exhibit_visitor) }
+  let!(:existing_user) { FactoryGirl.create(:exhibit_visitor) }
+  let!(:exhibit_admin) { FactoryGirl.create(:exhibit_admin) }
+  let!(:exhibit_curator) { FactoryGirl.create(:exhibit_curator) }
 
   before do
     login_as(user)
@@ -9,6 +11,16 @@ describe 'Site admin management', js: true do
 
   it 'displays the current admin users' do
     expect(page).to have_css('td', text: user.email)
+  end
+
+  describe 'copy email addresses' do
+    it 'displays only email addresses of users w/ roles' do
+      expect(page).to have_css('div#all_users', text: user.email)
+      expect(page).to have_css('div#all_users', text: exhibit_admin.email)
+      expect(page).to have_css('div#all_users', text: exhibit_curator.email)
+      expect(page).not_to have_css('div#all_users', text: existing_user.email)
+      expect(page).to have_css('button.copy-email-addresses')
+    end
   end
 
   it 'allows for existing users to be added as site adminstrators' do


### PR DESCRIPTION
Fixes #1472

Implementation:

![screenshot from 2016-08-03 10-06-44](https://cloud.githubusercontent.com/assets/131982/17374675/996298a4-5962-11e6-8834-fd6d7f8f8515.png)

Copy button color changes on hover:

![screenshot from 2016-08-03 10-06-50](https://cloud.githubusercontent.com/assets/131982/17374687/a7e908c2-5962-11e6-8ddc-32108f5ac460.png)

Addresses are highlighted when button is pressed (and they are copied to the clipboard):

![screenshot from 2016-08-03 10-06-55](https://cloud.githubusercontent.com/assets/131982/17374702/b7b03794-5962-11e6-871c-45e5ee5c9d8d.png)
