### PR TITLE
provide support to configure a view by default to show the title only

### DIFF
--- a/app/models/spotlight/blacklight_configuration.rb
+++ b/app/models/spotlight/blacklight_configuration.rb
@@ -319,7 +319,14 @@ module Spotlight
       return unless index_fields.blank?
 
       views = default_blacklight_config.view.keys | [:show, :enabled]
-      field.merge! Hash[views.map { |v| [v, true] }]
+      field.merge! Hash[views.map { |v| [v, !title_only_by_default?(v)] }]
+    end
+
+    # Check to see whether config.view.foobar.title_only_by_default is available
+    def title_only_by_default?(view)
+      return false if [:show, :enabled].include?(view)
+      title_only = default_blacklight_config.view.send(:[], view).try(:title_only_by_default)
+      title_only.nil? ? false : title_only
     end
 
     def set_show_field_defaults(field)

--- a/lib/generators/spotlight/templates/catalog_controller.rb
+++ b/lib/generators/spotlight/templates/catalog_controller.rb
@@ -22,5 +22,8 @@ class CatalogController < ApplicationController
     config.add_sort_field 'relevance', sort: 'score desc', label: 'Relevance'
 
     config.add_field_configuration_to_solr_request!
+
+    # Set which views by default only have the title displayed, e.g.,
+    # config.view.gallery.title_only_by_default = true
   end
 end

--- a/spec/models/spotlight/blacklight_configuration_spec.rb
+++ b/spec/models/spotlight/blacklight_configuration_spec.rb
@@ -289,6 +289,19 @@ describe Spotlight::BlacklightConfiguration, type: :model do
 
       expect(subject.blacklight_config.show_fields.keys).to eq %w(c a b)
     end
+
+    context 'title only configuration' do
+      before do
+        blacklight_config.configure do |config|
+          config.view.gallery.title_only_by_default = true
+          config.add_index_field 'a'
+        end
+      end
+      it 'only shows titles (i.e., no metadata) for gallery view' do
+        expect(subject.blacklight_config.index_fields['a'][:list]).to eq true
+        expect(subject.blacklight_config.index_fields['a'][:gallery]).to eq false
+      end
+    end
   end
 
   describe 'a newly created instance' do


### PR DESCRIPTION
This PR is connected to https://github.com/sul-dlss/exhibits/issues/999, and it fixes #1810, fixes #1809, and fixes #1808.

To enable the title only by default (i.e., deselected all metadata by default), you need to configure the `view.foobar` data, like so:

```
config.view.gallery.title_only_by_default = true
```

### After (with gallery, masonry, and slideshow configured to be off by default)

![screen shot 2017-12-07 at 1 28 49 pm](https://user-images.githubusercontent.com/1861171/33740171-95de1760-db54-11e7-8c2b-00c5b7a2d16e.png)