### PR TITLE
Enable exhibit specific translations to be stored in ActiveRecord

### DIFF
--- a/app/controllers/concerns/spotlight/controller.rb
+++ b/app/controllers/concerns/spotlight/controller.rb
@@ -8,6 +8,11 @@ module Spotlight
 
     included do
       helper_method :current_site, :current_exhibit, :current_masthead, :exhibit_masthead?, :resource_masthead?
+      before_action :set_exhibit_locale_scope
+    end
+
+    def set_exhibit_locale_scope
+      Translation.exhibit_default_scope(current_exhibit)
     end
 
     def current_site
@@ -15,7 +20,7 @@ module Spotlight
     end
 
     def current_exhibit
-      @exhibit
+      @exhibit || (Spotlight::Exhibit.find(params[:exhibit_id]) if params[:exhibit_id].present?)
     end
 
     def current_masthead

--- a/app/models/concerns/spotlight/custom_translation_extension.rb
+++ b/app/models/concerns/spotlight/custom_translation_extension.rb
@@ -1,0 +1,18 @@
+module Spotlight
+  ##
+  # Module that extends I18n::Backend::ActiveRecord::Translation to provide
+  # additional Spotlight behavior, such as exhibit specific Translations
+  module CustomTranslationExtension
+    extend ActiveSupport::Concern
+
+    included do
+      belongs_to :exhibit, class_name: 'Spotlight::Exhibit', inverse_of: :translations
+    end
+
+    class_methods do
+      def exhibit_default_scope(exhibit)
+        default_scope { where(exhibit: exhibit) }
+      end
+    end
+  end
+end

--- a/app/models/spotlight/exhibit.rb
+++ b/app/models/spotlight/exhibit.rb
@@ -43,6 +43,7 @@ module Spotlight
     has_many :users, through: :roles, class_name: Spotlight::Engine.config.user_class
     has_many :pages, dependent: :destroy
     has_many :filters, dependent: :delete_all
+    has_many :translations, class_name: 'I18n::Backend::ActiveRecord::Translation', dependent: :destroy, inverse_of: :exhibit
 
     has_one :blacklight_configuration, class_name: 'Spotlight::BlacklightConfiguration', dependent: :delete
     has_one :home_page

--- a/blacklight-spotlight.gemspec
+++ b/blacklight-spotlight.gemspec
@@ -54,6 +54,7 @@ these collections.)
   s.add_dependency 'iiif-presentation'
   s.add_dependency 'iiif_manifest'
   s.add_dependency 'leaflet-rails'
+  s.add_dependency 'i18n-active_record'
 
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'rspec-rails', '~> 3.1'

--- a/db/migrate/20180306142612_create_translations.rb
+++ b/db/migrate/20180306142612_create_translations.rb
@@ -1,0 +1,18 @@
+class CreateTranslations < ActiveRecord::Migration[5.0]
+  def self.up
+    create_table :translations do |t|
+      t.string :locale
+      t.string :key
+      t.text   :value
+      t.text   :interpolations
+      t.boolean :is_proc, default: false
+      t.references :exhibit
+
+      t.timestamps
+    end
+  end
+
+  def self.down
+    drop_table :translations
+  end
+end

--- a/lib/generators/spotlight/install_generator.rb
+++ b/lib/generators/spotlight/install_generator.rb
@@ -137,5 +137,9 @@ module Spotlight
       generate 'devise_invitable:install'
       generate 'devise_invitable', 'User'
     end
+
+    def add_translations
+      copy_file 'config/initializers/translation.rb'
+    end
   end
 end

--- a/lib/generators/spotlight/templates/config/initializers/translation.rb
+++ b/lib/generators/spotlight/templates/config/initializers/translation.rb
@@ -1,0 +1,17 @@
+require 'i18n/backend/active_record'
+
+Translation = I18n::Backend::ActiveRecord::Translation
+
+if Translation.table_exists?
+  ##
+  # Sets up the new Spotlight Translation backend, backed by ActiveRecord. To
+  # turn on the ActiveRecord backend, uncomment the following lines.
+
+  # I18n.backend = I18n::Backend::ActiveRecord.new
+  I18n::Backend::ActiveRecord.send(:include, I18n::Backend::Memoize)
+  Translation.send(:include, Spotlight::CustomTranslationExtension)
+  I18n::Backend::Simple.send(:include, I18n::Backend::Memoize)
+  I18n::Backend::Simple.send(:include, I18n::Backend::Pluralization)
+
+  # I18n.backend = I18n::Backend::Chain.new(I18n.backend, I18n::Backend::Simple.new)
+end

--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -12,6 +12,7 @@ require 'tophat'
 require 'paper_trail'
 require 'clipboard/rails'
 require 'leaflet-rails'
+require 'i18n/active_record'
 
 module Spotlight
   ##

--- a/spec/factories/translation.rb
+++ b/spec/factories/translation.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :translation do
+    locale 'en'
+    exhibit
+  end
+end

--- a/spec/features/translation_scope_spec.rb
+++ b/spec/features/translation_scope_spec.rb
@@ -1,0 +1,24 @@
+describe 'Translations scope setting', type: :feature do
+  let(:exhibit) { FactoryBot.create(:exhibit) }
+  let(:other_exhibit) { FactoryBot.create(:exhibit) }
+  let(:exhibit_curator) { FactoryBot.create(:exhibit_curator, exhibit: exhibit) }
+
+  describe 'exhibit route set' do
+    before do
+      login_as exhibit_curator
+      FactoryBot.create(:translation, exhibit: exhibit)
+      FactoryBot.create(:translation, exhibit: other_exhibit)
+    end
+    it 'default scope of Translation should be limited to current exhibit' do
+      visit spotlight.exhibit_path(exhibit)
+      expect(Translation.all.count).to eq 1
+    end
+  end
+
+  describe 'without the context of an exhibit' do
+    it 'renders page ok' do
+      visit root_path
+      expect(page).to have_css '.site-title', text: 'Blacklight'
+    end
+  end
+end


### PR DESCRIPTION
This groundwork is a prerequisite for additional i18n + translation issues.

Adopters wanting to take advantage of this will need to copy the `translation.rb` initializer into their Spotlight application and uncomment the commented lines.