### PR TITLE
Add limit to facets, fix custom field facet mapping

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -79,6 +79,10 @@ RSpec/MultipleExpectations:
   Exclude:
     - 'spec/features/**/*'
 
+RSpec/BeforeAfterAll:
+  Exclude:
+    - 'spec/models/spotlight/reindexing_log_entry_spec.rb'
+
 Bundler/DuplicatedGem:
   Enabled: false
 

--- a/app/models/spotlight/blacklight_configuration.rb
+++ b/app/models/spotlight/blacklight_configuration.rb
@@ -209,11 +209,12 @@ module Spotlight
     def custom_facet_fields
       Hash[exhibit.custom_fields.vocab.map do |x|
         field = Blacklight::Configuration::FacetField.new x.configuration.merge(
-          key: x.field, field: x.solr_field, show: false, custom_field: true
+          key: x.solr_field, field: x.solr_field, show: false, custom_field: true
         )
         field.if = :field_enabled?
         field.enabled = false
-        [x.field, field]
+        field.limit = true
+        [x.solr_field, field]
       end]
     end
 

--- a/spec/models/spotlight/blacklight_configuration_spec.rb
+++ b/spec/models/spotlight/blacklight_configuration_spec.rb
@@ -474,14 +474,22 @@ describe Spotlight::BlacklightConfiguration, type: :model do
   describe '#custom_facet_fields' do
     it 'converts exhibit-specific fields to Blacklight configurations' do
       allow(subject.exhibit).to receive_message_chain(:custom_fields, vocab: [
-                                                        stub_model(Spotlight::CustomField, field: 'abc', configuration: { a: 1 }, exhibit: subject.exhibit),
-                                                        stub_model(Spotlight::CustomField, field: 'xyz', configuration: { x: 2 }, exhibit: subject.exhibit)
+                                                        stub_model(Spotlight::CustomField,
+                                                                   solr_field: 'abc',
+                                                                   field: 'abc',
+                                                                   configuration: { a: 1 },
+                                                                   exhibit: subject.exhibit),
+                                                        stub_model(Spotlight::CustomField,
+                                                                   solr_field: 'xyz',
+                                                                   field: 'xyz',
+                                                                   configuration: { x: 2 },
+                                                                   exhibit: subject.exhibit)
                                                       ])
-
       expect(subject.custom_facet_fields).to include 'abc', 'xyz'
       expect(subject.custom_facet_fields['abc']).to be_a_kind_of Blacklight::Configuration::Field
       expect(subject.custom_facet_fields['abc'].a).to eq 1
       expect(subject.custom_facet_fields['abc'].custom_field).to eq true
+      expect(subject.custom_facet_fields['abc'].limit).to eq true
     end
   end
 


### PR DESCRIPTION
It turns out the key is important for the "more" button to work in Blacklight.