### PR TITLE
Uses a backwards compatible ujs adapater.

### DIFF
--- a/app/assets/javascripts/spotlight/pages.js.erb
+++ b/app/assets/javascripts/spotlight/pages.js.erb
@@ -1,13 +1,14 @@
 // Place all the behaviors and hooks related to the matching controller here.
 // All this logic will automatically be available in application.js.
 Spotlight.onLoad(function(){
-
+  // Set a ujs adapter to support both rails-ujs and jquery-ujs
+  var ujs = typeof Rails === 'undefined' ? $.rails : Rails;
   SirTrevor.setDefaults({
     iconUrl: <%= asset_path('spotlight/blocks/sir-trevor-icons.svg').to_json %>,
     uploadUrl: $('[data-attachment-endpoint]').data('attachment-endpoint'),
     ajaxOptions: {
       headers: {
-        'X-CSRF-Token': (Rails || $.rails).csrfToken() || ''
+        'X-CSRF-Token': ujs.csrfToken() || ''
       },
       credentials: 'same-origin'
     }


### PR DESCRIPTION
For a Spotlight adopter not on Rails 5.1, `Rails` will be undefined
without including rails-ujs. This sets the adapter for both rails-ujs
and jquery-ujs adopters.