### PR TITLE
Add class to right-align numeric table column

### DIFF
--- a/app/views/spotlight/dashboards/_analytics.html.erb
+++ b/app/views/spotlight/dashboards/_analytics.html.erb
@@ -17,17 +17,17 @@
   <% page_analytics = current_exhibit.page_analytics(1.month, exhibit_root_path(current_exhibit)) %>
   <% unless page_analytics.empty? %>
   <h4><%= t :'.pages.header' %></h4>
-  <table class="table table-striped">
+  <table class="table table-striped popular-pages">
     <thead>
       <tr>
         <th><%= t(:".pagetitle") %></th>
-        <th><%= t(:".pageviews") %></th>
+        <th class="text-right"><%= t(:".pageviews") %></th>
       </tr>
     </thead>
     <% page_analytics.each do |p| %>
       <tr>
         <td><%= link_to p.pageTitle, p.pagePath %></td>
-        <td><%= p.pageviews %></td>
+        <td class="text-right"><%= p.pageviews %></td>
       </tr>
     <% end %>
   </table>


### PR DESCRIPTION
Minor update to add classes that right-align the numeric column of the Analytics popular pages table, and to add a class to the table element so other table elements can be customized without complicated CSS.

### Before 

<img width="447" alt="before" src="https://user-images.githubusercontent.com/101482/37228153-e1a78b96-239c-11e8-8b58-cace04ec48e0.png">

### After

<img width="444" alt="after" src="https://user-images.githubusercontent.com/101482/37228169-f2659bbc-239c-11e8-8f54-e5e832f59875.png">

