### PR TITLE
Specifies png as the custom theme's image extension

### DIFF
--- a/app/views/spotlight/appearances/edit.html.erb
+++ b/app/views/spotlight/appearances/edit.html.erb
@@ -41,7 +41,7 @@
         <%= f.form_group :theme, label: { text: t(:'.site_theme.label') } do %>
           <% Spotlight::Engine.config.exhibit_themes.each do |theme| %>
             <div class="col-md-6">
-              <%= image_tag "spotlight/themes/#{theme}_preview", width: 100, height: 100 %>
+              <%= image_tag "spotlight/themes/#{theme}_preview.png", width: 100, height: 100 %>
               <%= f.radio_button :theme, theme, label: t(:".site_theme.#{theme}", default: theme.to_s.titleize), inline: true %>
             </div>
           <% end %>


### PR DESCRIPTION
Per Rails guides, when using `image_tag` you must specify the extension
of the image.

http://guides.rubyonrails.org/layouts_and_rendering.html#linking-to-images-with-the-image-tag

An error is noticed when using Spotlight in a production environment.