### PR TITLE
Remove PhantomJS requirement from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,6 @@ Our `$ rake ci` and `$ rake spotlight:server` tasks utilize Solr and the testing
 
 ## Tests
 
-### Prerequisites
-
-PhantomJS (https://github.com/teampoltergeist/poltergeist#installing-phantomjs) is an addition requirement for testing javascript.
-
 ### Run all the tests:
 
 ```


### PR DESCRIPTION
We switched from PhantomJS to ChromeDriver in [316ada6](https://github.com/projectblacklight/spotlight/commit/316ada66493bac8df93854c7602d6563c0578777).