### PR TITLE
Add configuration and UI for selected themes for an exhibit

### DIFF
--- a/app/controllers/spotlight/appearances_controller.rb
+++ b/app/controllers/spotlight/appearances_controller.rb
@@ -23,7 +23,8 @@ module Spotlight
     protected
 
     def exhibit_params
-      params.require(:exhibit).permit(main_navigations_attributes: [:id, :display, :label, :weight],
+      params.require(:exhibit).permit(:theme,
+                                      main_navigations_attributes: [:id, :display, :label, :weight],
                                       masthead_attributes: featured_image_params,
                                       thumbnail_attributes: featured_image_params)
     end

--- a/app/helpers/spotlight/application_helper.rb
+++ b/app/helpers/spotlight/application_helper.rb
@@ -132,6 +132,19 @@ module Spotlight
       current_exhibit.blacklight_configuration.default_blacklight_config.view.to_h.reject { |_k, v| v.if == false }
     end
 
+    def exhibit_stylesheet_link_tag(tag)
+      if current_exhibit_theme && current_exhibit.theme != 'default'
+        stylesheet_link_tag "#{tag}_#{current_exhibit_theme}"
+      else
+        Rails.logger.warn "Exhibit theme '#{current_exhibit_theme}' not in white-list of available themes: #{Spotlight::Engine.config.exhibit_themes}"
+        stylesheet_link_tag(tag)
+      end
+    end
+
+    def current_exhibit_theme
+      current_exhibit.theme if current_exhibit && current_exhibit.theme.present? && Spotlight::Engine.config.exhibit_themes.include?(current_exhibit.theme)
+    end
+
     private
 
     def main_app_url_helper?(method)

--- a/app/helpers/spotlight/main_app_helpers.rb
+++ b/app/helpers/spotlight/main_app_helpers.rb
@@ -34,5 +34,18 @@ module Spotlight
         show_presenter(document)
       end
     end
+
+    def exhibit_stylesheet_link_tag(tag)
+      if current_exhibit_theme && current_exhibit.theme != 'default'
+        stylesheet_link_tag "#{tag}_#{current_exhibit_theme}"
+      else
+        Rails.logger.warn "Exhibit theme '#{current_exhibit_theme}' not in white-list of available themes: #{Spotlight::Engine.config.exhibit_themes}"
+        stylesheet_link_tag(tag)
+      end
+    end
+
+    def current_exhibit_theme
+      current_exhibit.theme if current_exhibit && current_exhibit.theme.present? && Spotlight::Engine.config.exhibit_themes.include?(current_exhibit.theme)
+    end
   end
 end

--- a/app/models/spotlight/exhibit.rb
+++ b/app/models/spotlight/exhibit.rb
@@ -17,6 +17,7 @@ module Spotlight
     friendly_id :title, use: [:slugged, :finders]
     validates :title, presence: true
     validates :slug, uniqueness: true
+    validates :theme, inclusion: { in: Spotlight::Engine.config.exhibit_themes }, allow_blank: true
 
     acts_as_tagger
     acts_as_taggable

--- a/app/views/layouts/spotlight/spotlight.html.erb
+++ b/app/views/layouts/spotlight/spotlight.html.erb
@@ -16,7 +16,11 @@
     <title><%= h(@page_title || application_name) %></title>
     <link href="<%= current_exhibit ? spotlight.opensearch_exhibit_catalog_url(current_exhibit, format: 'xml') : main_app.opensearch_catalog_url(format: 'xml') %>" title="<%= application_name %>" type="application/opensearchdescription+xml" rel="search"/>
     <%= favicon_link_tag 'favicon.ico' %>
-    <%= stylesheet_link_tag    "application" %>
+    <% if current_exhibit %>
+      <%= exhibit_stylesheet_link_tag "application" %>
+    <% else %>
+      <%= stylesheet_link_tag "application" %>
+    <% end %>
     <%= javascript_include_tag "application" %>
     <%= csrf_meta_tags %>
     <%= content_for(:head) %>

--- a/app/views/spotlight/appearances/edit.html.erb
+++ b/app/views/spotlight/appearances/edit.html.erb
@@ -16,7 +16,13 @@
   <% end %>
   <div role="tabpanel">
     <ul class="nav nav-tabs" role="tablist">
-      <li role="presentation" class="active">
+      <% if Spotlight::Engine.config.exhibit_themes.many? %>
+        <li role="presentation" class="active">
+          <a href="#site-theme" aria-controls="site-theme" role="tab" data-toggle="tab"><%= t(:'.site_theme.heading') %></a>
+        </li>
+      <% end %>
+
+      <li role="presentation" <%= 'class="active"'.html_safe unless Spotlight::Engine.config.exhibit_themes.many? %>>
         <a href="#site-masthead" aria-controls="site-masthead" role="tab" data-toggle="tab"><%= t(:'.site_masthead.heading') %></a>
       </li>
 
@@ -29,7 +35,21 @@
       </li>
     </ul>
     <div class="tab-content">
-      <div role="tabpanel" class="tab-pane active" id="site-masthead">
+      <% if Spotlight::Engine.config.exhibit_themes.many? %>
+      <div role="tabpanel" class="tab-pane active" id="site-theme">
+        <p class="instructions"><%= t(:'.site_theme.help') %></p>
+        <%= f.form_group :theme, label: { text: t(:'.site_theme.label') } do %>
+          <% Spotlight::Engine.config.exhibit_themes.each do |theme| %>
+            <div class="col-md-6">
+              <%= image_tag "spotlight/themes/#{theme}_preview", width: 100, height: 100 %>
+              <%= f.radio_button :theme, theme, label: t(:".site_theme.#{theme}", default: theme.to_s.titleize), inline: true %>
+            </div>
+          <% end %>
+        <% end %>
+      </div>
+      <% end %>
+
+      <div role="tabpanel" class="tab-pane <%= 'active' unless Spotlight::Engine.config.exhibit_themes.many? %>" id="site-masthead">
         <p class="instructions"><%= t(:'.site_masthead.help') %></p>
         <%= f.fields_for(:masthead, current_exhibit.masthead || current_exhibit.build_masthead) do |m| %>
           <%= render '/spotlight/featured_images/form', f: m, initial_crop_selection: Spotlight::Engine.config.masthead_initial_crop_selection, crop_type: :masthead %>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -155,6 +155,10 @@ en:
             Click a menu item to change its display label. Drag and drop a menu item
             to change their order in the menu.
         restore_default: "Restore default"
+        site_theme:
+          heading: Visual theme
+          help: ""
+          label: Exhibit theme
         site_masthead:
           heading: Exhibit masthead
           help: >

--- a/db/migrate/20170204091234_add_theme_to_spotlight_exhibits.rb
+++ b/db/migrate/20170204091234_add_theme_to_spotlight_exhibits.rb
@@ -1,0 +1,5 @@
+class AddThemeToSpotlightExhibits < ActiveRecord::Migration
+  def change
+    add_column :spotlight_exhibits, :theme, :string
+  end
+end

--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -195,5 +195,7 @@ module Spotlight
 
     # make blacklight configuration play nice with bootstrap_form
     Blacklight::OpenStructWithHashAccess.send(:extend, ActiveModel::Translation)
+
+    config.exhibit_themes = ['default']
   end
 end

--- a/spec/features/autocomplete_typeahead_spec.rb
+++ b/spec/features/autocomplete_typeahead_spec.rb
@@ -8,6 +8,7 @@ describe 'Autocomplete typeahead', type: :feature, js: true do
     context 'for items that include a IIIF manifest' do
       it 'instantiates a cropper and persists all levels of the IIIF manifest' do
         visit spotlight.edit_exhibit_appearance_path(exhibit)
+        click_link 'Exhibit masthead'
 
         expect(page).not_to have_css('.leaflet-container')
 
@@ -35,6 +36,7 @@ describe 'Autocomplete typeahead', type: :feature, js: true do
 
       it 'provides an alert informing the user that they cannot crop from that item' do
         visit spotlight.edit_exhibit_appearance_path(exhibit)
+        click_link 'Exhibit masthead'
 
         expect(page).not_to have_css('[data-behavior="non-iiif-alert"]', visible: true)
 

--- a/spec/features/exhibit_themes_spec.rb
+++ b/spec/features/exhibit_themes_spec.rb
@@ -1,0 +1,25 @@
+describe 'Update the site theme', type: :feature do
+  let(:exhibit) { FactoryGirl.create(:exhibit) }
+  let(:user) { FactoryGirl.create(:exhibit_admin, exhibit: exhibit) }
+
+  before { login_as user }
+  it 'updates the exhibit theme' do
+    visit spotlight.edit_exhibit_appearance_path(exhibit)
+
+    expect(page).to have_content('Visual theme')
+    choose 'Modern'
+
+    click_button 'Save changes'
+
+    expect(page).to have_content('The exhibit was successfully updated.')
+
+    within '#sidebar' do
+      click_link 'Appearance'
+    end
+
+    click_link 'Exhibit masthead'
+
+    expect(field_labeled('Modern')).to be_checked
+    expect(page).to have_xpath('//link[contains(@href, "/stylesheets/application_modern.css")]', visible: false)
+  end
+end

--- a/spec/helpers/spotlight/main_app_helpers_spec.rb
+++ b/spec/helpers/spotlight/main_app_helpers_spec.rb
@@ -40,4 +40,49 @@ describe Spotlight::MainAppHelpers, type: :helper do
       its(:show_contact_form?) { should be_truthy }
     end
   end
+
+  describe '#exhibit_stylesheet_link_tag' do
+    let(:exhibit) { FactoryGirl.create(:exhibit) }
+    before do
+      allow(helper).to receive_messages(current_exhibit: exhibit)
+    end
+
+    context 'without an exhibit context' do
+      let(:exhibit) { nil }
+      it 'uses the standard stylesheet' do
+        expect(helper.exhibit_stylesheet_link_tag('application')).to eq helper.stylesheet_link_tag('application')
+      end
+    end
+
+    context 'for an exhibit without a selected theme' do
+      before do
+        exhibit.update(theme: nil)
+      end
+
+      it 'uses the standard stylesheet' do
+        expect(helper.exhibit_stylesheet_link_tag('application')).to eq helper.stylesheet_link_tag('application')
+      end
+    end
+
+    context 'for an exhibit with an invalid theme' do
+      before do
+        exhibit.update(theme: 'garbage')
+      end
+
+      it 'uses the standard stylesheet' do
+        expect(helper.exhibit_stylesheet_link_tag('application')).to eq helper.stylesheet_link_tag('application')
+      end
+    end
+
+    context 'for a themed exhibit' do
+      before do
+        allow(Spotlight::Engine.config).to receive(:exhibit_themes).and_return(%w(default modern))
+        exhibit.update(theme: 'modern')
+      end
+
+      it 'uses a suffixed stylesheet name' do
+        expect(helper.exhibit_stylesheet_link_tag('application')).to eq helper.stylesheet_link_tag('application_modern')
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,6 +40,9 @@ end
 
 require 'spotlight'
 
+# configure spotlight with all the settings necessary to test functionality
+Spotlight::Engine.config.exhibit_themes = %w(default modern)
+
 Dir['./spec/support/**/*.rb'].sort.each { |f| require f }
 
 FactoryGirl.definition_file_paths = [File.expand_path('../factories', __FILE__)]


### PR DESCRIPTION
Fixes #389

<img width="617" alt="screen shot 2017-02-07 at 7 57 46 am" src="https://cloud.githubusercontent.com/assets/111218/22699270/db63c4f2-ed0b-11e6-9a29-f407e0132913.png">
