### PR TITLE
Limit max-width of iframe in Embed + Text widget

### DIFF
--- a/app/assets/stylesheets/spotlight/_pages.scss
+++ b/app/assets/stylesheets/spotlight/_pages.scss
@@ -231,6 +231,12 @@
   @media (max-width: $screen-sm-max) {
     margin-bottom: $padding-base-horizontal;
   }
+
+  iframe {
+    @media (min-width: $screen-md-min) {
+      max-width: 100%;
+    }
+  }
 }
 
 .items-block {


### PR DESCRIPTION
When using the "text align: right" option for the Embed + Text widget, the text can overlap the embed if the embed width exceeds the width allocated for the six columns assigned to it (bottom example below):

![kogu_me_lugu__digital_video_interviews___the_baltic_video_archive_-_spotlight_at_stanford](https://user-images.githubusercontent.com/101482/30232817-d656b09e-94a6-11e7-8278-c233bca1d803.png)

This PR is a simple change that limits the width of the iframe (at medium or larger viewports), which keeps in within the column and thus prevents the text overlap:

<img width="501" alt="embed___text_widget_test_page___widget_test_-_blacklight" src="https://user-images.githubusercontent.com/101482/36274616-8903bbee-1245-11e8-812e-5f8bae625bfd.png">

It's not an ideal approach, since if the iframe width is greater than the available column width the iframe just gets its sides cut-off to fit, but the result is likely not to be terrible (e.g., compare before and after videos above) so might be sufficient for an immediate fix.

Longer term, a more sophisticated approach that would adjust the size of the iframe proportionally would probably be better. I'll create a [separate ticket](https://github.com/projectblacklight/spotlight/issues/1908) to document that goal.