### PR TITLE
Don't include jquery by default.

### DIFF
--- a/app/assets/javascripts/spotlight/application.js
+++ b/app/assets/javascripts/spotlight/application.js
@@ -10,7 +10,6 @@
 // Read Sprockets README (https://github.com/sstephenson/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//= require jquery
 //= require underscore
 //= require eventable
 //= require sir-trevor


### PR DESCRIPTION
Blacklight already generates jquery into the host app.
We also want to enable the host to change versions (to jquery3 for
example)