### PR TITLE
Add spotlight to current_page? and link_to helper in exhibit navbar…

### DIFF
--- a/app/views/shared/_exhibit_navbar.html.erb
+++ b/app/views/shared/_exhibit_navbar.html.erb
@@ -5,7 +5,7 @@
     <% end %>
 
     <ul class="nav navbar-nav">
-      <li class="<%= "active" if current_page?(current_exhibit) %>"><%= link_to t(:'spotlight.curation.nav.home'), current_exhibit %></li>
+      <li class="<%= "active" if current_page?([spotlight, current_exhibit]) %>"><%= link_to t(:'spotlight.curation.nav.home'), [spotlight, current_exhibit] %></li>
       <% current_exhibit.main_navigations.displayable.each do |navigation| %>
         <%= render partial: "shared/#{navigation.nav_type}_navbar", locals: { navigation: navigation } %>
       <% end %>


### PR DESCRIPTION
…partial.

This allows the upstream app to render this partial (e.g. when adding local admin pages)