### PR TITLE
Add iiif-presentation gem as a dependency

### DIFF
--- a/blacklight-spotlight.gemspec
+++ b/blacklight-spotlight.gemspec
@@ -51,6 +51,7 @@ these collections.)
   s.add_dependency 'almond-rails', '~> 0.1'
   s.add_dependency 'sprockets-es6'
   s.add_dependency 'riiif', '~> 1.0'
+  s.add_dependency 'iiif-presentation'
   s.add_dependency 'iiif_manifest'
   s.add_dependency 'leaflet-rails'
 


### PR DESCRIPTION
- Adds the [iiif-presentation gem](https://rubygems.org/gems/iiif-presentation/versions/0.2.0) to our dependencies and fixes our failing Travis builds
- `iiif_presentation` was [recently removed from the iiif_manifest gem](https://github.com/samvera-labs/iiif_manifest/commit/8324094efa93e6bd7e78ffd71b9c969543b40673#diff-3ca3e0de685e1e0bfa36f0c111f9710c)
