### PR TITLE
Cast empty items to a Hash for empty browse categories & feature pages

### DIFF
--- a/app/models/sir_trevor_rails/blocks/browse_block.rb
+++ b/app/models/sir_trevor_rails/blocks/browse_block.rb
@@ -32,7 +32,9 @@ module SirTrevorRails
       def as_json
         result = super
 
-        result[:data][:item].each do |_k, v|
+        result[:data][:item] ||= {}
+
+        result[:data][:item].each_value do |v|
           v['thumbnail_image_url'] = parent.exhibit.searches.find(v['id']).thumbnail_image_url
         end
 

--- a/app/models/sir_trevor_rails/blocks/featured_pages_block.rb
+++ b/app/models/sir_trevor_rails/blocks/featured_pages_block.rb
@@ -22,7 +22,9 @@ module SirTrevorRails
       def as_json
         result = super
 
-        result[:data][:item].each do |_k, v|
+        result[:data][:item] ||= {}
+
+        result[:data][:item].each_value do |v|
           v['thumbnail_image_url'] = parent.exhibit.pages.find(v['id']).thumbnail_image_url
         end
 

--- a/spec/models/sir_trevor_rails/blocks/browse_block_spec.rb
+++ b/spec/models/sir_trevor_rails/blocks/browse_block_spec.rb
@@ -18,4 +18,12 @@ describe SirTrevorRails::Blocks::BrowseBlock do
       expect(subject.items).to eq([])
     end
   end
+  describe '#as_json' do
+    context 'when no items are present' do
+      it 'returns an empty items value' do
+        block_data[:items] = nil
+        expect(subject.as_json[:data]).to include items: nil
+      end
+    end
+  end
 end

--- a/spec/models/sir_trevor_rails/blocks/featured_pages_block_spec.rb
+++ b/spec/models/sir_trevor_rails/blocks/featured_pages_block_spec.rb
@@ -17,4 +17,12 @@ describe SirTrevorRails::Blocks::FeaturedPagesBlock do
       expect(subject.items).to eq([])
     end
   end
+  describe '#as_json' do
+    context 'when no items are present' do
+      it 'returns an empty items value' do
+        block_data[:items] = nil
+        expect(subject.as_json[:data]).to include items: nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
We noticed this issue downstream in Exhibits, that when enabling "browse categories" and then creating an empty "BrowseBlock" (no browse category added), an "undefined method each for nil" error could be raised. This PR ensures that `items` retrieved from `data` are cast to a `Hash` with `.each` available.

See: https://github.com/sul-dlss/exhibits/issues/789