### PR TITLE
1570 contact avatars

### DIFF
--- a/app/assets/stylesheets/spotlight/_pages.scss
+++ b/app/assets/stylesheets/spotlight/_pages.scss
@@ -108,6 +108,7 @@
   float: left;
   margin-right: 15px;
   margin-top: 3px;
+  max-height: 70px;
 }
 
 // Indent contact fields so they align evenly, only when there is a contact photo

--- a/app/controllers/spotlight/contacts_controller.rb
+++ b/app/controllers/spotlight/contacts_controller.rb
@@ -56,7 +56,8 @@ module Spotlight
     def contact_params
       params.require(:contact).permit(:name,
                                       :avatar_id,
-                                      contact_info: Spotlight::Contact.fields.keys)
+                                      contact_info: Spotlight::Contact.fields.keys,
+                                      avatar_attributes: [:iiif_url])
     end
   end
 end

--- a/spec/controllers/spotlight/contacts_controller_spec.rb
+++ b/spec/controllers/spotlight/contacts_controller_spec.rb
@@ -69,6 +69,7 @@ describe Spotlight::ContactsController, type: :controller do
         end.to change { Spotlight::Contact.count }.by(1)
         expect(response).to redirect_to exhibit_about_pages_path(exhibit)
         expect(Spotlight::Contact.last.show_in_sidebar).to be_truthy
+        expect(Spotlight::Contact.last.avatar.iiif_url).to be_present
       end
     end
   end

--- a/spec/features/add_contacts_spec.rb
+++ b/spec/features/add_contacts_spec.rb
@@ -41,19 +41,17 @@ describe 'Add a contact to an exhibit', type: :feature do
   end
 
   it "allows the curator to crop the contact's avatar", js: true do
-    skip "Capyabara and jcrop don't play well together.."
-
     visit spotlight.exhibit_about_pages_path(exhibit)
     click_link 'Add contact'
-    page.document.synchronize do
-      find('.jcrop-holder')
-    end
+
     within '#new_contact' do
       fill_in 'Name', with: 'Pictured User'
       fill_in 'Email', with: 'marcus@rome.gov'
       attach_file('contact_avatar', File.absolute_path(File.join(FIXTURES_PATH, 'avatar.png')))
+      click_button 'Save'
     end
     expect(page).to have_content 'The contact was created.'
     expect(page).to have_selector 'img.contact-photo'
+    expect(Spotlight::Contact.last.avatar.iiif_url).to be_present
   end
 end


### PR DESCRIPTION
also:
* limit avatar height/width to 70px
* fix/augment tests to check for avatar info in DB for newly created contact

closes #1570 