### PR TITLE
Make autocomplete results with many items more usable

### DIFF
--- a/app/assets/javascripts/spotlight/block_mixins/autocompleteable.js
+++ b/app/assets/javascripts/spotlight/block_mixins/autocompleteable.js
@@ -60,7 +60,7 @@
           return Bloodhound.tokenizers.whitespace(d.title);
         },
         queryTokenizer: Bloodhound.tokenizers.whitespace,
-        limit: 10,
+        limit: 100,
       }, block.bloodhoundOptions()));
       results.initialize();
       return results;

--- a/app/assets/javascripts/spotlight/catalog_edit.js
+++ b/app/assets/javascripts/spotlight/catalog_edit.js
@@ -7,7 +7,7 @@ Spotlight.onLoad(function() {
     var tags = new Bloodhound({
       datumTokenizer: function(d) { return Bloodhound.tokenizers.whitespace(d.name); },
       queryTokenizer: Bloodhound.tokenizers.whitespace,
-      limit: 10,
+      limit: 100,
       prefetch: {
         url: $('#solr_document_exhibit_tag_list').data('autocomplete_url'),
         ttl: 1,
@@ -45,6 +45,6 @@ Spotlight.onLoad(function() {
               docTarget.addClass("blacklight-private");
             }
           }
-      }); 
+      });
 
 });

--- a/app/assets/javascripts/spotlight/search_typeahead.js
+++ b/app/assets/javascripts/spotlight/search_typeahead.js
@@ -31,10 +31,10 @@
 function itemsBloodhound() {
   var results = new Bloodhound({
     datumTokenizer: function(d) {
-      return Bloodhound.tokenizers.whitespace(d.title); 
+      return Bloodhound.tokenizers.whitespace(d.title);
     },
     queryTokenizer: Bloodhound.tokenizers.whitespace,
-    limit: 10,
+    limit: 100,
     remote: {
       url: $('form[data-autocomplete-exhibit-catalog-path]').data('autocomplete-exhibit-catalog-path').replace("%25QUERY", "%QUERY"),
       filter: function(response) {

--- a/app/assets/stylesheets/spotlight/_sir-trevor_overrides.scss
+++ b/app/assets/stylesheets/spotlight/_sir-trevor_overrides.scss
@@ -17,6 +17,12 @@
   margin-bottom: 3*$padding-large-vertical;
 }
 
+// Sir-trevor sets the overflow to hidden which
+// obscures the bottom of things like the typeahead
+.st-block {
+  overflow: visible;
+}
+
 .st-block__inner {
   border: 1px solid $gray-lighter;
   box-shadow: 3px 3px 15px $gray-lighter;

--- a/app/assets/stylesheets/spotlight/typeahead.css
+++ b/app/assets/stylesheets/spotlight/typeahead.css
@@ -22,6 +22,8 @@
 .tt-dropdown-menu {
   z-index: 1000 !important;
   margin-top: 2px;
+  max-height: 360px;
+  overflow-y: auto;
   padding: 8px 0;
   background-color: #fff;
   border: 1px solid #ccc;

--- a/app/controllers/spotlight/catalog_controller.rb
+++ b/app/controllers/spotlight/catalog_controller.rb
@@ -53,7 +53,7 @@ module Spotlight
     # results when a partial match is passed in the "q" parameter.
     def autocomplete
       search_params = params.merge(search_field: Spotlight::Engine.config.autocomplete_search_field)
-      (_, @document_list) = search_results(search_params.merge(public: true))
+      (_, @document_list) = search_results(search_params.merge(public: true, rows: 100))
 
       respond_to do |format|
         format.json do


### PR DESCRIPTION
Closes #1603 

- [x] Allow more that 10 items to be returned in autocomplete results.
- [x] Allow autocomplete pop-up to scroll after ~5 items.
- [x] Override sir-trevor block overflow styling to prevent the autocomplete pop-up from being obscured.

## Before
<img width="707" alt="dropdown-before" src="https://cloud.githubusercontent.com/assets/96776/18680938/89a4a208-7f1a-11e6-8dec-1b6893816263.png">

## After
![dropdown-after](https://cloud.githubusercontent.com/assets/96776/18680937/89a19d92-7f1a-11e6-9504-096e800695e3.gif)

