### PR TITLE
Update flaky JS test and add TravisCI workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
   include:
     - rvm: 2.3.4
       env: "RAILS_VERSION=5.0.5"
-      
+
 before_install:
   - gem update --system
   - gem install bundler
@@ -25,7 +25,9 @@ env:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
     - RAILS_VERSION=5.1.2
 
-sudo: false
+# Workaround for https://github.com/travis-ci/travis-ci/issues/8836
+# sudo: false
+sudo: required
 language: ruby
 
 script:

--- a/spec/features/javascript/search_config_admin_spec.rb
+++ b/spec/features/javascript/search_config_admin_spec.rb
@@ -14,6 +14,7 @@ feature 'Search Configuration Administration', js: true do
       end
       click_link 'Search'
 
+      expect(page).to have_css 'input#enable_feature', visible: true
       uncheck 'Display search box'
 
       click_button 'Save changes'


### PR DESCRIPTION
- Updating some JS tests that have been (inconsistently) killing Travis builds this week
- Applying a .travis.yml workaround that may help with builds timing out


- [x] `rspec ./spec/features/javascript/search_config_admin_spec.rb:7` # Search Configuration Administration search fields allows the curator to disable all search field
- [x] add `sudo: required` TravisCI workaround ([related to Meltdown](https://blog.travis-ci.com/2018-01-08-travis-response-meltdown-spectre))


- [ ] ~~rspec ./spec/features/javascript/blocks/solr_documents_block_spec.rb:130 # Solr Document Block should allow you to optionally display a ZPR link with the image~~ (putting a pin in this for later)
```ruby
Failure/Error: expect(page).to have_selector('.zpr-link[data-iiif-tilesource]')
     expected to find visible css ".zpr-link[data-iiif-tilesource]" but there were no matches
   # ./spec/features/javascript/blocks/solr_documents_block_spec.rb:137:in `block (2 levels) in <top (required)>'
```
