### PR TITLE
After reindexing a resource, touch the exhibit to break any caches that might exist

### DIFF
--- a/app/models/spotlight/resource.rb
+++ b/app/models/spotlight/resource.rb
@@ -29,6 +29,7 @@ module Spotlight
     around_index :reindex_with_logging
     after_index :commit
     after_index :completed!
+    after_index :touch_exhibit!
 
     ##
     # Persist the record to the database, and trigger a reindex to solr
@@ -134,6 +135,10 @@ module Spotlight
         blacklight_solr.commit
       rescue => e
         Rails.logger.warn "Unable to commit to solr: #{e}"
+      end
+
+      def touch_exhibit!
+        exhibit.touch
       end
 
       def write?

--- a/app/views/spotlight/browse/_search.html.erb
+++ b/app/views/spotlight/browse/_search.html.erb
@@ -1,4 +1,4 @@
-<%= cache [@exhibit, search, search.documents.size] do %>
+<%= cache [@exhibit, search] do %>
   <div class="col-sm-4 col-xs-12 category">
     <%= link_to spotlight.exhibit_browse_path(@exhibit, search) do %>
       <div class="image-overlay">

--- a/spec/models/spotlight/resource_spec.rb
+++ b/spec/models/spotlight/resource_spec.rb
@@ -83,6 +83,14 @@ describe Spotlight::Resource, type: :model do
           subject.reindex
         end
 
+        it 'touches the exhibit to clear any caches' do
+          allow(subject.exhibit).to receive(:touch)
+
+          subject.reindex
+
+          expect(subject.exhibit).to have_received(:touch)
+        end
+
         it 'records indexing metadata as document attributes' do
           subject.reindex
 


### PR DESCRIPTION
This includes things like the browse#index caches, which can now avoid expensive
solr queries by relying on the exhibit cache key.

Fixes #1657