### PR TITLE
Update description for Embed + Text widget

### DIFF
--- a/app/assets/javascripts/spotlight/sir-trevor/locales.js
+++ b/app/assets/javascripts/spotlight/sir-trevor/locales.js
@@ -23,7 +23,7 @@ SirTrevor.Locales.en.blocks = $.extend(SirTrevor.Locales.en.blocks, {
 
   oembed: {
     title: "Embed + Text",
-    description: 'This widget embeds a web resource and a text block to the left or right of it.',
+    description: "This widget embeds an oEmbed-supported web resource and a text block to the left or right of it. Examples of oEmbed-supported resources include those from YouTube, Twitter, Flickr, and SlideShare.",
     url: "URL",
   },
 


### PR DESCRIPTION
Closes sul-dlss/exhibits#1023

This PR adds example to the description text for the "Embed + Text" widget. 

### Before
"This widget embeds a web resource and a text block to the left or right of it."

### After
"This widget embeds an oEmbed-supported web resource and a text block to the left or right of it. Examples of oEmbed-supported resources include those from YouTube, Twitter, Flickr, and SlideShare."