### PR TITLE
style sir trevor quote widget to make quotation more visually distinct

### DIFF
--- a/app/assets/stylesheets/spotlight/_sir-trevor_overrides.scss
+++ b/app/assets/stylesheets/spotlight/_sir-trevor_overrides.scss
@@ -17,6 +17,12 @@
   margin-bottom: 3*$padding-large-vertical;
 }
 
+.quote__content {
+  border-left: 0.4em solid $gray-lighter;
+  color: $gray;
+  padding: 0 1em;
+}
+
 // Sir-trevor sets the overflow to hidden which
 // obscures the bottom of things like the typeahead
 .st-blocks {


### PR DESCRIPTION
~~leaving as WIP because i wasn't sure if this needed a test, and if so, where that test should go.~~ (ran it by @jkeck, we agreed that a new test was unnecessary since it's just a small CSS addition)

i basically ripped off and adapted the styling that github uses for quotes.

after the styling change:
![screen shot 2016-12-12 at 4 06 50 pm](https://cloud.githubusercontent.com/assets/7741604/21122084/0c63f4f4-c085-11e6-96ec-3ab193585b52.png)

closes #1604 