### PR TITLE
Prevent overflow of the index_status when deploying to mysql

### DIFF
--- a/db/migrate/20170821165811_change_index_status_to_longblob.rb
+++ b/db/migrate/20170821165811_change_index_status_to_longblob.rb
@@ -1,0 +1,5 @@
+class ChangeIndexStatusToLongblob < ActiveRecord::Migration[5.0]
+  def change
+    change_column :spotlight_solr_document_sidecars, :index_status, :binary, limit: 10.megabytes
+  end
+end


### PR DESCRIPTION
Prevents an error like:
```
ActiveRecord::ValueTooLong: Mysql2::Error: Data too long for column
'index_status' at row 1: UPDATE `spotlight_solr_document_sidecars` SET
`index_status` = x'2d2d2d0a3a6f6...
```

by converting the `binary` column into a LONGBLOB type