### PR TITLE
[WIP] put the spambot honeypot field name in the config to make usage clearer in the code

### DIFF
--- a/app/controllers/spotlight/contact_forms_controller.rb
+++ b/app/controllers/spotlight/contact_forms_controller.rb
@@ -29,7 +29,7 @@ module Spotlight
     end
 
     def contact_form_params
-      params.require(:contact_form).permit(:name, :email, :message, :current_url)
+      params.require(:contact_form).permit(:name, :email, :email_address, :message, :current_url)
     end
   end
 end

--- a/app/controllers/spotlight/contact_forms_controller.rb
+++ b/app/controllers/spotlight/contact_forms_controller.rb
@@ -29,7 +29,7 @@ module Spotlight
     end
 
     def contact_form_params
-      params.require(:contact_form).permit(:name, :email, :email_address, :message, :current_url)
+      params.require(:contact_form).permit(:name, :email, Spotlight::Engine.config.spambot_honeypot_email_field, :message, :current_url)
     end
   end
 end

--- a/app/models/spotlight/contact_form.rb
+++ b/app/models/spotlight/contact_form.rb
@@ -8,12 +8,12 @@ module Spotlight
 
     validates :email, format: { with: /\A([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})\z/i }
 
-    # the email_address field is intended to be hidden visually from the user, in hope that
-    # a spam bot filling out the form will enter a value, whereas a human with a browser wouldn't,
-    # allowing us to differentiate and reject likely spam messages.
+    # the spambot_honeypot_email_field field is intended to be hidden visually from the user,
+    # in hope that a spam bot filling out the form will enter a value, whereas a human with a
+    # browser wouldn't, allowing us to differentiate and reject likely spam messages.
     # the field must be present, since we expect real users to just submit the form as-is w/o
     # hacking what fields are present.
-    validates :email_address, length: { is: 0 }
+    validates Spotlight::Engine.config.spambot_honeypot_email_field, length: { is: 0 }
 
     def headers
       {

--- a/app/models/spotlight/contact_form.rb
+++ b/app/models/spotlight/contact_form.rb
@@ -4,9 +4,16 @@ module Spotlight
   class ContactForm
     include ActiveModel::Model
 
-    attr_accessor :current_exhibit, :name, :email, :message, :current_url, :request
+    attr_accessor :current_exhibit, :name, :email, :email_address, :message, :current_url, :request
 
     validates :email, format: { with: /\A([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})\z/i }
+
+    # the email_address field is intended to be hidden visually from the user, in hope that
+    # a spam bot filling out the form will enter a value, whereas a human with a browser wouldn't,
+    # allowing us to differentiate and reject likely spam messages.
+    # the field must be present, since we expect real users to just submit the form as-is w/o
+    # hacking what fields are present.
+    validates :email_address, length: { is: 0 }
 
     def headers
       {

--- a/app/views/spotlight/contact_forms/new.html.erb
+++ b/app/views/spotlight/contact_forms/new.html.erb
@@ -4,8 +4,9 @@
   <div class="row">
     <%= f.text_field :name %>
     <span style="display:none;visibility:hidden;">
-      <%= label_tag(:email_address, 'Ignore this text box. It is used to detect spammers. If you enter anything into this text box, your message will not be sent.') %><br/>
-      <%= f.email_field :email_address %>
+      <% honeypot_field_name = Spotlight::Engine.config.spambot_honeypot_email_field %>
+      <%= label_tag(honeypot_field_name, t(:'.honeypot_field_explanation')) %><br/>
+      <%= f.email_field honeypot_field_name %>
     </span>
     <%= f.email_field :email %>
     <%= f.text_area :message, rows: 7 %>

--- a/app/views/spotlight/contact_forms/new.html.erb
+++ b/app/views/spotlight/contact_forms/new.html.erb
@@ -3,7 +3,11 @@
   <h1 class="page-title"><%= t(:'.header') %></h1>
   <div class="row">
     <%= f.text_field :name %>
-    <%= f.text_field :email %>
+    <span style="display:none;visibility:hidden;">
+      <%= label_tag(:email_address, 'Ignore this text box. It is used to detect spammers. If you enter anything into this text box, your message will not be sent.') %><br/>
+      <%= f.email_field :email_address %>
+    </span>
+    <%= f.email_field :email %>
     <%= f.text_area :message, rows: 7 %>
     <%= f.hidden_field :current_url %>
     <div class="form-actions">

--- a/app/views/spotlight/shared/_report_a_problem.html.erb
+++ b/app/views/spotlight/shared/_report_a_problem.html.erb
@@ -6,7 +6,11 @@
 
     <h2><%= t(:'.title') %></h2>
     <%= f.text_field :name %>
-    <%= f.text_field :email %>
+    <span style="display:none;visibility:hidden;">
+      <%= label_tag(:email_address, 'Ignore this text box. It is used to detect spammers. If you enter anything into this text box, your message will not be sent.') %><br/>
+      <%= f.email_field :email_address %>
+    </span>
+    <%= f.email_field :email %>
     <%= f.text_area :message, rows: 7 %>
     <%= f.hidden_field :current_url %>
     <div class="form-actions">

--- a/app/views/spotlight/shared/_report_a_problem.html.erb
+++ b/app/views/spotlight/shared/_report_a_problem.html.erb
@@ -7,8 +7,9 @@
     <h2><%= t(:'.title') %></h2>
     <%= f.text_field :name %>
     <span style="display:none;visibility:hidden;">
-      <%= label_tag(:email_address, 'Ignore this text box. It is used to detect spammers. If you enter anything into this text box, your message will not be sent.') %><br/>
-      <%= f.email_field :email_address %>
+      <% honeypot_field_name = Spotlight::Engine.config.spambot_honeypot_email_field %>
+      <%= label_tag(honeypot_field_name, t(:'.honeypot_field_explanation')) %><br/>
+      <%= f.email_field honeypot_field_name %>
     </span>
     <%= f.email_field :email %>
     <%= f.text_area :message, rows: 7 %>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -172,6 +172,7 @@ en:
     contact_forms:
       new:
         header: "Feedback"
+        honeypot_field_explanation: 'Ignore this text box. It is used to detect spammers. If you enter anything into this text box, your message will not be sent.'
     curation:
       sidebar:
         header: Curation
@@ -650,6 +651,7 @@ en:
     shared:
       report_a_problem:
         title: Contact Us
+        honeypot_field_explanation: 'Ignore this text box. It is used to detect spammers. If you enter anything into this text box, your message will not be sent.'
     indexing_complete_mailer:
       documents_indexed:
         title: "Your CSV file has just finished being processed."

--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -15,6 +15,7 @@ require 'clipboard/rails'
 module Spotlight
   ##
   # Spotlight::Engine
+  # rubocop:disable ClassLength
   class Engine < ::Rails::Engine
     isolate_namespace Spotlight
     # Breadcrumbs on rails must be required outside of an initializer or it doesn't get loaded.
@@ -171,6 +172,8 @@ module Spotlight
 
     # default email address to send "Report a Problem" feedback to (in addition to any exhibit-specific contacts)
     config.default_contact_email = nil
+
+    config.spambot_honeypot_email_field = :email_address
 
     initializer 'blacklight.configuration' do
       # Field containing the last modified date for a Solr document

--- a/spec/controllers/spotlight/contact_forms_controller_spec.rb
+++ b/spec/controllers/spotlight/contact_forms_controller_spec.rb
@@ -16,15 +16,15 @@ describe Spotlight::ContactFormsController, type: :controller do
   describe 'POST create' do
     it 'sends an email' do
       expect do
-        post :create, params: { exhibit_id: exhibit.id, contact_form: { name: 'Joe Doe', email: 'jdoe@example.com' } }
+        post :create, params: { exhibit_id: exhibit.id, contact_form: { name: 'Joe Doe', email: 'jdoe@example.com', email_address: '' } }
       end.to change { ActionMailer::Base.deliveries.count }.by(1)
     end
     it 'redirects back' do
-      post :create, params: { exhibit_id: exhibit.id, contact_form: { name: 'Joe Doe', email: 'jdoe@example.com' } }
+      post :create, params: { exhibit_id: exhibit.id, contact_form: { name: 'Joe Doe', email: 'jdoe@example.com', email_address: '' } }
       expect(response).to redirect_to 'http://example.com'
     end
     it 'sets a flash message' do
-      post :create, params: { exhibit_id: exhibit.id, contact_form: { name: 'Joe Doe', email: 'jdoe@example.com' } }
+      post :create, params: { exhibit_id: exhibit.id, contact_form: { name: 'Joe Doe', email: 'jdoe@example.com', email_address: '' } }
       expect(flash[:notice]).to eq 'Thanks. Your feedback has been sent.'
     end
   end

--- a/spec/controllers/spotlight/contact_forms_controller_spec.rb
+++ b/spec/controllers/spotlight/contact_forms_controller_spec.rb
@@ -1,6 +1,8 @@
 describe Spotlight::ContactFormsController, type: :controller do
   routes { Spotlight::Engine.routes }
   let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:honeypot_field_name) { Spotlight::Engine.config.spambot_honeypot_email_field }
+
   before do
     request.env['HTTP_REFERER'] = 'http://example.com'
     exhibit.contact_emails_attributes = [{ 'email' => 'test@example.com' }, { 'email' => 'test2@example.com' }]
@@ -16,15 +18,15 @@ describe Spotlight::ContactFormsController, type: :controller do
   describe 'POST create' do
     it 'sends an email' do
       expect do
-        post :create, params: { exhibit_id: exhibit.id, contact_form: { name: 'Joe Doe', email: 'jdoe@example.com', email_address: '' } }
+        post :create, params: { exhibit_id: exhibit.id, contact_form: { name: 'Joe Doe', email: 'jdoe@example.com', honeypot_field_name => '' } }
       end.to change { ActionMailer::Base.deliveries.count }.by(1)
     end
     it 'redirects back' do
-      post :create, params: { exhibit_id: exhibit.id, contact_form: { name: 'Joe Doe', email: 'jdoe@example.com', email_address: '' } }
+      post :create, params: { exhibit_id: exhibit.id, contact_form: { name: 'Joe Doe', email: 'jdoe@example.com', honeypot_field_name => '' } }
       expect(response).to redirect_to 'http://example.com'
     end
     it 'sets a flash message' do
-      post :create, params: { exhibit_id: exhibit.id, contact_form: { name: 'Joe Doe', email: 'jdoe@example.com', email_address: '' } }
+      post :create, params: { exhibit_id: exhibit.id, contact_form: { name: 'Joe Doe', email: 'jdoe@example.com', honeypot_field_name => '' } }
       expect(flash[:notice]).to eq 'Thanks. Your feedback has been sent.'
     end
   end

--- a/spec/features/report_a_problem_spec.rb
+++ b/spec/features/report_a_problem_spec.rb
@@ -30,5 +30,19 @@ describe 'Report a Problem', type: :feature do
         click_on 'Send'
       end.to change { ActionMailer::Base.deliveries.count }.by(1)
     end
+
+    it 'rejects a spammy looking problem report', js: true do
+      visit spotlight.exhibit_solr_document_path(exhibit, id: 'dq287tq6352')
+      click_on 'Feedback'
+      expect(find('#contact_form_current_url', visible: false).value).to end_with spotlight.exhibit_solr_document_path(exhibit, id: 'dq287tq6352')
+      fill_in 'Name', with: 'Some Body'
+      fill_in 'Email', with: 'test@example.com'
+      page.find('#contact_form_email_address', visible: false).set 'possible_spam@spam.com'
+      fill_in 'Message', with: 'This is my problem report'
+
+      expect do
+        click_on 'Send'
+      end.not_to change { ActionMailer::Base.deliveries.count }
+    end
   end
 end

--- a/spec/features/report_a_problem_spec.rb
+++ b/spec/features/report_a_problem_spec.rb
@@ -1,5 +1,7 @@
 describe 'Report a Problem', type: :feature do
   let!(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:honeypot_field_name) { Spotlight::Engine.config.spambot_honeypot_email_field }
+
   it 'does not have a header link' do
     visit root_path
     expect(page).to_not have_content 'Feedback'
@@ -37,7 +39,7 @@ describe 'Report a Problem', type: :feature do
       expect(find('#contact_form_current_url', visible: false).value).to end_with spotlight.exhibit_solr_document_path(exhibit, id: 'dq287tq6352')
       fill_in 'Name', with: 'Some Body'
       fill_in 'Email', with: 'test@example.com'
-      page.find('#contact_form_email_address', visible: false).set 'possible_spam@spam.com'
+      page.find("#contact_form_#{honeypot_field_name}", visible: false).set 'possible_spam@spam.com'
       fill_in 'Message', with: 'This is my problem report'
 
       expect do

--- a/spec/models/spotlight/contact_form_spec.rb
+++ b/spec/models/spotlight/contact_form_spec.rb
@@ -30,4 +30,28 @@ describe Spotlight::ContactForm do
       expect(subject.headers[:cc]).to eq 'curator@example.com, addl_curator@example.com'
     end
   end
+
+  context 'when validating feedback submission fields' do
+    it 'allows submissions that set a valid email address' do
+      subject.email = 'user@legitimatebusinesspersonssocialclub.biz'
+      subject.email_address = ''
+      expect(subject).to be_valid
+    end
+
+    it 'rejects submissions that set an invalid email address' do
+      subject.email = 'user'
+      subject.email_address = ''
+      expect(subject).to_not be_valid
+    end
+
+    it 'allows submissions that leave the spammer honeypot field blank' do
+      subject.email_address = ''
+      expect(subject).to be_valid
+    end
+
+    it 'rejects submissions that set the spammer honeypot field' do
+      subject.email_address = 'spam@spam.com'
+      expect(subject).to_not be_valid
+    end
+  end
 end

--- a/spec/models/spotlight/contact_form_spec.rb
+++ b/spec/models/spotlight/contact_form_spec.rb
@@ -1,6 +1,7 @@
 describe Spotlight::ContactForm do
   subject { described_class.new(name: 'Root', email: 'user@example.com').tap { |c| c.current_exhibit = exhibit } }
   let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:honeypot_field_name) { Spotlight::Engine.config.spambot_honeypot_email_field }
 
   context 'with a site-wide contact email' do
     before { allow(Spotlight::Engine.config).to receive_messages default_contact_email: 'root@localhost' }
@@ -34,23 +35,23 @@ describe Spotlight::ContactForm do
   context 'when validating feedback submission fields' do
     it 'allows submissions that set a valid email address' do
       subject.email = 'user@legitimatebusinesspersonssocialclub.biz'
-      subject.email_address = ''
+      subject.send("#{honeypot_field_name}=", '')
       expect(subject).to be_valid
     end
 
     it 'rejects submissions that set an invalid email address' do
       subject.email = 'user'
-      subject.email_address = ''
+      subject.send("#{honeypot_field_name}=", '')
       expect(subject).to_not be_valid
     end
 
     it 'allows submissions that leave the spammer honeypot field blank' do
-      subject.email_address = ''
+      subject.send("#{honeypot_field_name}=", '')
       expect(subject).to be_valid
     end
 
     it 'rejects submissions that set the spammer honeypot field' do
-      subject.email_address = 'spam@spam.com'
+      subject.send("#{honeypot_field_name}=", 'spam@spam.com')
       expect(subject).to_not be_valid
     end
   end


### PR DESCRIPTION
as per @cbeer's suggestion.

if we want to go this route, i think i'd prefer to not merge this PR into that branch, but would rather just squash both commits into the the base exhibits-345 branch.  this is more of a convenient place to see the differences in the two approaches.