### PR TITLE
Remove explicit disabling of papertrail associations in test app…

### DIFF
--- a/blacklight-spotlight.gemspec
+++ b/blacklight-spotlight.gemspec
@@ -29,7 +29,7 @@ these collections.)
   s.add_dependency 'mini_magick'
   s.add_dependency 'bootstrap_form', '~> 2.2'
   s.add_dependency 'acts-as-taggable-on', '>= 4.0.0.pre'
-  s.add_dependency 'friendly_id', '>= 5.2.0.beta.1', '< 6'
+  s.add_dependency 'friendly_id', '~> 5.2'
   s.add_dependency 'breadcrumbs_on_rails', '~> 2.3.0'
   s.add_dependency 'blacklight-gallery', '>= 0.3.0'
   s.add_dependency 'blacklight-oembed', '>= 0.0.3'

--- a/lib/generators/spotlight/install_generator.rb
+++ b/lib/generators/spotlight/install_generator.rb
@@ -17,9 +17,6 @@ module Spotlight
     end
 
     def friendly_id
-      gem 'friendly_id', github: 'norman/friendly_id'
-      # we need to immediately run `bundle install` while pointing at github.
-      Bundler.with_clean_env { run 'bundle install' }
       generate 'friendly_id'
     end
 

--- a/spec/test_app_templates/Gemfile.extra
+++ b/spec/test_app_templates/Gemfile.extra
@@ -1,1 +1,0 @@
-gem 'friendly_id', github: 'norman/friendly_id'

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -47,12 +47,4 @@ class TestAppGenerator < Rails::Generators::Base
 EOF
     end
   end
-
-  def disable_papertrail_associations
-    initializer 'paper_trail.rb' do
-      <<-EOF
-        PaperTrail.config.track_associations = false
-      EOF
-    end
-  end
 end


### PR DESCRIPTION
…generator.

This file is already generated as-is by the papertrail installer.

See https://github.com/airblade/paper_trail/blob/c37e48973d8006edf635c72d5c742ce2d76c2f25/lib/generators/paper_trail/install_generator.rb#L38 which appears to set it to false by default.