### PR TITLE
Reduce the pagination size of exhibits to 48, so it tiles nicely on i…

### DIFF
--- a/app/models/spotlight/exhibit.rb
+++ b/app/models/spotlight/exhibit.rb
@@ -13,7 +13,7 @@ module Spotlight
     scope :unpublished, -> { where(published: false) }
     scope :ordered_by_weight, -> { order('weight ASC') }
 
-    paginates_per 50
+    paginates_per 48
 
     extend FriendlyId
     friendly_id :title, use: [:slugged, :finders]


### PR DESCRIPTION
…ndex pages.

I'm not sure where `50` came from, but a number divisible by 3 will look nicer on the `exhibits#index` page.