### PR TITLE
allow deleting contact email addresses

### DIFF
--- a/app/assets/javascripts/spotlight/exhibits.js
+++ b/app/assets/javascripts/spotlight/exhibits.js
@@ -26,6 +26,7 @@ Spotlight.onLoad(function() {
     });
 
     input_container.find('.first-row-only').remove();
+    input_container.find('.confirmation-status').remove();
 
     // bootstrap does not render input-groups with only one value in them correctly.
     input_container.find('.input-group input:only-child').closest('.input-group').removeClass('input-group');

--- a/app/assets/javascripts/spotlight/exhibits.js
+++ b/app/assets/javascripts/spotlight/exhibits.js
@@ -25,7 +25,6 @@ Spotlight.onLoad(function() {
       $(this).attr('name', $(this).attr('name').replace('0', contacts.length));
     });
 
-    input_container.find('.first-row-only').remove();
     input_container.find('.confirmation-status').remove();
 
     // bootstrap does not render input-groups with only one value in them correctly.

--- a/app/assets/javascripts/spotlight/exhibits.js
+++ b/app/assets/javascripts/spotlight/exhibits.js
@@ -16,21 +16,32 @@ Spotlight.onLoad(function() {
   $("#another-email").on("click", function() {
     var container = $(this).closest('.form-group');
     var contacts = container.find('.contact');
-    var input_container = contacts.first().clone();
+    var inputContainer = contacts.first().clone();
 
     // wipe out any values from the inputs
-    input_container.find('input').each(function() {
+    inputContainer.find('input').each(function() {
       $(this).val('');
       $(this).attr('id', $(this).attr('id').replace('0', contacts.length));
       $(this).attr('name', $(this).attr('name').replace('0', contacts.length));
     });
 
-    input_container.find('.confirmation-status').remove();
+    inputContainer.find('.contact-email-delete-wrapper').remove();
+    inputContainer.find('.confirmation-status').remove();
 
     // bootstrap does not render input-groups with only one value in them correctly.
-    input_container.find('.input-group input:only-child').closest('.input-group').removeClass('input-group');
+    inputContainer.find('.input-group input:only-child').closest('.input-group').removeClass('input-group');
 
-    $(input_container).insertAfter(contacts.last());
+    $(inputContainer).insertAfter(contacts.last());
+  });
+
+  $('.contact-email-delete').on('ajax:success', function() {
+    $(this).closest('.contact').fadeOut(250, function() { $(this).remove(); });
+  });
+
+  $('.contact-email-delete').on('ajax:error', function(_event, _xhr, _status, error) {
+    var errSpan = $(this).closest('.contact').find('.contact-email-delete-error');
+    errSpan.show();
+    errSpan.find('.error-msg').first().text(error);
   });
 
   $('.btn-with-tooltip').tooltip();

--- a/app/controllers/spotlight/contact_email_controller.rb
+++ b/app/controllers/spotlight/contact_email_controller.rb
@@ -1,0 +1,22 @@
+module Spotlight
+  ##
+  # CRUD actions for exhibit contact emails
+  class ContactEmailController < Spotlight::ApplicationController
+    rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
+
+    before_action :authenticate_user!
+    load_and_authorize_resource :exhibit, class: 'Spotlight::Exhibit'
+    load_and_authorize_resource through: :exhibit
+
+    def destroy
+      @contact_email.destroy
+      render json: { success: true, error: nil }
+    end
+
+    private
+
+    def record_not_found(_error)
+      render json: { success: false, error: 'Not Found' }, status: :not_found
+    end
+  end
+end

--- a/app/models/spotlight/ability.rb
+++ b/app/models/spotlight/ability.rb
@@ -14,7 +14,7 @@ module Spotlight
 
       # exhibit admin
       can [:update, :import, :export, :destroy], Spotlight::Exhibit, id: user.admin_roles.pluck(:resource_id)
-      can :manage, Spotlight::BlacklightConfiguration, exhibit_id: user.admin_roles.pluck(:resource_id)
+      can :manage, [Spotlight::BlacklightConfiguration, Spotlight::ContactEmail], exhibit_id: user.admin_roles.pluck(:resource_id)
       can :manage, Spotlight::Role, resource_id: user.admin_roles.pluck(:resource_id), resource_type: 'Spotlight::Exhibit'
 
       can :manage, PaperTrail::Version if user.roles.any?

--- a/app/views/spotlight/exhibits/_confirmation_status.html.erb
+++ b/app/views/spotlight/exhibits/_confirmation_status.html.erb
@@ -1,4 +1,4 @@
-            <div class="col-md-4 confirmation-status <%= 'not-validated' unless contact_email.confirmed? or contact_email.recently_sent? %>">
+            <div class="confirmation-status <%= 'not-validated' unless contact_email.confirmed? or contact_email.recently_sent? %>">
               <% if contact_email.confirmed? %>
                 <span class="confirmed"><span class="glyphicon glyphicon-ok-sign"></span> <%= t('.confirmed') %></span>
               <% elsif contact_email.recently_sent? %>

--- a/app/views/spotlight/exhibits/_contact.html.erb
+++ b/app/views/spotlight/exhibits/_contact.html.erb
@@ -1,10 +1,20 @@
-        <%= contact.hidden_field :id %>
         <div class="row contact">
+          <%= contact.hidden_field :id %>
           <div class="col-md-8<%= ' has-error' if contact.object.errors[:email].present? %>">
             <%= text_field_tag "#{contact.object_name}[email]", contact.object.email, class: 'exhibit-contact form-control' %>
             <% if contact.object.errors[:email].present? %>
               <span class="help-block"><%=contact.object.errors[:email].join(", ".html_safe) %></span>
             <% end %>
+            <p>
+              <span class="contact-email-delete-error text-danger callout-danger" style="display: none;"><%= t('.email_delete_error') %> <span class="error-msg"></span></span>
+            </p>
           </div>
-          <%= render partial: 'confirmation_status', locals: {contact_email: contact.object} unless contact.object.new_record? %>
+          <div class="col-md-4">
+            <% if contact.object.id %>
+              <span class="contact-email-delete-wrapper">
+                <%= link_to "<span class=\"btn-xs btn-danger\">#{t('.email_delete_button')}</span>".html_safe, exhibit_contact_email_path(exhibit_id: exhibit.id, id: contact.object.id), class: 'contact-email-delete', method: :delete, data: { confirm: t('.email_delete_confirmation'), remote: true } %>
+              </span>
+            <% end %>
+            <%= render partial: 'confirmation_status', locals: {contact_email: contact.object} unless contact.object.new_record? %>
+          </div>
         </div>

--- a/app/views/spotlight/exhibits/_contact.html.erb
+++ b/app/views/spotlight/exhibits/_contact.html.erb
@@ -1,14 +1,7 @@
         <%= contact.hidden_field :id %>
         <div class="row contact">
           <div class="col-md-8<%= ' has-error' if contact.object.errors[:email].present? %>">
-            <% if contact.index == 0 %>
-              <div class="input-group">
-                <%= text_field_tag "#{contact.object_name}[email]", contact.object.email, class: 'exhibit-contact form-control' %>
-                <span id='another-email' class="input-group-addon first-row-only">+</span>
-              </div>
-            <% else %>
-              <%= text_field_tag "#{contact.object_name}[email]", contact.object.email, class: 'exhibit-contact form-control' %>
-            <% end %>
+            <%= text_field_tag "#{contact.object_name}[email]", contact.object.email, class: 'exhibit-contact form-control' %>
             <% if contact.object.errors[:email].present? %>
               <span class="help-block"><%=contact.object.errors[:email].join(", ".html_safe) %></span>
             <% end %>

--- a/app/views/spotlight/exhibits/_contact.html.erb
+++ b/app/views/spotlight/exhibits/_contact.html.erb
@@ -12,7 +12,9 @@
           <div class="col-md-4">
             <% if contact.object.id %>
               <span class="contact-email-delete-wrapper">
-                <%= link_to "<span class=\"btn-xs btn-danger\">#{t('.email_delete_button')}</span>".html_safe, exhibit_contact_email_path(exhibit_id: exhibit.id, id: contact.object.id), class: 'contact-email-delete', method: :delete, data: { confirm: t('.email_delete_confirmation'), remote: true } %>
+                <%= link_to exhibit_contact_email_path(exhibit_id: exhibit.id, id: contact.object.id), class: 'contact-email-delete btn btn-xs btn-danger', method: :delete, data: { confirm: t('.email_delete_confirmation'), remote: true } do %>
+                  <%= t('.email_delete_button') %>
+                <% end %>
               </span>
             <% end %>
             <%= render partial: 'confirmation_status', locals: {contact_email: contact.object} unless contact.object.new_record? %>

--- a/app/views/spotlight/exhibits/_form.html.erb
+++ b/app/views/spotlight/exhibits/_form.html.erb
@@ -6,7 +6,7 @@
   <%= f.text_field :tag_list, value: f.object.tag_list.to_s %>
   <%= f.form_group(:contact_emails, label: { text: nil, class: nil }, help: nil) do %>
     <%= f.fields_for :contact_emails do |contact| %>
-      <%= render partial: 'contact', locals: {contact: contact} %>
+      <%= render partial: 'contact', locals: {exhibit: @exhibit, contact: contact} %>
     <% end %>
     <span id='another-email' class="btn-sm btn-info"><%= t('.add_contact_email_button') %></span>
     <p class="help-block"><%= t(:'.fields.contact_emails.help_block') %></p>

--- a/app/views/spotlight/exhibits/_form.html.erb
+++ b/app/views/spotlight/exhibits/_form.html.erb
@@ -5,14 +5,14 @@
   <%= f.text_area :description %>
   <%= f.text_field :tag_list, value: f.object.tag_list.to_s %>
   <%= f.form_group(:contact_emails, label: { text: nil, class: nil }, help: nil) do %>
-  <%= f.fields_for :contact_emails do |contact| %>
-  <%= render partial: 'contact', locals: {contact: contact} %>
-  <% end %>
-  <p class="help-block"><%= t(:'.fields.contact_emails.help_block') %></p>
+    <%= f.fields_for :contact_emails do |contact| %>
+      <%= render partial: 'contact', locals: {contact: contact} %>
+    <% end %>
+    <p class="help-block"><%= t(:'.fields.contact_emails.help_block') %></p>
   <% end %>
   <%= f.form_group :published, label: { text: nil, class: nil }, help: nil do %>
-  <%= f.check_box :published, label: "" %>
-  <p class="help-block"><%= t(:'.fields.published.help_block') %></p>
+    <%= f.check_box :published, label: "" %>
+    <p class="help-block"><%= t(:'.fields.published.help_block') %></p>
   <% end %>
   
   <div class="form-actions">

--- a/app/views/spotlight/exhibits/_form.html.erb
+++ b/app/views/spotlight/exhibits/_form.html.erb
@@ -8,6 +8,7 @@
     <%= f.fields_for :contact_emails do |contact| %>
       <%= render partial: 'contact', locals: {contact: contact} %>
     <% end %>
+    <span id='another-email' class="btn-sm btn-info"><%= t('.add_contact_email_button') %></span>
     <p class="help-block"><%= t(:'.fields.contact_emails.help_block') %></p>
   <% end %>
   <%= f.form_group :published, label: { text: nil, class: nil }, help: nil do %>

--- a/app/views/spotlight/exhibits/_form.html.erb
+++ b/app/views/spotlight/exhibits/_form.html.erb
@@ -8,7 +8,7 @@
     <%= f.fields_for :contact_emails do |contact| %>
       <%= render partial: 'contact', locals: {exhibit: @exhibit, contact: contact} %>
     <% end %>
-    <span id='another-email' class="btn-sm btn-info"><%= t('.add_contact_email_button') %></span>
+    <span id='another-email' class="btn btn-sm btn-info"><%= t('.add_contact_email_button') %></span>
     <p class="help-block"><%= t(:'.fields.contact_emails.help_block') %></p>
   <% end %>
   <%= f.form_group :published, label: { text: nil, class: nil }, help: nil do %>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -382,6 +382,10 @@ en:
         header: General
         basic_settings:
           heading: Basic settings
+      contact:
+        email_delete_confirmation: Delete contact email address?
+        email_delete_error: 'Problem deleting contact email:'
+        email_delete_button: Delete contact
       form:
         add_contact_email_button: Add new contact
         fields:

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -383,6 +383,7 @@ en:
         basic_settings:
           heading: Basic settings
       form:
+        add_contact_email_button: Add new contact
         fields:
           contact_emails:
             help_block: Each contact email will receive feedback submissions

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Spotlight::Engine.routes.draw do
       post 'reindex', to: 'exhibits#reindex'
     end
 
+    resources :contact_email, only: [:destroy], defaults: { format: :json }
     resources :attachments, only: :create
     resource :contact_form, path: 'contact', only: [:new, :create]
     resource :blacklight_configuration, only: [:update]

--- a/spec/controllers/spotlight/contact_email_controller_spec.rb
+++ b/spec/controllers/spotlight/contact_email_controller_spec.rb
@@ -1,0 +1,63 @@
+describe Spotlight::ContactEmailController, type: :controller do
+  routes { Spotlight::Engine.routes }
+  let(:contact_email) { FactoryGirl.create(:contact_email) }
+
+  context 'when not logged in' do
+    describe 'DELETE destroy' do
+      it 'redirects to the login page' do
+        # note about odd behavior: it was discovered in testing that if format: :json is explicitly specified here, the user is redirected
+        # to login on rails 4, but gets a 401 on rails 5.  we suspect differing CanCan behavior, but didn't investigate in depth.
+        delete :destroy, params: { id: contact_email, exhibit_id: contact_email.exhibit }
+        # custom logic in ApplicationController redirects user to app login page on CanCan::AccessDenied if user can't read current exhibit
+        expect(response).to redirect_to main_app.new_user_session_path
+      end
+    end
+  end
+
+  context 'when logged in' do
+    before { sign_in user }
+
+    context 'as a visitor' do
+      let(:user) { FactoryGirl.create(:exhibit_visitor) }
+
+      describe 'DELETE destroy' do
+        it 'redirects to the home page' do
+          delete :destroy, params: { id: contact_email, exhibit_id: contact_email.exhibit }
+          # custom logic in ApplicationController redirects user to app root on CanCan::AccessDenied if user's allowed to view current exhibit
+          expect(response).to redirect_to main_app.root_path
+        end
+      end
+    end
+
+    context 'as an exhibit curator' do
+      let(:user) { FactoryGirl.create(:exhibit_curator, exhibit: contact_email.exhibit) }
+
+      describe 'DELETE destroy' do
+        it 'redirects to the home page' do
+          delete :destroy, params: { id: contact_email, exhibit_id: contact_email.exhibit }
+          # custom logic in ApplicationController redirects user to app root on CanCan::AccessDenied if user's allowed to view current exhibit
+          expect(response).to redirect_to main_app.root_path
+        end
+      end
+    end
+
+    context 'as an exhibit admin' do
+      let(:user) { FactoryGirl.create(:exhibit_admin, exhibit: contact_email.exhibit) }
+
+      describe 'DELETE destroy' do
+        it 'is successful when the record exists' do
+          delete :destroy, params: { id: contact_email, exhibit_id: contact_email.exhibit }
+          expect(response).to be_successful
+          expect(JSON.parse(response.body)).to eq('success' => true, 'error' => nil)
+        end
+
+        it 'gives a 404 with appropriate message when the record no longer exists' do
+          contact_email.destroy
+          delete :destroy, params: { id: contact_email, exhibit_id: contact_email.exhibit }
+          expect(response.status).to eq 404
+          expect(JSON.parse(response.body)).to eq('success' => false, 'error' => 'Not Found')
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/contact_emails.rb
+++ b/spec/factories/contact_emails.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :contact_email, class: Spotlight::ContactEmail do
+    email 'exhibit_contact@example.com'
+    exhibit
+  end
+end

--- a/spec/features/exhibits/administration_spec.rb
+++ b/spec/features/exhibits/administration_spec.rb
@@ -1,9 +1,11 @@
-
 describe 'Exhibit Administration', type: :feature do
   let(:exhibit) { FactoryGirl.create(:exhibit) }
   let(:admin) { FactoryGirl.create(:exhibit_admin, exhibit: exhibit) }
+  let(:hidden_input_id_0) { 'exhibit_contact_emails_attributes_0_id' }
   let(:email_id_0) { 'exhibit_contact_emails_attributes_0_email' }
   let(:email_address_0) { 'admin@example.com' }
+  let(:hidden_input_id_1) { 'exhibit_contact_emails_attributes_1_id' }
+  let(:hidden_input_val_1) { '2' }
   let(:email_id_1) { 'exhibit_contact_emails_attributes_1_email' }
   let(:email_address_1) { 'admin2@example.com' }
   before { login_as admin }
@@ -19,7 +21,8 @@ describe 'Exhibit Administration', type: :feature do
       expect(page).to have_css('input.exhibit-contact')
       expect(find_field(email_id_0).value).to be_blank
     end
-    it 'stores and retreive a contact email address' do
+
+    it 'stores and retreives a contact email address' do
       visit spotlight.edit_exhibit_path(exhibit)
       fill_in email_id_0, with: email_address_0
       click_button 'Save changes'
@@ -27,6 +30,7 @@ describe 'Exhibit Administration', type: :feature do
       visit spotlight.edit_exhibit_path(exhibit)
       expect(find_field(email_id_0).value).to eq email_address_0
     end
+
     it "has new inputs added when clicking on the 'add contact' button", js: true do
       # Exhibit administration edit
       visit spotlight.edit_exhibit_path(exhibit)
@@ -51,6 +55,76 @@ describe 'Exhibit Administration', type: :feature do
 
       expect(find_field(email_id_0).value).to eq email_address_0
       expect(find_field(email_id_1).value).to eq email_address_1
+    end
+
+    it 'allows deletion of contact email addresses', js: true do
+      # go to edit page, fill in first email field, click the + (add contact) button, fill in the second email field, click save.
+      visit spotlight.edit_exhibit_path(exhibit)
+      fill_in email_id_0, with: email_address_0
+      find('#another-email').click
+      fill_in email_id_1, with: email_address_1
+      click_button 'Save changes'
+
+      # saving should redirect back to the edit page, which should now have the contact
+      # email addresses, with delete buttons now that the entries have been saved.
+      expect(find_field(email_id_0).value).to eq email_address_0
+      expect(find_field(email_id_1).value).to eq email_address_1
+      expect(find_all('.contact-email-delete').length).to eq 2
+
+      # delete the first address in the list
+      page.accept_confirm do
+        find_all('.contact-email-delete').first.click
+      end
+
+      # the page element for the first entry should now be gone, but the second should still be present
+      expect(page).not_to have_css("##{email_id_0}")
+      expect(find_field(email_id_1).value).to eq email_address_1
+
+      # reload the edit page to confirm deletion from db...
+      visit spotlight.edit_exhibit_path(exhibit)
+
+      # what was the second address should now be the only one on the page, and should now be
+      # in the first/only form field (form fields are numbered at page load from 0).
+      expect(find_field(email_id_0).value).to eq email_address_1
+      expect(page).not_to have_css("##{email_id_1}")
+
+      # the hidden input field is what contains the underlying id of the contact for db retrieval
+      expect(find("##{hidden_input_id_0}", visible: false).value).to eq hidden_input_val_1
+    end
+
+    it 'creates an empty form field with no associated delete command or confirmation status when creating a blank row for a new contact', js: true do
+      # create a contact email address and save (shouldn't see delete button or confirmation status on unsaved entries)
+      visit spotlight.edit_exhibit_path(exhibit)
+      fill_in email_id_0, with: email_address_0
+      click_button 'Save changes'
+
+      find('#another-email').click
+      expect(find_field(email_id_0).value).to eq email_address_0
+      expect(find_field(email_id_1).value).to eq ''
+
+      # conf status and email delete are nested in a sibling div of the hidden
+      # id field that's used to indicate the id of the record to be updated.
+      expect(page).to have_css("##{hidden_input_id_0}~div div.confirmation-status")
+      expect(page).to have_css("##{hidden_input_id_0}~div span.contact-email-delete-wrapper")
+      expect(page).not_to have_css("##{hidden_input_id_1}~div div.confirmation-status")
+      expect(page).not_to have_css("##{hidden_input_id_1}~div span.contact-email-delete-wrapper")
+      expect(find_all('.confirmation-status').length).to eq 1
+      expect(find_all('.contact-email-delete-wrapper').length).to eq 1
+    end
+
+    it 'displays the error message from the server if there is one', js: true do
+      visit spotlight.edit_exhibit_path(exhibit)
+      fill_in email_id_0, with: email_address_0
+      find('#another-email').click
+      fill_in email_id_1, with: email_address_1
+      click_button 'Save changes'
+
+      Spotlight::ContactEmail.all.first.destroy
+      page.accept_confirm do
+        find_all('.contact-email-delete').first.click
+      end
+
+      expect(page).to have_css("##{hidden_input_id_0}~div span.contact-email-delete-error", text: 'Problem deleting contact email: Not Found')
     end
   end
 end


### PR DESCRIPTION
successful deletion example (including manual page refresh to show contact email was actually deleted):
![669-delete-contact-email-success](https://cloud.githubusercontent.com/assets/7741604/22912440/26f08212-f21a-11e6-8031-466d19b0e448.gif)

error deleting (contact address already deleted, e.g. in another page load in a different tab):
![669-delete-contact-email-error](https://cloud.githubusercontent.com/assets/7741604/22912444/31256c16-f21a-11e6-907f-eb511b3cc5f3.gif)

closes #669 