### PR TITLE
just use existing search_results icon

### DIFF
--- a/app/assets/javascripts/spotlight/blocks/link_to_search_block.js
+++ b/app/assets/javascripts/spotlight/blocks/link_to_search_block.js
@@ -6,7 +6,7 @@ SirTrevor.Blocks.LinkToSearch = (function(){
 
     type: "link_to_search",
 
-    icon_name: 'link_to_search',
+    icon_name: 'search_results',
 
     searches_key: "slug",
     view_key: "view",


### PR DESCRIPTION
Closes #1863 for now. So we don't have to update the svg sprites for this. Likely we should have a repo / process / command for doing this in the future.

<img width="327" alt="screen shot 2017-11-15 at 2 50 11 pm" src="https://user-images.githubusercontent.com/1656824/32864501-4f4e4870-ca14-11e7-939f-865a23ded499.png">
