### PR TITLE
add missing migration from acts-as-taggable-on

### DIFF
--- a/db/migrate/20171005231502_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20171005231502_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
@@ -1,0 +1,23 @@
+# This migration comes from acts_as_taggable_on_engine (originally 6)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingIndexesOnTaggings < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingIndexesOnTaggings < ActiveRecord::Migration; end
+end
+AddMissingIndexesOnTaggings.class_eval do
+  def change
+    add_index :taggings, :tag_id unless index_exists? :taggings, :tag_id
+    add_index :taggings, :taggable_id unless index_exists? :taggings, :taggable_id
+    add_index :taggings, :taggable_type unless index_exists? :taggings, :taggable_type
+    add_index :taggings, :tagger_id unless index_exists? :taggings, :tagger_id
+    add_index :taggings, :context unless index_exists? :taggings, :context
+
+    unless index_exists? :taggings, [:tagger_id, :tagger_type]
+      add_index :taggings, [:tagger_id, :tagger_type]
+    end
+
+    unless index_exists? :taggings, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+      add_index :taggings, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+    end
+  end
+end


### PR DESCRIPTION
I think this migration was missed in the acts-as-taggable-on v5.0 upgrade cc @cbeer 