### PR TITLE
Allow the browse category description to be marked up with markdown

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -100,7 +100,7 @@ Rails/OutputSafety:
     - 'app/controllers/spotlight/filters_controller.rb'
     - 'app/controllers/spotlight/searches_controller.rb'
     - 'app/controllers/spotlight/sites_controller.rb'
-    - 'app/helpers/spotlight/pages_helper.rb'
+    - 'app/helpers/spotlight/rendering_helper.rb'
     - 'app/helpers/spotlight/title_helper.rb'
 
 # Offense count: 6

--- a/app/helpers/spotlight/browse_helper.rb
+++ b/app/helpers/spotlight/browse_helper.rb
@@ -3,6 +3,8 @@ module Spotlight
   # Helper for browse views
   module BrowseHelper
     include ::BlacklightConfigurationHelper
+    include Spotlight::RenderingHelper
+
     def document_index_view_type
       if @search && @search.default_index_view_type.present? && params[:view].blank?
         blacklight_config.view[@search.default_index_view_type].key

--- a/app/helpers/spotlight/pages_helper.rb
+++ b/app/helpers/spotlight/pages_helper.rb
@@ -2,6 +2,8 @@ module Spotlight
   ##
   # Sir-trevor helpers methods
   module PagesHelper
+    include Spotlight::RenderingHelper
+
     ##
     # Override the default #sir_trevor_markdown so we can use
     # a more complete markdown rendered
@@ -12,7 +14,7 @@ module Spotlight
                      ''
                    end
 
-      GitHub::Markup.render('.md', clean_text).html_safe
+      render_markdown(clean_text)
     end
 
     def available_index_fields

--- a/app/helpers/spotlight/rendering_helper.rb
+++ b/app/helpers/spotlight/rendering_helper.rb
@@ -1,0 +1,7 @@
+module Spotlight
+  module RenderingHelper # :nodoc:
+    def render_markdown(text)
+      GitHub::Markup.render('.md', text).html_safe
+    end
+  end
+end

--- a/app/views/spotlight/browse/show.html.erb
+++ b/app/views/spotlight/browse/show.html.erb
@@ -10,7 +10,7 @@
     <h1><%= render 'search_title', search: @search %></h1>
   <% end %>
   <% if @search.long_description.present? %>
-    <p class="long-description-text"><%= @search.long_description %></p>
+    <p class="long-description-text"><%= render_markdown @search.long_description %></p>
   <% end %>
 </div>
 

--- a/spec/support/views/test_view_helpers.rb
+++ b/spec/support/views/test_view_helpers.rb
@@ -4,6 +4,7 @@ module Spotlight
 
     included do
       before do
+        view.send(:extend, Spotlight::RenderingHelper)
         view.send(:extend, Spotlight::MainAppHelpers)
         view.send(:extend, Spotlight::CrudLinkHelpers)
         view.send(:extend, Spotlight::TitleHelper)

--- a/spec/views/spotlight/browse/show.html.erb_spec.rb
+++ b/spec/views/spotlight/browse/show.html.erb_spec.rb
@@ -45,6 +45,12 @@ describe 'spotlight/browse/show', type: :view do
     expect(response).to have_selector 'p', text: search.long_description
   end
 
+  it 'renders the long description as markdown' do
+    allow(search).to receive_messages(long_description: '[some link](/somewhere)')
+    render
+    expect(response).to have_selector 'p a', text: 'some link'
+  end
+
   it 'displays search results actions' do
     render
     expect(response).to have_content 'Sort and Per Page actions'


### PR DESCRIPTION
Possibly fixes #1621?