### PR TITLE
Add helptext to add user form

### DIFF
--- a/app/views/spotlight/roles/_edit_fields.html.erb
+++ b/app/views/spotlight/roles/_edit_fields.html.erb
@@ -1,6 +1,6 @@
         <tr data-edit-for="<%= f.object.new_record? ? 'new' : f.object.id %>">
           <td>
-            <%= f.email_field :user_key, hide_label: true, disabled: f.object.persisted? %>
+            <%= f.email_field :user_key, hide_label: true, disabled: f.object.persisted?, help: (t('.help') if f.object.new_record?) %>
           </td>
           <td><%= f.select :role, roles_for_select, hide_label: true %></td>
           <td></td>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -589,6 +589,7 @@ en:
       edit_fields:
         invite_html: "This user does not yet exist. Would you like to send them an %{link}?"
         invite_link: invite
+        help: Enter a valid email address
       index:
         title: Site Configuration - Users
         invite_pending: pending


### PR DESCRIPTION
TODO:
- [x] Investigate why `master` build is failing on Travis #1875 

Related: sul-dlss/exhibits#1040

This PR adds help text to the new user form in Configuration > Users. The default i18n key can be overridden in `spotlight.roles.edit_fields.help`.

@ggeisler What do you think about this default helper text?
@jkeck opinions? 

## ~~Option 1: Bootstrappy~~
<img width="710" alt="bootstrappy" src="https://user-images.githubusercontent.com/5402927/34278148-03b5b720-e65e-11e7-924e-0af535444c37.png">

```html
<div class="form-group">
  <label class="sr-only control-label" for="exhibit_roles_attributes_2_user_key">User key</label>
  <input aria-describedby="newUserHelpBlock" class="form-control" type="email" name="exhibit[roles_attributes][2][user_key]" id="exhibit_roles_attributes_2_user_key">
</div>
<small id="newUserHelpBlock" class="form-text text-muted">Please use a valid email address</small>
```

- [x] ~~throw in some CSS to fix the margin?~~

## Option 2: Form helper inline magic
<img width="708" alt="form helper" src="https://user-images.githubusercontent.com/5402927/34278150-0583c65a-e65e-11e7-8ed9-79f7ce3513f5.png">

```html
<div class="form-group">
  <label class="sr-only control-label" for="exhibit_roles_attributes_2_user_key">User key</label>
  <input class="form-control" type="email" name="exhibit[roles_attributes][2][user_key]" id="exhibit_roles_attributes_2_user_key">
  <span class="help-block">Please use a valid email address</span>
</div>
```
  
  
  