### PR TITLE
Parameterize configuration keys in Nestable's data-id attribute.

### DIFF
--- a/app/views/spotlight/search_configurations/_search_fields.html.erb
+++ b/app/views/spotlight/search_configurations/_search_fields.html.erb
@@ -31,7 +31,7 @@
     <div class="panel-group dd search_fields_admin col-sm-7" id="nested-search-fields" data-behavior="nestable" data-max-depth="1">
       <ol class="dd-list">
         <% @blacklight_configuration.blacklight_config.search_fields.select { |_k, v| v.include_in_simple_select != false }.except(default_field.key).each_with_index do |(k, config), index| %>
-            <li class="dd-item dd3-item" data-id="<%= k %>-id">
+            <li class="dd-item dd3-item" data-id="<%= k.parameterize %>-id">
               <div class="dd3-content panel panel-default">
                 <div class="dd-handle dd3-handle"><%= t(:drag) %></div>
                 <div class="panel-heading" data-behavior="restore-default">

--- a/app/views/spotlight/search_configurations/_sort.html.erb
+++ b/app/views/spotlight/search_configurations/_sort.html.erb
@@ -26,7 +26,7 @@
     <div class="panel-group dd sort_fields_admin col-sm-7" id="nested-sort-fields" data-behavior="nestable" data-max-depth="1">
       <ol class="dd-list">
         <% @blacklight_configuration.blacklight_config.sort_fields.except(default_field.key).each_with_index do |(k, config), index| %>
-            <li class="dd-item dd3-item" data-id="<%= k %>-id">
+            <li class="dd-item dd3-item" data-id="<%= k.parameterize %>-id">
               <div class="dd3-content panel panel-default">
                 <div class="dd-handle dd3-handle"><%= t(:drag) %></div>
                 <div class="panel-heading" data-behavior="restore-default">

--- a/spec/views/spotlight/search_configurations/_search_fields.html.erb_spec.rb
+++ b/spec/views/spotlight/search_configurations/_search_fields.html.erb_spec.rb
@@ -13,6 +13,7 @@ describe 'spotlight/search_configurations/_search_fields', type: :view do
     assign(:blacklight_configuration, exhibit.blacklight_configuration)
     allow(view).to receive_messages(current_exhibit: exhibit)
     exhibit.blacklight_config.add_search_field 'some_hidden_field', include_in_simple_select: false
+    exhibit.blacklight_config.add_search_field 'some_field with_a_space'
     render partial: 'spotlight/search_configurations/search_fields', locals: { f: f }
   end
 
@@ -36,5 +37,9 @@ describe 'spotlight/search_configurations/_search_fields', type: :view do
   it 'excludes search options that do not show up in the search dropdown' do
     expect(rendered).not_to have_selector "input[name='blacklight_configuration[search_fields][autocomplete][enabled]']"
     expect(rendered).not_to have_selector "input[name='blacklight_configuration[search_fields][some_hidden_field][enabled]']"
+  end
+
+  it 'parameterizes the data-id attribute for searcn field keh' do
+    expect(rendered).to have_selector '[data-id="some_field-with_a_space-id"]'
   end
 end

--- a/spec/views/spotlight/search_configurations/_sort.html.erb_spec.rb
+++ b/spec/views/spotlight/search_configurations/_sort.html.erb_spec.rb
@@ -1,6 +1,7 @@
 describe 'spotlight/search_configurations/_sort', type: :view do
   let(:exhibit) { FactoryGirl.create(:exhibit) }
   before do
+    exhibit.blacklight_config.add_sort_field 'sort_title_ssi asc, plus_another_field desc', label: 'TestSort'
     assign(:exhibit, exhibit)
     assign(:blacklight_configuration, exhibit.blacklight_configuration)
     allow(view).to receive_messages(
@@ -20,5 +21,10 @@ describe 'spotlight/search_configurations/_sort', type: :view do
   it 'has a disabled relevance sort option' do
     render partial: 'spotlight/search_configurations/sort', locals: { f: f }
     expect(rendered).to have_selector "input[name='blacklight_configuration[sort_fields][relevance][enable]'][disabled='disabled']"
+  end
+
+  it 'parameterizes the data-id attribute for sort fields (e.g. when no key is supplied and the sort is used as the key)' do
+    render partial: 'spotlight/search_configurations/sort', locals: { f: f }
+    expect(rendered).to have_css('[data-id="sort_title_ssi-asc-plus_another_field-desc-id"]')
   end
 end


### PR DESCRIPTION
Fixes #1608 

## Before
![sort-fields-before](https://cloud.githubusercontent.com/assets/96776/18560997/dbbb1694-7b32-11e6-8e5d-600d22300ffe.gif)

## After
![sort-fields-after](https://cloud.githubusercontent.com/assets/96776/18560998/dbccd8fc-7b32-11e6-9d73-a03e60b768b2.gif)


@ggeisler it would be helpful if you could validate that the behavior in the **Before** gif was what you were seeing on the exhibits site (particularly the empty dotted border).