### PR TITLE
Remove application.scss as it duplicates spotlight.scss

### DIFF
--- a/app/assets/stylesheets/spotlight/application.scss
+++ b/app/assets/stylesheets/spotlight/application.scss
@@ -1,5 +1,0 @@
-@import 'spotlight/variables_bootstrap';
-@import "bootstrap-sprockets";
-@import 'bootstrap';
-@import 'sir-trevor/main';
-@import 'spotlight/spotlight';


### PR DESCRIPTION
The latter is generated into the application.  Having both scss files
means that bootstrap is loaded twice.

Fixes #1833