### PR TITLE
remove remaining jcrop references

### DIFF
--- a/app/assets/stylesheets/spotlight/typeahead.css
+++ b/app/assets/stylesheets/spotlight/typeahead.css
@@ -37,7 +37,6 @@
 }
 
 .twitter-typeahead {
-  z-index: 1000 !important; /* get typeahead to float on top of e.g. jcrop */
   .tt-suggestion {
     font-size: 18px;
     line-height: 24px;

--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -15,7 +15,6 @@ require 'clipboard/rails'
 module Spotlight
   ##
   # Spotlight::Engine
-  # rubocop:disable Metrics/ClassLength
   class Engine < ::Rails::Engine
     isolate_namespace Spotlight
     # Breadcrumbs on rails must be required outside of an initializer or it doesn't get loaded.
@@ -138,10 +137,6 @@ module Spotlight
     config.featured_image_thumb_size = [400, 300]
     config.featured_image_square_size = '400,'
     config.contact_square_size = [70, 70]
-
-    initializer 'spotlight-assets.initialize' do
-      Rails.application.config.assets.precompile += %w(Jcrop.gif)
-    end
 
     # To present curators with analytics reports on the exhibit dashboard, you need to configure
     # an Analytics provider. Google Analytics support is provided out-of-the-box.

--- a/spec/features/exhibit_masthead_spec.rb
+++ b/spec/features/exhibit_masthead_spec.rb
@@ -87,7 +87,8 @@ describe 'Add and update the site masthead', type: :feature do
   end
 
   it 'displays a masthead image when one is uploaded from an exhibit item', js: true do
-    skip "Capyabara and jcrop don't play well together.."
+    skip "Capyabara and the cropping tool don't play well together.."
+
     visit spotlight.exhibit_dashboard_path(exhibit)
     expect(page).to_not have_css('.image-masthead')
     within '#sidebar' do


### PR DESCRIPTION
also, get rid of no-longer-applicable `rubocop:disable` statement

note that there are still a couple references to jcrop in add_contacts_spec.rb, but those should be taken care of by PR #1643.

closes #1623