### PR TITLE
Update crop area help text.

### DIFF
--- a/app/views/spotlight/appearances/edit.html.erb
+++ b/app/views/spotlight/appearances/edit.html.erb
@@ -32,14 +32,14 @@
       <div role="tabpanel" class="tab-pane active" id="site-masthead">
         <p class="instructions"><%= t(:'.site_masthead.help') %></p>
         <%= f.fields_for(:masthead, current_exhibit.masthead || current_exhibit.build_masthead) do |m| %>
-          <%= render '/spotlight/featured_images/form', f: m, initial_crop_selection: Spotlight::Engine.config.masthead_initial_crop_selection %>
+          <%= render '/spotlight/featured_images/form', f: m, initial_crop_selection: Spotlight::Engine.config.masthead_initial_crop_selection, crop_type: :masthead %>
         <% end %>
       </div>
 
       <div role="tabpanel" class="tab-pane" id="site-thumbnail">
         <p class="instructions"><%= t(:'.site_thumbnail.help') %></p>
         <%= f.fields_for(:thumbnail, current_exhibit.thumbnail || current_exhibit.build_thumbnail) do |m| %>
-          <%= render '/spotlight/featured_images/form', f: m, initial_crop_selection: Spotlight::Engine.config.thumbnail_initial_crop_selection %>
+          <%= render '/spotlight/featured_images/form', f: m, initial_crop_selection: Spotlight::Engine.config.thumbnail_initial_crop_selection, crop_type: :thumbnail %>
         <% end %>
       </div>
 

--- a/app/views/spotlight/contacts/_form.html.erb
+++ b/app/views/spotlight/contacts/_form.html.erb
@@ -9,7 +9,7 @@
   <%= f.fields_for :avatar, (@contact.avatar || @contact.build_avatar) do |af| %>
     <div data-cropper="<%= af.object.model_name.singular_route_key %>" data-form-prefix="<%= form_prefix(af) %>">
     <%= field_set_tag(t(:'.avatar.header')) do %>
-      <p class="instructions"><%= t(:'.avatar.help') %></p>
+      <p class="instructions"><%= t(:'featured_images.form.crop_area.help', scope: [:spotlight], thing: 'contact photo') %></p>
 
       <div>
         <%= af.radio_button(:source, :remote, label: t(:'.source.remote.label')) %>

--- a/app/views/spotlight/featured_images/_form.html.erb
+++ b/app/views/spotlight/featured_images/_form.html.erb
@@ -23,7 +23,7 @@
   </div>
 <% end %>
 <%= field_set_tag(t(:'.source.remote.header')) do %>
-  <p class="instructions"><%= t(:'.source.remote.help') %></p>
+  <p class="instructions"><%= t(:'.crop_area.help', thing: crop_type) %></p>
   <%= iiif_cropper_tags f, initial_crop_selection: initial_crop_selection %>
 <% end %>
 </div>

--- a/app/views/spotlight/featured_images/_upload_form.html.erb
+++ b/app/views/spotlight/featured_images/_upload_form.html.erb
@@ -9,7 +9,7 @@
   </div>
 <% end %>
 <%= field_set_tag(t(:'.source.remote.header')) do %>
-  <p class="instructions"><%= t(:'.source.remote.help') %></p>
+  <p class="instructions"><%= t(:'.crop_area.help', thing: crop_type) %></p>
   <%= iiif_cropper_tags f, initial_crop_selection: initial_crop_selection %>
 <% end %>
 </div>

--- a/app/views/spotlight/pages/_form.html.erb
+++ b/app/views/spotlight/pages/_form.html.erb
@@ -63,7 +63,7 @@
       <div role="tabpanel" class="tab-pane" id="page-thumbnail">
         <%= f.fields_for :thumbnail, (@page.thumbnail || @page.build_thumbnail) do |m| %>
           <p class="instructions"><%= t(:'.thumbnail.help') %></p>
-          <%= render '/spotlight/featured_images/form', f: m, initial_crop_selection: Spotlight::Engine.config.featured_image_thumb_size %>
+          <%= render '/spotlight/featured_images/form', f: m, initial_crop_selection: Spotlight::Engine.config.featured_image_thumb_size, crop_type: :thumbnail %>
         <% end %>
       </div>
       <% end %>

--- a/app/views/spotlight/searches/_form.html.erb
+++ b/app/views/spotlight/searches/_form.html.erb
@@ -45,13 +45,13 @@
         <%= f.fields_for :masthead, (@search.masthead || @search.build_masthead) do |m| %>
           <p class="instructions"><%= t(:'.masthead.help') %></p>
           <p class="instructions"><%= t(:'.masthead.help_secondary') %></p>
-          <%= render '/spotlight/featured_images/form', f: m, initial_crop_selection: Spotlight::Engine.config.masthead_initial_crop_selection %>
+          <%= render '/spotlight/featured_images/form', f: m, initial_crop_selection: Spotlight::Engine.config.masthead_initial_crop_selection, crop_type: :masthead %>
         <% end %>
       </div>
       <div role="tabpanel" class="tab-pane" id="search-thumbnail">
         <%= f.fields_for :thumbnail, (@search.thumbnail || @search.build_thumbnail) do |m| %>
           <p class="instructions"><%= t(:'.thumbnail.help') %></p>
-          <%= render '/spotlight/featured_images/form', f: m, initial_crop_selection: Spotlight::Engine.config.featured_image_thumb_size %>
+          <%= render '/spotlight/featured_images/form', f: m, initial_crop_selection: Spotlight::Engine.config.featured_image_thumb_size, crop_type: :thumbnail %>
         <% end %>
       </div>
 

--- a/app/views/spotlight/sites/edit.html.erb
+++ b/app/views/spotlight/sites/edit.html.erb
@@ -21,7 +21,7 @@
         <div role="tabpanel" class="tab-pane" id="site-masthead">
           <p class="instructions"><%= t(:'.site_masthead.help') %></p>
           <%= f.fields_for(:masthead, @site.masthead || @site.build_masthead) do |m| %>
-            <%= render '/spotlight/featured_images/upload_form', f: m, initial_crop_selection: Spotlight::Engine.config.masthead_initial_crop_selection %>
+            <%= render '/spotlight/featured_images/upload_form', f: m, initial_crop_selection: Spotlight::Engine.config.masthead_initial_crop_selection, crop_type: :masthead %>
           <% end %>
         </div>
       </div>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -485,9 +485,6 @@ en:
             label: "Upload an image"
         avatar:
           header: Avatar
-          help: >
-            Adjust the cropping box to cover the area of the image you want to use
-            as the avatar image. Click "Save" to save the cropped area.
     about_pages:
       contacts_form:
         header: Contacts
@@ -510,6 +507,10 @@ en:
         published: "Publish"
     featured_images:
       form: &featured_images_form
+        crop_area:
+          help: >
+            Adjust the image so that the rectangle contains the area you want to use as the %{thing}.
+            Click "Save changes" to save the cropped area.
         source:
           header: "Image source"
           exhibit:
@@ -518,9 +519,6 @@ en:
           remote:
             label: "Upload an image"
             header: "Cropped image"
-            help: >
-              Adjust the cropping box to cover the area of the image you want to use
-              as the thumbnail image. Click "Save changes" to save the cropped area.
       upload_form: *featured_images_form
 
     resources:

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -156,14 +156,14 @@ en:
             to change their order in the menu.
         restore_default: "Restore default"
         site_masthead:
-          heading: Site masthead
+          heading: Exhibit masthead
           help: >
             You can select and crop an image to use as a background in your exhibit site's
             masthead. To use an image as a masthead background, you should use an image that
             is at least 120 pixels tall and 1200 pixels wide. For best results use an image at
             least 1800 pixels wide. You can crop larger images using the cropping tool below.
         site_thumbnail:
-          heading: Site thumbnail
+          heading: Exhibit thumbnail
           help: "You can select and crop an image to visually represent this exhibit."
         thumbnail:
           small: Small

--- a/spec/features/exhibit_masthead_spec.rb
+++ b/spec/features/exhibit_masthead_spec.rb
@@ -10,7 +10,7 @@ describe 'Add and update the site masthead', type: :feature do
       click_link 'Appearance'
     end
 
-    click_link 'Site masthead'
+    click_link 'Exhibit masthead'
 
     within '#site-masthead' do
       check 'Show background image in masthead'
@@ -30,7 +30,7 @@ describe 'Add and update the site masthead', type: :feature do
       click_link 'Appearance'
     end
 
-    click_link 'Site masthead'
+    click_link 'Exhibit masthead'
 
     within '#site-masthead' do
       expect(field_labeled('Show background image in masthead')).to be_checked
@@ -45,7 +45,7 @@ describe 'Add and update the site masthead', type: :feature do
       click_link 'Appearance'
     end
 
-    click_link 'Site masthead'
+    click_link 'Exhibit masthead'
 
     within '#site-masthead' do
       check 'Show background image in masthead'
@@ -70,7 +70,7 @@ describe 'Add and update the site masthead', type: :feature do
       click_link 'Appearance'
     end
 
-    click_link 'Site masthead'
+    click_link 'Exhibit masthead'
 
     within '#site-masthead' do
       attach_file('exhibit_masthead_attributes_file', File.absolute_path(File.join(FIXTURES_PATH, 'avatar.png')))
@@ -92,7 +92,7 @@ describe 'Add and update the site masthead', type: :feature do
       click_link 'Appearance'
     end
 
-    click_link 'Site masthead'
+    click_link 'Exhibit masthead'
 
     within '#site-masthead' do
       check 'Show background image in masthead'


### PR DESCRIPTION
Closes #1670 

This PR also aims to distinguish between Site and Exhibit mastheads in tab labeling.


## Site masthead
<img width="892" alt="site" src="https://cloud.githubusercontent.com/assets/96776/22315428/697eda92-e31b-11e6-9359-09fb8eeb86c5.png">

## Exhibit masthead/thumbnail
<img width="865" alt="exhibit-masthead" src="https://cloud.githubusercontent.com/assets/96776/22315425/697b42d8-e31b-11e6-8a06-ab8916d01b19.png">
<img width="868" alt="exhibit-thumb" src="https://cloud.githubusercontent.com/assets/96776/22315427/697e3a4c-e31b-11e6-9d00-4436d7d7c009.png">

## Browse masthead/thumbnail
<img width="868" alt="browse-masthead" src="https://cloud.githubusercontent.com/assets/96776/22315426/697deda8-e31b-11e6-9105-a487421d2a82.png">
<img width="879" alt="browse-thumb" src="https://cloud.githubusercontent.com/assets/96776/22315424/6979b922-e31b-11e6-8cb0-485c8f88a760.png">

## Page thumbnail
<img width="1098" alt="page" src="https://cloud.githubusercontent.com/assets/96776/22315429/697f8dac-e31b-11e6-9ba8-aaa5dde64fd2.png">

## Contact avatar
<img width="688" alt="avatar" src="https://cloud.githubusercontent.com/assets/96776/22315430/698c34e4-e31b-11e6-83c3-ce3554860d8d.png">

