### PR TITLE
Override typeahead z-index with a big enough value (restores #1588)

### DIFF
--- a/app/assets/stylesheets/spotlight/typeahead.css
+++ b/app/assets/stylesheets/spotlight/typeahead.css
@@ -20,7 +20,7 @@
 }
 
 .tt-dropdown-menu {
-  z-index: 1000 !important;
+  z-index: $zindex-dropdown !important;
   margin-top: 2px;
   max-height: 360px;
   overflow-y: auto;
@@ -37,6 +37,7 @@
 }
 
 .twitter-typeahead {
+  z-index: $zindex-dropdown !important; /* get typeahead to float on top of e.g. leaflet */
   .tt-suggestion {
     font-size: 18px;
     line-height: 24px;


### PR DESCRIPTION
Fixes https://github.com/sul-dlss/exhibits/issues/1750

Reverts part of 0f02dd9dac3ca494d6ecb0e1534344a70dd7ebaa