### PR TITLE
Store a copy of the original field configuration before applying spotlight-specific changes

### DIFF
--- a/app/controllers/spotlight/concerns/application_controller.rb
+++ b/app/controllers/spotlight/concerns/application_controller.rb
@@ -27,9 +27,7 @@ module Spotlight
       end
 
       def enabled_in_spotlight_view_type_configuration?(config, *args)
-        if config.respond_to?(:upstream_if) &&
-           !config.upstream_if.nil? &&
-           !blacklight_configuration_context.evaluate_configuration_conditional(config.upstream_if, config, *args)
+        if config.respond_to?(:original) && !blacklight_configuration_context.evaluate_if_unless_configuration(config.original, *args)
           false
         elsif current_exhibit.nil? || is_a?(Spotlight::PagesController)
           true
@@ -38,13 +36,11 @@ module Spotlight
         end
       end
 
-      # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/MethodLength
+      # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity, Metrics/MethodLength
       def field_enabled?(field, *args)
         if !field.enabled
           false
-        elsif field.respond_to?(:upstream_if) &&
-              !field.upstream_if.nil? &&
-              !blacklight_configuration_context.evaluate_configuration_conditional(field.upstream_if, field, *args)
+        elsif field.respond_to?(:original) && !blacklight_configuration_context.evaluate_if_unless_configuration(field.original, *args)
           false
         elsif field.is_a?(Blacklight::Configuration::SortField) || field.is_a?(Blacklight::Configuration::SearchField)
           field.enabled
@@ -54,7 +50,7 @@ module Spotlight
           field.send(document_index_view_type)
         end
       end
-      # rubocop:enable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/MethodLength
+      # rubocop:enable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity, Metrics/MethodLength
 
       private
 

--- a/app/models/spotlight/blacklight_configuration.rb
+++ b/app/models/spotlight/blacklight_configuration.rb
@@ -88,6 +88,7 @@ module Spotlight
 
         # Update with customizations
         config.index_fields.each do |k, v|
+          v.original = v.dup
           if index_fields[k]
             v.merge! index_fields[k].symbolize_keys
           elsif custom_index_fields[k]
@@ -99,7 +100,6 @@ module Spotlight
           v.immutable = Blacklight::OpenStructWithHashAccess.new(v.immutable)
           v.merge! v.immutable.to_h.symbolize_keys
 
-          v.upstream_if = v.if unless v.if.nil?
           v.if = :field_enabled? unless v.if == false
 
           v.normalize! config
@@ -109,6 +109,7 @@ module Spotlight
         config.show_fields.reject! { |_k, v| v.if == false }
 
         config.show_fields.reject { |k, _v| config.index_fields[k] }.each do |k, v|
+          v.original = v.dup
           config.index_fields[k] = v
 
           if index_fields[k]
@@ -120,7 +121,6 @@ module Spotlight
           v.immutable = Blacklight::OpenStructWithHashAccess.new(v.immutable)
           v.merge! v.immutable.to_h.symbolize_keys
 
-          v.upstream_if = v.if unless v.if.nil?
           v.if = :field_enabled? unless v.if == false
 
           v.normalize! config
@@ -133,7 +133,7 @@ module Spotlight
           config.search_fields = Hash[config.search_fields.sort_by { |k, _v| field_weight(search_fields, k) }]
 
           config.search_fields.each do |k, v|
-            v.upstream_if = v.if unless v.if.nil?
+            v.original = v.dup
             v.if = :field_enabled? unless v.if == false
             next if search_fields[k].blank?
 
@@ -147,7 +147,7 @@ module Spotlight
           config.sort_fields = Hash[config.sort_fields.sort_by { |k, _v| field_weight(sort_fields, k) }]
 
           config.sort_fields.each do |k, v|
-            v.upstream_if = v.if unless v.if.nil?
+            v.original = v.dup
             v.if = :field_enabled? unless v.if == false
             next if sort_fields[k].blank?
 
@@ -162,13 +162,12 @@ module Spotlight
           config.facet_fields = Hash[config.facet_fields.sort_by { |k, _v| field_weight(facet_fields, k) }]
 
           config.facet_fields.each do |k, v|
+            v.original = v.dup
             next if facet_fields[k].blank?
 
             v.merge! facet_fields[k].symbolize_keys
-            v.upstream_if = v.if unless v.if.nil?
             v.enabled = v.show
             v.if = :field_enabled? unless v.if == false
-            v.upstream_if = nil if v.upstream_if == v.if
             v.normalize! config
             v.validate!
           end
@@ -182,8 +181,8 @@ module Spotlight
         end
 
         config.view.each do |k, v|
+          v.original = v.dup
           v.key = k
-          v.upstream_if = v.if unless v.if.nil?
           v.if = :enabled_in_spotlight_view_type_configuration? unless v.if == false
         end unless document_index_view_types.blank?
 

--- a/app/views/spotlight/metadata_configurations/edit.html.erb
+++ b/app/views/spotlight/metadata_configurations/edit.html.erb
@@ -28,7 +28,7 @@
       </thead>
       <tbody class="metadata_fields dd dd-list" data-behavior="nestable" data-max-depth="1" data-list-node-name="tbody" data-item-node-name="tr" data-expand-btn-HTML=" " data-collapse-btn-HTML=" ">
         <%= f.fields_for :index_fields do |idxf| %>
-          <% @blacklight_configuration.blacklight_config.index_fields.each do |key, config| %>
+          <% @blacklight_configuration.blacklight_config.index_fields.select { |k, v| blacklight_configuration_context.evaluate_if_unless_configuration(v.original) }.each do |key, config| %>
             <%= render partial: 'metadata_field', locals: { key: key, config: config, f: idxf } %>
           <% end %>
         <% end %>

--- a/app/views/spotlight/search_configurations/_facets.html.erb
+++ b/app/views/spotlight/search_configurations/_facets.html.erb
@@ -2,7 +2,7 @@
 <div class="panel-group dd facet_fields" id="nested-fields" data-behavior="nestable" data-max-depth="1">
   <ol class="dd-list">
     <%= f.fields_for :facet_fields do |idxf| %>
-      <% @blacklight_configuration.blacklight_config.facet_fields.each do |key, config| %>
+      <% @blacklight_configuration.blacklight_config.facet_fields.select { |k, v| blacklight_configuration_context.evaluate_if_unless_configuration(v.original) }.each do |key, config| %>
         <% metadata = @field_metadata.field(key) %>
         <% next unless metadata[:document_count] > 0 || config.custom_field %>
         <li class="dd-item" data-id="<%= key.parameterize %>">

--- a/app/views/spotlight/search_configurations/_search_fields.html.erb
+++ b/app/views/spotlight/search_configurations/_search_fields.html.erb
@@ -30,7 +30,7 @@
     </ol>
     <div class="panel-group dd search_fields_admin col-sm-7" id="nested-search-fields" data-behavior="nestable" data-max-depth="1">
       <ol class="dd-list">
-        <% @blacklight_configuration.blacklight_config.search_fields.select { |_k, v| v.include_in_simple_select != false }.except(default_field.key).each_with_index do |(k, config), index| %>
+        <% @blacklight_configuration.blacklight_config.search_fields.select { |_k, v| blacklight_configuration_context.evaluate_if_unless_configuration(v.original) && v.include_in_simple_select != false }.except(default_field.key).each_with_index do |(k, config), index| %>
             <li class="dd-item dd3-item" data-id="<%= k.parameterize %>-id">
               <div class="dd3-content panel panel-default">
                 <div class="dd-handle dd3-handle"><%= t(:drag) %></div>

--- a/app/views/spotlight/search_configurations/_sort.html.erb
+++ b/app/views/spotlight/search_configurations/_sort.html.erb
@@ -25,7 +25,7 @@
     </ol>
     <div class="panel-group dd sort_fields_admin col-sm-7" id="nested-sort-fields" data-behavior="nestable" data-max-depth="1">
       <ol class="dd-list">
-        <% @blacklight_configuration.blacklight_config.sort_fields.except(default_field.key).each_with_index do |(k, config), index| %>
+        <% @blacklight_configuration.blacklight_config.sort_fields.select { |k, v| blacklight_configuration_context.evaluate_if_unless_configuration(v.original) }.except(default_field.key).each_with_index do |(k, config), index| %>
             <li class="dd-item dd3-item" data-id="<%= k.parameterize %>-id">
               <div class="dd3-content panel panel-default">
                 <div class="dd-handle dd3-handle"><%= t(:drag) %></div>

--- a/spec/controllers/spotlight/catalog_controller_spec.rb
+++ b/spec/controllers/spotlight/catalog_controller_spec.rb
@@ -440,7 +440,7 @@ describe Spotlight::CatalogController, type: :controller do
       expect(controller.field_enabled?(field)).to eq :value
     end
     it 'returns the value of the original if condition' do
-      allow(field).to receive(:upstream_if).and_return false
+      allow(field).to receive(:original).and_return false
       expect(controller.field_enabled?(field)).to eq false
     end
   end
@@ -452,7 +452,7 @@ describe Spotlight::CatalogController, type: :controller do
     end
 
     it 'respects the original if condition' do
-      view.upstream_if = false
+      view.original = false
       expect(controller.enabled_in_spotlight_view_type_configuration?(view)).to eq false
     end
 

--- a/spec/views/spotlight/search_configurations/_facets.html.erb_spec.rb
+++ b/spec/views/spotlight/search_configurations/_facets.html.erb_spec.rb
@@ -37,4 +37,16 @@ describe 'spotlight/search_configurations/_facets', type: :view do
   it 'hides the config for the empty genre facet' do
     expect(rendered).not_to have_content 'Genre'
   end
+
+  describe do
+    before do
+      original_config = Spotlight::Engine.blacklight_config.deep_dup
+      allow(Spotlight::Engine).to receive(:blacklight_config).and_return(original_config)
+      original_config.add_facet_field 'some_hidden_field', if: ->(*_args) { false }
+    end
+
+    it 'hides the config facets configured not to display' do
+      expect(rendered).not_to have_content 'Some hidden field'
+    end
+  end
 end

--- a/spec/views/spotlight/search_configurations/_search_fields.html.erb_spec.rb
+++ b/spec/views/spotlight/search_configurations/_search_fields.html.erb_spec.rb
@@ -9,6 +9,9 @@ describe 'spotlight/search_configurations/_search_fields', type: :view do
   end
 
   before do
+    original_config = Spotlight::Engine.blacklight_config.deep_dup
+    allow(Spotlight::Engine).to receive(:blacklight_config).and_return(original_config)
+    original_config.add_search_field 'some_field_with_a_condition', if: ->(*_args) { false }
     assign(:exhibit, exhibit)
     assign(:blacklight_configuration, exhibit.blacklight_configuration)
     allow(view).to receive_messages(current_exhibit: exhibit)
@@ -39,7 +42,11 @@ describe 'spotlight/search_configurations/_search_fields', type: :view do
     expect(rendered).not_to have_selector "input[name='blacklight_configuration[search_fields][some_hidden_field][enabled]']"
   end
 
-  it 'parameterizes the data-id attribute for searcn field keh' do
+  it 'excludes search options that have if/unless configuration that causes them not to be displayed' do
+    expect(rendered).not_to have_selector "input[name='blacklight_configuration[search_fields][some_field_with_a_condition][enabled]']"
+  end
+
+  it 'parameterizes the data-id attribute for search field key' do
     expect(rendered).to have_selector '[data-id="some_field-with_a_space-id"]'
   end
 end

--- a/spec/views/spotlight/search_configurations/_sort.html.erb_spec.rb
+++ b/spec/views/spotlight/search_configurations/_sort.html.erb_spec.rb
@@ -1,6 +1,10 @@
 describe 'spotlight/search_configurations/_sort', type: :view do
   let(:exhibit) { FactoryBot.create(:exhibit) }
+
   before do
+    original_config = Spotlight::Engine.blacklight_config.deep_dup
+    allow(Spotlight::Engine).to receive(:blacklight_config).and_return(original_config)
+    original_config.add_sort_field 'some_disabled_field', if: ->(*_args) { false }
     exhibit.blacklight_config.add_sort_field 'sort_title_ssi asc, plus_another_field desc', label: 'TestSort'
     assign(:exhibit, exhibit)
     assign(:blacklight_configuration, exhibit.blacklight_configuration)
@@ -26,5 +30,10 @@ describe 'spotlight/search_configurations/_sort', type: :view do
   it 'parameterizes the data-id attribute for sort fields (e.g. when no key is supplied and the sort is used as the key)' do
     render partial: 'spotlight/search_configurations/sort', locals: { f: f }
     expect(rendered).to have_css('[data-id="sort_title_ssi-asc-plus_another_field-desc-id"]')
+  end
+
+  it 'hides fields that are configured not to display' do
+    render partial: 'spotlight/search_configurations/sort', locals: { f: f }
+    expect(rendered).not_to have_css('[data-id="some_disabled_field-id"]')
   end
 end


### PR DESCRIPTION
Use this, instead of the upstream_if hack, to evaluate whether to offer fields for admin users or not