### PR TITLE
make sure the data attribute is in form of data-block-types for Sir T…

### DIFF
--- a/app/views/spotlight/pages/_form.html.erb
+++ b/app/views/spotlight/pages/_form.html.erb
@@ -51,7 +51,7 @@
         </div>
         <div class="form-group">
           <%= f.label :content, class: 'sr-only' %>
-          <%= f.text_area_without_bootstrap :content, value: { data: f.object.content.as_json }.to_json, class: 'js-st-instance', data: { blockTypes: Spotlight::Engine.config.sir_trevor_widgets } %>
+          <%= f.text_area_without_bootstrap :content, value: { data: f.object.content.as_json }.to_json, class: 'js-st-instance', data: { 'block-types': Spotlight::Engine.config.sir_trevor_widgets } %>
         </div>
       </div>
 

--- a/spec/views/spotlight/pages/_form.html.erb_spec.rb
+++ b/spec/views/spotlight/pages/_form.html.erb_spec.rb
@@ -1,0 +1,18 @@
+describe 'spotlight/pages/edit', type: :view do
+  let(:exhibit) { stub_model(Spotlight::Exhibit) }
+  let(:page) { stub_model(Spotlight::FeaturePage, exhibit: exhibit) }
+  let :blacklight_config do
+    Blacklight::Configuration.new
+  end
+  before do
+    assign(:page, page)
+    allow(view).to receive_messages(blacklight_config: blacklight_config,
+                                    available_index_fields: [],
+                                    available_view_fields: [],
+                                    featured_images_path: '/foo')
+  end
+  it 'contains data-block-types attribute needed for SirTrevor instantiation' do
+    render
+    expect(rendered).to have_css '.js-st-instance[data-block-types]'
+  end
+end


### PR DESCRIPTION
…revor widgets

This bug was introduced in PR #1781. Essentially, previously, the JavaScript method `instance.data('blockTypes')` was not finding anything because the data-attribute was in the form of `data-blocktypes`. This caused all of the sir trevor registered widgets to be loaded unexpectedly allowing exhibit curators to possibly select unsupported widgets.