### PR TITLE
Only handle browse block items whose block id/slug exists.

### DIFF
--- a/app/models/sir_trevor_rails/blocks/browse_block.rb
+++ b/app/models/sir_trevor_rails/blocks/browse_block.rb
@@ -34,6 +34,10 @@ module SirTrevorRails
 
         result[:data][:item] ||= {}
 
+        # TODO: This is a temporary fix that simply removes any item if the search identifier does not exist
+        #       We should have a more permanent solution that will allow browse blocks to be updated without erroring
+        result[:data][:item].select! { |_, v| parent.exhibit.searches.exists?(v['id']) }
+
         result[:data][:item].each_value do |v|
           v['thumbnail_image_url'] = parent.exhibit.searches.find(v['id']).thumbnail_image_url
         end

--- a/spec/models/sir_trevor_rails/blocks/browse_block_spec.rb
+++ b/spec/models/sir_trevor_rails/blocks/browse_block_spec.rb
@@ -25,5 +25,15 @@ describe SirTrevorRails::Blocks::BrowseBlock do
         expect(subject.as_json[:data]).to include items: nil
       end
     end
+
+    context 'when the id of a browse category does not exist' do
+      it 'is not included the returned items hash' do
+        search = FactoryGirl.create(:search, exhibit: page.exhibit)
+        block_data[:item] = { item_0: { 'id' => 'abc123' }, item_1: { 'id' => search.slug } }
+
+        expect(subject.as_json[:data][:item]).not_to have_key :item_0
+        expect(subject.as_json[:data][:item]).to have_key :item_1
+      end
+    end
   end
 end

--- a/spec/models/sir_trevor_rails/blocks/browse_block_spec.rb
+++ b/spec/models/sir_trevor_rails/blocks/browse_block_spec.rb
@@ -21,8 +21,8 @@ describe SirTrevorRails::Blocks::BrowseBlock do
   describe '#as_json' do
     context 'when no items are present' do
       it 'returns an empty items value' do
-        block_data[:items] = nil
-        expect(subject.as_json[:data]).to include items: nil
+        block_data[:item] = nil
+        expect(subject.as_json[:data]).to include item: {}
       end
     end
 

--- a/spec/models/sir_trevor_rails/blocks/featured_pages_block_spec.rb
+++ b/spec/models/sir_trevor_rails/blocks/featured_pages_block_spec.rb
@@ -20,8 +20,8 @@ describe SirTrevorRails::Blocks::FeaturedPagesBlock do
   describe '#as_json' do
     context 'when no items are present' do
       it 'returns an empty items value' do
-        block_data[:items] = nil
-        expect(subject.as_json[:data]).to include items: nil
+        block_data[:item] = nil
+        expect(subject.as_json[:data]).to include item: {}
       end
     end
   end


### PR DESCRIPTION
This is a temporary fix to stop errors being thrown on edit pages.  A more permanent solution should be implemented in the future.

Connects to #1782 

