### PR TITLE
Empty out existing IIIF hidden inputs when a file is uploaded…

### DIFF
--- a/app/assets/javascripts/spotlight/crop.es6
+++ b/app/assets/javascripts/spotlight/crop.es6
@@ -30,6 +30,12 @@ export default class Crop {
     this.iiifImageField.val(iiifObject.imageId);
   }
 
+  emptyIiifFields() {
+    this.iiifManifestField.val('');
+    this.iiifCanvasField.val('');
+    this.iiifImageField.val('');
+  }
+
   // Set the Crop tileSource and setup the cropper
   setTileSource(source) {
     if (source == this.tileSource) {
@@ -202,6 +208,7 @@ export default class Crop {
   }
 
   successHandler(data, stat, xhr) {
+    this.emptyIiifFields();
     this.setTileSource(data.tilesource);
   }
 }


### PR DESCRIPTION
…directly (so we don't persist IIIF information from previously cropped documents).