### PR TITLE
Add rubocop exclusions to make specs run.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -79,6 +79,10 @@ RSpec/MultipleExpectations:
   Exclude:
     - 'spec/features/**/*'
 
+RSpec/BeforeAfterAll:
+  Exclude:
+    - 'spec/models/spotlight/reindexing_log_entry_spec.rb'
+
 Bundler/DuplicatedGem:
   Enabled: false
 


### PR DESCRIPTION
Possibly made redundant by #1765.