### PR TITLE
Wrap "no indexing activity" notice in a paragraph tag for improved vertical spacing

### DIFF
--- a/app/views/spotlight/dashboards/_reindexing_activity.html.erb
+++ b/app/views/spotlight/dashboards/_reindexing_activity.html.erb
@@ -24,5 +24,5 @@
   </tbody>
   </table>
 <% else %>
-  <%= t(:'.no_reindexing_activity') %>
+  <p><%= t(:'.no_reindexing_activity') %></p>
 <% end %>


### PR DESCRIPTION
Before:

<img width="249" alt="screen shot 2017-02-03 at 8 50 45 am" src="https://cloud.githubusercontent.com/assets/111218/22600069/debbbb3a-e9ed-11e6-834f-de1e72ce10b6.png">


After:

<img width="398" alt="screen shot 2017-02-03 at 8 50 29 am" src="https://cloud.githubusercontent.com/assets/111218/22600059/d3b1ae70-e9ed-11e6-8c1c-ad207d40e740.png">
