### PR TITLE
Only set browse category descriptions into 3 columns if they are long…

### DIFF
--- a/app/assets/stylesheets/spotlight/_browse.scss
+++ b/app/assets/stylesheets/spotlight/_browse.scss
@@ -6,9 +6,17 @@ $image-overlay-bottom-margin: $padding-large-vertical * 3;
 }
 
 .long-description-text {
-  column-width: 20em;
-  column-gap: 3em;
   margin: ($padding-base-vertical * 2) 0;
+  width: 40em;
+}
+
+.very-long-description-text {
+  width: auto;
+
+  @media (min-width: $screen-sm-max) {
+    column-gap: 3em;
+    column-width: 20em;
+  }
 }
 
 .browse-landing {

--- a/app/views/spotlight/browse/show.html.erb
+++ b/app/views/spotlight/browse/show.html.erb
@@ -10,7 +10,9 @@
     <h1><%= render 'search_title', search: @search %></h1>
   <% end %>
   <% if @search.long_description.present? %>
-    <p class="long-description-text"><%= render_markdown @search.long_description %></p>
+    <div class="long-description-text <%= 'very-long-description-text' if @search.long_description.length > 600 %>">
+      <%= render_markdown @search.long_description %>
+    </div>
   <% end %>
 </div>
 

--- a/spec/views/spotlight/browse/show.html.erb_spec.rb
+++ b/spec/views/spotlight/browse/show.html.erb_spec.rb
@@ -42,7 +42,14 @@ describe 'spotlight/browse/show', type: :view do
   it 'displays the long description' do
     allow(search).to receive_messages(long_description: 'Long description')
     render
-    expect(response).to have_selector 'p', text: search.long_description
+    expect(response).to have_selector '.long-description-text p', text: search.long_description
+    expect(response).not_to have_selector '.very-long-description-text'
+  end
+
+  it 'adds markup for very long descriptions' do
+    allow(search).to receive_messages(long_description: 'A' * 601)
+    render
+    expect(response).to have_selector '.very-long-description-text p'
   end
 
   it 'renders the long description as markdown' do


### PR DESCRIPTION
… enough to have multiple columns

Also, make the columns responsive so they only appear on larger screens.

3-column layout for "very long" descriptions (~600 characters, anecdotally at least 4 lines of texts in each column):
<img width="1206" alt="screen shot 2017-02-10 at 9 19 02 am" src="https://cloud.githubusercontent.com/assets/111218/22836711/6135039e-ef72-11e6-9358-9650d0c6210e.png">

Responsive columns, collapses to single columns on small screens:
<img width="781" alt="screen shot 2017-02-10 at 9 19 06 am" src="https://cloud.githubusercontent.com/assets/111218/22836712/613f7914-ef72-11e6-92c2-0a9c50bd224b.png">

Limited the max line length for shorter descriptions:
<img width="730" alt="screen shot 2017-02-10 at 9 20 53 am" src="https://cloud.githubusercontent.com/assets/111218/22836716/6450acc2-ef72-11e6-8946-1c5d7e6beb4d.png">

Related to #1622 
