### PR TITLE
Add a configurable search box to browse categories

### DIFF
--- a/app/assets/javascripts/spotlight/clear_form_button.js
+++ b/app/assets/javascripts/spotlight/clear_form_button.js
@@ -4,18 +4,24 @@ Spotlight.onLoad(function() {
 
 (function($) {
   $.fn.ClearFormButton = function() {
-    var clearBtn = this;
-    var input = $(clearBtn).parent().prev('input');
-    $(input).on('keyup', function() {
-      if (input.val() !== '') {
-        $(clearBtn).css('display', 'inline-block');
+    var $clearBtn = $(this);
+    var $input = $clearBtn.parent().prev('input');
+    var btnCheck = function(){
+      if ($input.val() !== '') {
+        $clearBtn.css('display', 'inline-block');
       } else {
-        $(clearBtn).css('display', 'none');
+        $clearBtn.css('display', 'none');
       }
+    };
+
+    btnCheck();
+    $input.on('keyup', function() {
+      btnCheck();
     });
-    $(clearBtn).on('click', function(event) {
+
+    $clearBtn.on('click', function(event) {
       event.preventDefault();
-      input.val('');
+      $input.val('');
     });
   };
 })(jQuery);

--- a/app/assets/javascripts/spotlight/clear_form_button.js
+++ b/app/assets/javascripts/spotlight/clear_form_button.js
@@ -1,0 +1,21 @@
+Spotlight.onLoad(function() {
+  $('.btn-reset').ClearFormButton();
+});
+
+(function($) {
+  $.fn.ClearFormButton = function() {
+    var clearBtn = this;
+    var input = $(clearBtn).parent().prev('input');
+    $(input).on('keyup', function() {
+      if (input.val() !== '') {
+        $(clearBtn).css('display', 'inline-block');
+      } else {
+        $(clearBtn).css('display', 'none');
+      }
+    });
+    $(clearBtn).on('click', function(event) {
+      event.preventDefault();
+      input.val('');
+    });
+  };
+})(jQuery);

--- a/app/assets/stylesheets/spotlight/_browse.scss
+++ b/app/assets/stylesheets/spotlight/_browse.scss
@@ -103,3 +103,15 @@ $image-overlay-bottom-margin: $padding-large-vertical * 3;
     .image-overlay {max-height: $image-overlay-max-height;}
   }
 }
+
+.search-box-container {
+  margin: 0 auto;
+  text-align: center;
+  width: 100%;
+
+  .browse-search-form {
+    .browse-search-expand {
+      text-align: center;
+    }
+  }
+}

--- a/app/assets/stylesheets/spotlight/_browse.scss
+++ b/app/assets/stylesheets/spotlight/_browse.scss
@@ -113,5 +113,17 @@ $image-overlay-bottom-margin: $padding-large-vertical * 3;
     .browse-search-expand {
       text-align: center;
     }
+
+    .btn-reset {
+      background-color: transparent;
+      display: none;
+      left: -40px;
+      z-index: 20;
+    }
+
+    .search-btn {
+      left: -40px;
+      z-index: 30;
+    }
   }
 }

--- a/app/controllers/spotlight/browse_controller.rb
+++ b/app/controllers/spotlight/browse_controller.rb
@@ -39,6 +39,7 @@ module Spotlight
     end
 
     def search_query
+      @search.query_params[:q] = [@search.query_params[:q], params[:browse_q]].join(' ')
       @search.merge_params_for_search(params, blacklight_config)
     end
 

--- a/app/controllers/spotlight/searches_controller.rb
+++ b/app/controllers/spotlight/searches_controller.rb
@@ -102,6 +102,7 @@ module Spotlight
       params.require(:search).permit(
         :title,
         :long_description,
+        :search_box,
         :default_index_view_type,
         masthead_attributes: featured_image_params,
         thumbnail_attributes: featured_image_params

--- a/app/helpers/spotlight/browse_helper.rb
+++ b/app/helpers/spotlight/browse_helper.rb
@@ -27,7 +27,7 @@ module Spotlight
     ##
     # Get parent results count of a browse category search
     def parent_search_count
-      Spotlight::Search.find(@search.id).count
+      @parent_search_count ||= Spotlight::Search.find(@search.id).count
     end
 
     private

--- a/app/helpers/spotlight/browse_helper.rb
+++ b/app/helpers/spotlight/browse_helper.rb
@@ -24,6 +24,12 @@ module Spotlight
       end
     end
 
+    ##
+    # Get parent results count of a browse category search
+    def parent_search_count
+      Spotlight::Search.find(@search.id).count
+    end
+
     private
 
     def view_available?(view)

--- a/app/views/spotlight/browse/_search_box.html.erb
+++ b/app/views/spotlight/browse/_search_box.html.erb
@@ -1,0 +1,30 @@
+<div class="search-box-container">
+  <%= form_tag exhibit_browse_path(current_exhibit, search), method: :get, class: 'browse-search-form form-horizontal', role: 'browse-search' do %>
+    <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :exhibit_id, :browse_q, :qt, :page, :utf8)) %>
+    <div class="form-group">
+        <label class="offset-sm-3 col-sm-3 control-label" for="browse_q"><%= t('spotlight.browse.search_box.label') %></label>
+      <div class="col-sm-6">
+        <div class="input-group">
+          <%= text_field_tag :browse_q, params[:browse_q], placeholder: t('spotlight.browse.search_box.placeholder'), class: "form-control", id: "browse_q" %>
+          <a class="clear-input-text" style="visibility: visible; left: 671px; line-height: 34px;"><span class="sr-only">Clear search box</span><i class="fa fa-times-circle"></i></a>
+            <span class="input-group-btn">
+              <button type="submit" class="btn btn-primary search-btn" id="browse-search">
+              <span class="submit-search-text"><%= t('spotlight.browse.search_box.submit') %></span>
+              <span class="glyphicon glyphicon-search"></span>
+              </button>
+            </span>
+        </div>
+      </div>
+    </div>
+  <% end %>
+  <% if params[:browse_q]%>
+    <div class="browse-search-expand">
+      <% if search.documents.size > 0 %>
+        You can also <%= link_to "search all items for \"#{params[:browse_q]}\"", search_exhibit_catalog_path(current_exhibit, q: params[:browse_q]) %>
+      <% else %>
+        <p>Your search did not match any items in this result set.</p>
+        <p>You can <%= link_to 'clear this search', exhibit_browse_path(current_exhibit, search)%> or try <%= link_to "searching all items for \"#{params[:browse_q]}\"", search_exhibit_catalog_path(current_exhibit, q: params[:browse_q]) %><p>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/spotlight/browse/_search_box.html.erb
+++ b/app/views/spotlight/browse/_search_box.html.erb
@@ -19,11 +19,12 @@
   <% end %>
   <% if params[:browse_q]%>
     <div class="browse-search-expand">
-      <% if search.documents.size > 0 %>
-        You can also <%= link_to "search all items for \"#{params[:browse_q]}\"", search_exhibit_catalog_path(current_exhibit, q: params[:browse_q]) %>
+      <% if search.count > 0 %>
+        <p>Your search matched <strong><%= search.count %> of <%= parent_search_count%> items in this result set.</p>
+        <p>You can also <%= link_to "search all items for \"#{params[:browse_q]}\"", search_exhibit_catalog_path(current_exhibit, q: params[:browse_q]) %>.</p>
       <% else %>
         <p>Your search did not match any items in this result set.</p>
-        <p>You can <%= link_to 'clear this search', exhibit_browse_path(current_exhibit, search)%> or try <%= link_to "searching all items for \"#{params[:browse_q]}\"", search_exhibit_catalog_path(current_exhibit, q: params[:browse_q]) %><p>
+        <p>You can <%= link_to 'clear this search', exhibit_browse_path(current_exhibit, search)%> or try <%= link_to "searching all items for \"#{params[:browse_q]}\"", search_exhibit_catalog_path(current_exhibit, q: params[:browse_q]) %>.<p>
       <% end %>
     </div>
   <% end %>

--- a/app/views/spotlight/browse/_search_box.html.erb
+++ b/app/views/spotlight/browse/_search_box.html.erb
@@ -2,7 +2,7 @@
   <%= form_tag exhibit_browse_path(current_exhibit, search), method: :get, class: 'browse-search-form form-horizontal', role: 'browse-search' do %>
     <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :exhibit_id, :browse_q, :qt, :page, :utf8)) %>
     <div class="form-group">
-        <label class="offset-sm-3 col-sm-3 control-label" for="browse_q"><%= t(:'.label') %></label>
+        <label class="col-sm-4 control-label" for="browse_q"><%= t(:'.label') %></label>
       <div class="col-sm-6">
         <div class="input-group">
           <%= text_field_tag :browse_q, params[:browse_q], placeholder: t(:'.placeholder'), class: "form-control", id: "browse_q" %>

--- a/app/views/spotlight/browse/_search_box.html.erb
+++ b/app/views/spotlight/browse/_search_box.html.erb
@@ -2,14 +2,14 @@
   <%= form_tag exhibit_browse_path(current_exhibit, search), method: :get, class: 'browse-search-form form-horizontal', role: 'browse-search' do %>
     <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :exhibit_id, :browse_q, :qt, :page, :utf8)) %>
     <div class="form-group">
-        <label class="offset-sm-3 col-sm-3 control-label" for="browse_q"><%= t('spotlight.browse.search_box.label') %></label>
+        <label class="offset-sm-3 col-sm-3 control-label" for="browse_q"><%= t(:'.label') %></label>
       <div class="col-sm-6">
         <div class="input-group">
-          <%= text_field_tag :browse_q, params[:browse_q], placeholder: t('spotlight.browse.search_box.placeholder'), class: "form-control", id: "browse_q" %>
+          <%= text_field_tag :browse_q, params[:browse_q], placeholder: t(:'.placeholder'), class: "form-control", id: "browse_q" %>
             <span class="input-group-btn">
-              <button class="btn btn-reset" type="reset"><span class="sr-only">Clear search box</span><span class="glyphicon glyphicon-remove-circle"></span></button>
+              <button class="btn btn-reset" type="reset"><span class="sr-only"><%= t(:'.reset') %></span><span class="glyphicon glyphicon-remove-circle"></span></button>
               <button type="submit" class="btn btn-primary search-btn" id="browse-search">
-              <span class="submit-search-text"><%= t('spotlight.browse.search_box.submit') %></span>
+              <span class="submit-search-text"><%= t(:'.submit') %></span>
               <span class="glyphicon glyphicon-search"></span>
               </button>
             </span>
@@ -20,11 +20,18 @@
   <% if params[:browse_q]%>
     <div class="browse-search-expand">
       <% if search.count > 0 %>
-        <p>Your search matched <strong><%= search.count %> of <%= parent_search_count%> items</strong> in this browse category.</p>
-        <p>You can also <%= link_to "search all exhibit items for \"#{params[:browse_q]}\"", search_exhibit_catalog_path(current_exhibit, q: params[:browse_q]) %>.</p>
+        <p><%= t(:'.success.result_number_html', search_size: search.count, parent_search_count: parent_search_count) %></p>
+        <p><%= t(:'.success.expand_html',
+                  expand_search_url: search_exhibit_catalog_path(current_exhibit, q: params[:browse_q]),
+                  browse_query: params[:browse_q]) %>
+        </p>
       <% else %>
-        <p>Your search did not match any items in this browse category.</p>
-        <p>You can <%= link_to 'clear this search', exhibit_browse_path(current_exhibit, search)%> or try <%= link_to "searching all exhibit items for \"#{params[:browse_q]}\"", search_exhibit_catalog_path(current_exhibit, q: params[:browse_q]) %>.<p>
+        <p><%= t(:'.zero_results.result_number') %></p>
+        <p><%= t(:'.zero_results.expand_html',
+                  clear_search_url: exhibit_browse_path(current_exhibit, search),
+                  expand_search_url: search_exhibit_catalog_path(current_exhibit, q: params[:browse_q]),
+                  browse_query: params[:browse_q])%>
+        </p>
       <% end %>
     </div>
   <% end %>

--- a/app/views/spotlight/browse/_search_box.html.erb
+++ b/app/views/spotlight/browse/_search_box.html.erb
@@ -6,8 +6,8 @@
       <div class="col-sm-6">
         <div class="input-group">
           <%= text_field_tag :browse_q, params[:browse_q], placeholder: t('spotlight.browse.search_box.placeholder'), class: "form-control", id: "browse_q" %>
-          <a class="clear-input-text" style="visibility: visible; left: 671px; line-height: 34px;"><span class="sr-only">Clear search box</span><i class="fa fa-times-circle"></i></a>
             <span class="input-group-btn">
+              <button class="btn btn-reset" type="reset"><span class="sr-only">Clear search box</span><span class="glyphicon glyphicon-remove-circle"></span></button>
               <button type="submit" class="btn btn-primary search-btn" id="browse-search">
               <span class="submit-search-text"><%= t('spotlight.browse.search_box.submit') %></span>
               <span class="glyphicon glyphicon-search"></span>
@@ -20,7 +20,7 @@
   <% if params[:browse_q]%>
     <div class="browse-search-expand">
       <% if search.count > 0 %>
-        <p>Your search matched <strong><%= search.count %> of <%= parent_search_count%> items in this result set.</p>
+        <p>Your search matched <strong><%= search.count %> of <%= parent_search_count%> items</strong> in this result set.</p>
         <p>You can also <%= link_to "search all items for \"#{params[:browse_q]}\"", search_exhibit_catalog_path(current_exhibit, q: params[:browse_q]) %>.</p>
       <% else %>
         <p>Your search did not match any items in this result set.</p>

--- a/app/views/spotlight/browse/_search_box.html.erb
+++ b/app/views/spotlight/browse/_search_box.html.erb
@@ -20,11 +20,11 @@
   <% if params[:browse_q]%>
     <div class="browse-search-expand">
       <% if search.count > 0 %>
-        <p>Your search matched <strong><%= search.count %> of <%= parent_search_count%> items</strong> in this result set.</p>
-        <p>You can also <%= link_to "search all items for \"#{params[:browse_q]}\"", search_exhibit_catalog_path(current_exhibit, q: params[:browse_q]) %>.</p>
+        <p>Your search matched <strong><%= search.count %> of <%= parent_search_count%> items</strong> in this browse category.</p>
+        <p>You can also <%= link_to "search all exhibit items for \"#{params[:browse_q]}\"", search_exhibit_catalog_path(current_exhibit, q: params[:browse_q]) %>.</p>
       <% else %>
-        <p>Your search did not match any items in this result set.</p>
-        <p>You can <%= link_to 'clear this search', exhibit_browse_path(current_exhibit, search)%> or try <%= link_to "searching all items for \"#{params[:browse_q]}\"", search_exhibit_catalog_path(current_exhibit, q: params[:browse_q]) %>.<p>
+        <p>Your search did not match any items in this browse category.</p>
+        <p>You can <%= link_to 'clear this search', exhibit_browse_path(current_exhibit, search)%> or try <%= link_to "searching all exhibit items for \"#{params[:browse_q]}\"", search_exhibit_catalog_path(current_exhibit, q: params[:browse_q]) %>.<p>
       <% end %>
     </div>
   <% end %>

--- a/app/views/spotlight/browse/_search_title.html.erb
+++ b/app/views/spotlight/browse/_search_title.html.erb
@@ -1,2 +1,2 @@
 <%= search.title %>
-<small class="item-count"><%= t :'spotlight.browse.search.item_count', count: search.documents.size %></small>
+<small class="item-count"><%= t :'spotlight.browse.search.item_count', count: params[:browse_q] ? parent_search_count: search.documents.size %></small>

--- a/app/views/spotlight/browse/show.html.erb
+++ b/app/views/spotlight/browse/show.html.erb
@@ -18,6 +18,9 @@
 
 <div class="col-md-12">
   <%= render 'sort_and_per_page' %>
+  <% if @search.search_box? %>
+    <%= render partial: 'search_box', locals: {search: @search} %>
+  <% end %>
   <% if @search.default_index_view_type && params[:view].blank? %>
     <%= render_document_index_with_view(@search.default_index_view_type, @document_list) %>
   <% else %>

--- a/app/views/spotlight/searches/_form.html.erb
+++ b/app/views/spotlight/searches/_form.html.erb
@@ -30,6 +30,9 @@
       <div role="tabpanel" class="tab-pane active" id="search-description">
         <%= f.text_field :title, control_col: "col-sm-5" %>
         <%= f.text_area :long_description, rows: 5 %>
+        <%= f.form_group :search_box, label: { text: t(:'.search_box.label'), class: nil }, help: t(:'.search_box.help_block') do %>
+          <%= f.check_box :search_box, label: "" %>
+        <% end %>
         <%= f.form_group label: { text: t(:".default_index_view_type") } do %>
           <% available_document_index_views.each do |view| %>
             <%= f.radio_button :default_index_view_type, view, label: view_label(view) %>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -646,6 +646,9 @@ en:
           other: "%{count} items"
         missing_description_html: "%{link} to add a description."
       form:
+        search_box:
+          label: Display search box
+          help_block: Displays a search box that enables users to search within the browse category results
         search_description: "Description"
         search_masthead: "Masthead"
         search_thumbnail: "Thumbnail"
@@ -668,6 +671,10 @@ en:
         item_count:
           one: "%{count} item"
           other: "%{count} items"
+      search_box:
+        placeholder: Search…
+        label: Search within these results
+        submit: Search within results
     tags:
       index:
         title: "Curation - Tags"

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -675,6 +675,13 @@ en:
         placeholder: Search…
         label: Search within this browse category
         submit: Search within browse category
+        reset: Clear search box
+        success:
+          result_number_html: Your search matched <strong> %{search_size} of %{parent_search_count} items</strong> in this browse category.
+          expand_html: You can also <a href="%{expand_search_url}">search all exhibit items for "%{browse_query}"</a>.
+        zero_results:
+          result_number: Your search did not match any items in this browse category.
+          expand_html: You can <a href="%{clear_search_url}"> clear this search</a> or try <a href="%{expand_search_url}">searching all exhibit items for "%{browse_query}"</a>.
     tags:
       index:
         title: "Curation - Tags"

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -673,8 +673,8 @@ en:
           other: "%{count} items"
       search_box:
         placeholder: Search…
-        label: Search within these results
-        submit: Search within results
+        label: Search within this browse category
+        submit: Search within browse category
     tags:
       index:
         title: "Curation - Tags"

--- a/db/migrate/20180119193632_add_search_box_to_spotlight_searches.rb
+++ b/db/migrate/20180119193632_add_search_box_to_spotlight_searches.rb
@@ -1,0 +1,5 @@
+class AddSearchBoxToSpotlightSearches < ActiveRecord::Migration[5.0]
+  def change
+    add_column :spotlight_searches, :search_box, :boolean, default: false
+  end
+end

--- a/spec/features/browse_category_admin_spec.rb
+++ b/spec/features/browse_category_admin_spec.rb
@@ -83,6 +83,19 @@ describe 'Browse Category Administration', type: :feature do
       expect(search.thumbnail).not_to be nil
     end
 
+    it 'can configure a search box' do
+      visit spotlight.edit_exhibit_search_path exhibit, search
+      expect(search.search_box).to eq false
+
+      check 'Display search box'
+
+      click_button 'Save changes'
+      expect(page).to have_content('The search was successfully updated.')
+      search.reload
+
+      expect(search.search_box).to eq true
+    end
+
     it 'can select a default index view type' do
       visit spotlight.edit_exhibit_search_path exhibit, search
       choose 'List'

--- a/spec/features/browse_category_spec.rb
+++ b/spec/features/browse_category_spec.rb
@@ -94,8 +94,8 @@ feature 'Browse pages' do
         expect(page).to have_selector '.browse-search-form'
         expect(page).not_to have_css '.browse-search-expand'
 
-        fill_in 'Search within these results', with: 'SEPTENTRIONALE'
-        click_button 'Search within results'
+        fill_in 'Search within this browse category', with: 'SEPTENTRIONALE'
+        click_button 'Search within browse category'
 
         expect(page).to have_css '.browse-search-expand'
       end

--- a/spec/features/browse_category_spec.rb
+++ b/spec/features/browse_category_spec.rb
@@ -87,6 +87,20 @@ feature 'Browse pages' do
       end
     end
 
+    context 'with category search box enabled' do
+      let(:search) { FactoryBot.create(:default_search, exhibit: exhibit, published: true, search_box: true) }
+      it 'renders search box' do
+        visit spotlight.exhibit_browse_path(exhibit, search)
+        expect(page).to have_selector '.browse-search-form'
+        expect(page).not_to have_css '.browse-search-expand'
+
+        fill_in 'Search within these results', with: 'SEPTENTRIONALE'
+        click_button 'Search within results'
+
+        expect(page).to have_css '.browse-search-expand'
+      end
+    end
+
     it 'has <meta> tags' do
       TopHat.current['twitter_card'] = nil
       TopHat.current['opengraph'] = nil


### PR DESCRIPTION
Fixes #1880 

This PR adds a configurable search box to browse categories. Users can provide a query to search within the browse category / saved search.

## Screenshots

### Successful Search
![successful_search](https://user-images.githubusercontent.com/5402927/35536644-54595d5a-04fc-11e8-8fed-990cbe0e391b.png)

### No results
![zero_results_search](https://user-images.githubusercontent.com/5402927/35535504-a6fc3130-04f8-11e8-93af-54a56918bab8.png)

## Todo:
- [x] test behavior for facet-only browse category
- [x] clear search link
- [x] link to search all items
- [x] add behavior for unsuccessful search
- [x] finish styling (clear results button)
- [x] add "1 of 5 results" 
- [x] accessibility check re: second search box
- [x] specs
- [x] maintain browse category total as results number
- [x] change text to use "browse category"
- [x] Fix JS
- [x] recenter search bar