### PR TITLE
Fix browse controller bug: access query params with string

### DIFF
--- a/app/controllers/spotlight/browse_controller.rb
+++ b/app/controllers/spotlight/browse_controller.rb
@@ -39,7 +39,7 @@ module Spotlight
     end
 
     def search_query
-      @search.query_params[:q] = [@search.query_params[:q], params[:browse_q]].join(' ')
+      @search.query_params['q'] = [@search.query_params['q'], params[:browse_q]].join(' ')
       @search.merge_params_for_search(params, blacklight_config)
     end
 


### PR DESCRIPTION
Hopefully fixes sul-dlss/exhibits#1103

This PR updates the `search_query` method that is used to construct browse categories. Accessing the query params for a `Spotlight::Search` requires a string (`"q"`), not a symbol (`:q`). This change was introduced in #1888 https://github.com/projectblacklight/spotlight/blob/0a3e4302e1240efbd084e7cd2d833e2f826f310e/app/controllers/spotlight/browse_controller.rb#L42