### PR TITLE
add non-visible field for catching spammy feedback submissions, add tests for field validation

### DIFF
--- a/app/controllers/spotlight/contact_forms_controller.rb
+++ b/app/controllers/spotlight/contact_forms_controller.rb
@@ -29,7 +29,7 @@ module Spotlight
     end
 
     def contact_form_params
-      params.require(:contact_form).permit(:name, :email, :message, :current_url)
+      params.require(:contact_form).permit(:name, :email, Spotlight::Engine.config.spambot_honeypot_email_field, :message, :current_url)
     end
   end
 end

--- a/app/models/spotlight/contact_form.rb
+++ b/app/models/spotlight/contact_form.rb
@@ -4,9 +4,16 @@ module Spotlight
   class ContactForm
     include ActiveModel::Model
 
-    attr_accessor :current_exhibit, :name, :email, :message, :current_url, :request
+    attr_accessor :current_exhibit, :name, :email, Spotlight::Engine.config.spambot_honeypot_email_field, :message, :current_url, :request
 
     validates :email, format: { with: /\A([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})\z/i }
+
+    # the spambot_honeypot_email_field field is intended to be hidden visually from the user,
+    # in hope that a spam bot filling out the form will enter a value, whereas a human with a
+    # browser wouldn't, allowing us to differentiate and reject likely spam messages.
+    # the field must be present, since we expect real users to just submit the form as-is w/o
+    # hacking what fields are present.
+    validates Spotlight::Engine.config.spambot_honeypot_email_field, length: { is: 0 }
 
     def headers
       {

--- a/app/views/spotlight/contact_forms/new.html.erb
+++ b/app/views/spotlight/contact_forms/new.html.erb
@@ -3,7 +3,12 @@
   <h1 class="page-title"><%= t(:'.header') %></h1>
   <div class="row">
     <%= f.text_field :name %>
-    <%= f.text_field :email %>
+    <span style="display:none;visibility:hidden;">
+      <% honeypot_field_name = Spotlight::Engine.config.spambot_honeypot_email_field %>
+      <%= label_tag(honeypot_field_name, t(:'.honeypot_field_explanation')) %><br/>
+      <%= f.email_field honeypot_field_name %>
+    </span>
+    <%= f.email_field :email %>
     <%= f.text_area :message, rows: 7 %>
     <%= f.hidden_field :current_url %>
     <div class="form-actions">

--- a/app/views/spotlight/shared/_report_a_problem.html.erb
+++ b/app/views/spotlight/shared/_report_a_problem.html.erb
@@ -6,7 +6,12 @@
 
     <h2><%= t(:'.title') %></h2>
     <%= f.text_field :name %>
-    <%= f.text_field :email %>
+    <span style="display:none;visibility:hidden;">
+      <% honeypot_field_name = Spotlight::Engine.config.spambot_honeypot_email_field %>
+      <%= label_tag(honeypot_field_name, t(:'.honeypot_field_explanation')) %><br/>
+      <%= f.email_field honeypot_field_name %>
+    </span>
+    <%= f.email_field :email %>
     <%= f.text_area :message, rows: 7 %>
     <%= f.hidden_field :current_url %>
     <div class="form-actions">

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -172,6 +172,7 @@ en:
     contact_forms:
       new:
         header: "Feedback"
+        honeypot_field_explanation: 'Ignore this text box. It is used to detect spammers. If you enter anything into this text box, your message will not be sent.'
     curation:
       sidebar:
         header: Curation
@@ -650,6 +651,7 @@ en:
     shared:
       report_a_problem:
         title: Contact Us
+        honeypot_field_explanation: 'Ignore this text box. It is used to detect spammers. If you enter anything into this text box, your message will not be sent.'
     indexing_complete_mailer:
       documents_indexed:
         title: "Your CSV file has just finished being processed."

--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -15,6 +15,7 @@ require 'clipboard/rails'
 module Spotlight
   ##
   # Spotlight::Engine
+  # rubocop:disable ClassLength
   class Engine < ::Rails::Engine
     isolate_namespace Spotlight
     # Breadcrumbs on rails must be required outside of an initializer or it doesn't get loaded.
@@ -171,6 +172,8 @@ module Spotlight
 
     # default email address to send "Report a Problem" feedback to (in addition to any exhibit-specific contacts)
     config.default_contact_email = nil
+
+    config.spambot_honeypot_email_field = :email_address
 
     initializer 'blacklight.configuration' do
       # Field containing the last modified date for a Solr document

--- a/spec/controllers/spotlight/contact_forms_controller_spec.rb
+++ b/spec/controllers/spotlight/contact_forms_controller_spec.rb
@@ -1,6 +1,8 @@
 describe Spotlight::ContactFormsController, type: :controller do
   routes { Spotlight::Engine.routes }
   let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:honeypot_field_name) { Spotlight::Engine.config.spambot_honeypot_email_field }
+
   before do
     request.env['HTTP_REFERER'] = 'http://example.com'
     exhibit.contact_emails_attributes = [{ 'email' => 'test@example.com' }, { 'email' => 'test2@example.com' }]
@@ -16,15 +18,15 @@ describe Spotlight::ContactFormsController, type: :controller do
   describe 'POST create' do
     it 'sends an email' do
       expect do
-        post :create, params: { exhibit_id: exhibit.id, contact_form: { name: 'Joe Doe', email: 'jdoe@example.com' } }
+        post :create, params: { exhibit_id: exhibit.id, contact_form: { name: 'Joe Doe', email: 'jdoe@example.com', honeypot_field_name => '' } }
       end.to change { ActionMailer::Base.deliveries.count }.by(1)
     end
     it 'redirects back' do
-      post :create, params: { exhibit_id: exhibit.id, contact_form: { name: 'Joe Doe', email: 'jdoe@example.com' } }
+      post :create, params: { exhibit_id: exhibit.id, contact_form: { name: 'Joe Doe', email: 'jdoe@example.com', honeypot_field_name => '' } }
       expect(response).to redirect_to 'http://example.com'
     end
     it 'sets a flash message' do
-      post :create, params: { exhibit_id: exhibit.id, contact_form: { name: 'Joe Doe', email: 'jdoe@example.com' } }
+      post :create, params: { exhibit_id: exhibit.id, contact_form: { name: 'Joe Doe', email: 'jdoe@example.com', honeypot_field_name => '' } }
       expect(flash[:notice]).to eq 'Thanks. Your feedback has been sent.'
     end
   end


### PR DESCRIPTION
also, turn the email fields from text fields to proper HTML email fields.

here's a screenshot of the feedback form, with the new DOM element for the (visually) hidden form field in view in the debugger:
![screen shot 2016-12-13 at 6 17 24 pm](https://cloud.githubusercontent.com/assets/7741604/21167323/9f974bc8-c160-11e6-9527-a37eacaa4904.png)


paired w/ @jkeck.

closes sul-dlss/exhibits#345