### PR TITLE
Cleanup feedback form inconsistencies

### DIFF
--- a/app/controllers/spotlight/contact_forms_controller.rb
+++ b/app/controllers/spotlight/contact_forms_controller.rb
@@ -29,6 +29,7 @@ module Spotlight
     end
 
     def contact_form_params
+      return {} if params[:action] == 'new'
       params.require(:contact_form).permit(:name, :email, Spotlight::Engine.config.spambot_honeypot_email_field, :message, :current_url)
     end
   end

--- a/app/views/shared/_masthead.html.erb
+++ b/app/views/shared/_masthead.html.erb
@@ -1,11 +1,15 @@
-<%= render 'spotlight/shared/report_a_problem' if show_contact_form? %>
+<% if show_contact_form? %>
+  <div id="report-problem-form">
+    <%= render 'spotlight/shared/report_a_problem' %>
+  </div>
+<% end %>
 
 <div class="masthead <%= 'image-masthead' if current_masthead %> <%= 'resource-masthead' if resource_masthead? %>">
   <% if current_masthead %>
     <span class='background-container' style="background-image: url('<%= current_masthead.iiif_url %>')"></span>
     <span class='background-container-gradient'></span>
   <% end %>
-  
+
   <%= render 'shared/exhibit_navbar' if current_exhibit && resource_masthead? %>
 
   <div class="container site-title-container">

--- a/app/views/spotlight/contact_forms/new.html.erb
+++ b/app/views/spotlight/contact_forms/new.html.erb
@@ -1,22 +1,3 @@
 <div id="content" class="col-md-9">
-<%= bootstrap_form_for @contact_form, url: spotlight.exhibit_contact_form_path(current_exhibit, @contact_form), layout: :horizontal, label_col: 'col-md-3 col-sm-3', control_col: 'col-sm-5 col-md-5' do |f| %>
-  <h1 class="page-title"><%= t(:'.header') %></h1>
-  <div class="row">
-    <%= f.text_field :name %>
-    <span style="display:none;visibility:hidden;">
-      <% honeypot_field_name = Spotlight::Engine.config.spambot_honeypot_email_field %>
-      <%= label_tag(honeypot_field_name, t(:'.honeypot_field_explanation')) %><br/>
-      <%= f.email_field honeypot_field_name %>
-    </span>
-    <%= f.email_field :email %>
-    <%= f.text_area :message, rows: 7 %>
-    <%= f.hidden_field :current_url %>
-    <div class="form-actions">
-      <div class="primary-actions">
-      <%= link_to t(:'helpers.action.cancel'), '#', class: 'btn btn-link', data: { 'behavior' => 'cancel-link' } %>
-      <%= f.submit nil, class: 'btn btn-primary' %>
-      </div>
-    </div>
-  </div>
-<% end %>
+  <%= render partial: 'spotlight/shared/report_a_problem', locals: { contact_form: @contact_form } %>
 </div>

--- a/app/views/spotlight/shared/_report_a_problem.html.erb
+++ b/app/views/spotlight/shared/_report_a_problem.html.erb
@@ -1,26 +1,24 @@
-<div id="report-problem-form">
 <div class="container">
-<div class="row">
-  <% contact_form = Spotlight::ContactForm.new current_url: request.original_url %>
-  <%= bootstrap_form_for contact_form, url: spotlight.exhibit_contact_form_path(current_exhibit, contact_form), layout: :horizontal, label_col: 'col-sm-3', control_col: 'col-sm-9', html: { class: 'col-md-offset-2 col-md-8 '} do |f| %>
+  <div class="row">
+    <% contact_form ||= Spotlight::ContactForm.new current_url: request.original_url %>
+    <%= bootstrap_form_for contact_form, url: spotlight.exhibit_contact_form_path(current_exhibit, contact_form), layout: :horizontal, label_col: 'col-sm-3', control_col: 'col-sm-9', html: { class: 'col-md-offset-2 col-md-8 '} do |f| %>
 
-    <h2><%= t(:'.title') %></h2>
-    <%= f.text_field :name %>
-    <span style="display:none;visibility:hidden;">
-      <% honeypot_field_name = Spotlight::Engine.config.spambot_honeypot_email_field %>
-      <%= label_tag(honeypot_field_name, t(:'.honeypot_field_explanation')) %><br/>
-      <%= f.email_field honeypot_field_name %>
-    </span>
-    <%= f.email_field :email %>
-    <%= f.text_area :message, rows: 7 %>
-    <%= f.hidden_field :current_url %>
-    <div class="form-actions">
-      <div class="primary-actions">
-      <%= link_to t(:'helpers.action.cancel'), '#', class: 'btn btn-link', data: { 'behavior' => 'cancel-link' } %>
-      <%= f.submit nil, class: 'btn btn-primary' %>
+      <h2><%= t(:'.title') %></h2>
+      <%= f.text_field :name %>
+      <span style="display:none;visibility:hidden;">
+        <% honeypot_field_name = Spotlight::Engine.config.spambot_honeypot_email_field %>
+        <%= label_tag(honeypot_field_name, t(:'.honeypot_field_explanation')) %><br/>
+        <%= f.email_field honeypot_field_name %>
+      </span>
+      <%= f.email_field :email %>
+      <%= f.text_area :message, rows: 7 %>
+      <%= f.hidden_field :current_url %>
+      <div class="form-actions">
+        <div class="primary-actions">
+        <%= link_to t(:'helpers.action.cancel'), '#', class: 'btn btn-link', data: { 'behavior' => 'cancel-link' } %>
+        <%= f.submit nil, class: 'btn btn-primary' %>
+        </div>
       </div>
-    </div>
-  <% end %>
-  </div>
+    <% end %>
   </div>
 </div>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -173,10 +173,6 @@ en:
           small: Small
           medium: Medium
           large: Large
-    contact_forms:
-      new:
-        header: "Feedback"
-        honeypot_field_explanation: 'Ignore this text box. It is used to detect spammers. If you enter anything into this text box, your message will not be sent.'
     curation:
       sidebar:
         header: Curation

--- a/spec/features/report_a_problem_spec.rb
+++ b/spec/features/report_a_problem_spec.rb
@@ -20,6 +20,14 @@ describe 'Report a Problem', type: :feature do
       end
     end
 
+    it 'allows the link to be opened w/o javascript (or in a new tab/window)' do
+      visit spotlight.exhibit_solr_document_path(exhibit, id: 'dq287tq6352')
+
+      click_on 'Feedback'
+
+      expect(page).to have_css('h2', text: 'Contact Us', visible: true)
+    end
+
     it 'accepts a problem report', js: true do
       visit spotlight.exhibit_solr_document_path(exhibit, id: 'dq287tq6352')
       click_on 'Feedback'


### PR DESCRIPTION
- [x] Allow for Feedback links to be opened in a new tab/window
- [x] Have both javascript toggle and stand-alone page use the same form partial

Closes #1656 