### PR TITLE
Bootstrap_form_for email_address field handles labels

### DIFF
--- a/app/views/spotlight/shared/_report_a_problem.html.erb
+++ b/app/views/spotlight/shared/_report_a_problem.html.erb
@@ -7,8 +7,7 @@
       <%= f.text_field :name %>
       <span style="display:none;visibility:hidden;">
         <% honeypot_field_name = Spotlight::Engine.config.spambot_honeypot_email_field %>
-        <%= label_tag(honeypot_field_name, t(:'.honeypot_field_explanation')) %><br/>
-        <%= f.email_field honeypot_field_name %>
+        <%= f.email_field honeypot_field_name, label: t(:'.honeypot_field_explanation') %>
       </span>
       <%= f.email_field :email %>
       <%= f.text_area :message, rows: 7 %>


### PR DESCRIPTION
This prevents us from having a label that points at a non-existant
field, which is an accessability concern.