### PR TITLE
Update flaky JS tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
 before_install:
   - gem update --system
   - gem install bundler
-  - google-chrome-stable --headless --disable-gpu --no-sandbox --remote-debugging-port=9222 http://localhost &
+  - google-chrome-stable --headless --disable-gpu --no-sandbox --blink-settings=imagesEnabled=false --remote-debugging-port=9222 http://localhost &
 
 notifications:
   irc: "irc.freenode.org#blacklight"

--- a/app/views/spotlight/search_configurations/_search_fields.html.erb
+++ b/app/views/spotlight/search_configurations/_search_fields.html.erb
@@ -1,6 +1,6 @@
 <% default_field = @blacklight_configuration.blacklight_config.default_search_field %>
 <div class="checkbox">
-  <label>
+  <label for="enable_feature">
     <%= check_box_tag :enable_feature, '1', @blacklight_configuration.blacklight_config.search_fields.select { |_k, v| v.enabled && v.include_in_simple_select != false }.any?, data: { behavior: 'enable-feature', target: '#search_fields' } %> <%= t(:'.enable_feature') %>
   </label>
 </div>

--- a/spec/features/javascript/blocks/solr_documents_block_spec.rb
+++ b/spec/features/javascript/blocks/solr_documents_block_spec.rb
@@ -34,7 +34,7 @@ feature 'Solr Document Block', feature: true, versioning: true do
     save_page
 
     # verify that the item + image widget is displaying an image from the document.
-    within(:css, '.items-block') do
+    within(:css, '.items-block', visible: true) do
       expect(page).to have_css('.thumbnail')
       expect(page).to have_css('.thumbnail a img')
       expect(page).not_to have_css('.title')
@@ -47,7 +47,7 @@ feature 'Solr Document Block', feature: true, versioning: true do
 
     save_page
 
-    expect(page).to have_selector '.items-block .box', count: 2
+    expect(page).to have_selector '.items-block .box', count: 2, visible: true
   end
 
   scenario 'it should allow you to choose from a multi-image solr document (and persist through edits)', js: true do
@@ -97,7 +97,7 @@ feature 'Solr Document Block', feature: true, versioning: true do
 
     save_page
 
-    expect(page).to have_selector '.items-block .box', count: 1
+    expect(page).to have_selector '.items-block .box', count: 1, visible: true
     expect(page).to have_content '[World map]'
     expect(page).not_to have_content "L'AMERIQUE"
   end
@@ -119,7 +119,7 @@ feature 'Solr Document Block', feature: true, versioning: true do
     save_page
 
     # verify that the item + image widget is displaying image and title from the requested document.
-    within(:css, '.items-block') do
+    within(:css, '.items-block', visible: true) do
       expect(page).to have_css('.thumbnail')
       expect(page).to have_css('.thumbnail a img')
       expect(page).to have_css('.primary-caption', text: '[World map]')
@@ -130,13 +130,16 @@ feature 'Solr Document Block', feature: true, versioning: true do
   scenario 'should allow you to optionally display a ZPR link with the image', js: true do
     fill_in_typeahead_field with: 'gk446cj2442'
 
-    check 'zpr_link'
-
+    check 'Display ZPR link'
     save_page
 
-    expect(page).to have_selector('.zpr-link[data-iiif-tilesource]')
-    click_on 'Show in ZPR viewer'
-    expect(page).to have_css('#osd-modal-container')
+    within '.contents' do
+      click_button 'Show in ZPR viewer'
+    end
+
+    within '.modal-content' do
+      expect(page).to have_css('#osd-modal-container')
+    end
   end
 
   scenario 'should allow you to add text to the image', js: true do
@@ -148,7 +151,7 @@ feature 'Solr Document Block', feature: true, versioning: true do
 
     # visit the show page for the document we just saved
     # verify that the item + image widget is displaying image and title from the requested document.
-    within(:css, '.items-block') do
+    within(:css, '.items-block', visible: true) do
       expect(page).to have_content 'zzz'
     end
   end
@@ -166,9 +169,10 @@ feature 'Solr Document Block', feature: true, versioning: true do
 
     # verify that the item + image widget is displaying image and title from the requested document.
     within(:css, '.items-block') do
-      expect(page).to have_content 'zzz'
+      within('.text-col') do
+        expect(page).to have_content 'zzz'
+      end
       expect(page).to have_css('.items-col.pull-left')
-      expect(page).to have_css('.text-col')
     end
   end
 
@@ -197,7 +201,7 @@ feature 'Solr Document Block', feature: true, versioning: true do
 
     click_on 'Edit'
 
-    expect(page).to have_selector '.panel', count: 2
+    expect(page).to have_selector '.panel', count: 2, visible: true
 
     # for some reason, the text area above isn't getting filled in
     # expect(page).to have_selector ".st-text-block", text: "zzz"

--- a/spec/features/javascript/search_config_admin_spec.rb
+++ b/spec/features/javascript/search_config_admin_spec.rb
@@ -19,7 +19,7 @@ feature 'Search Configuration Administration', js: true do
 
       click_button 'Save changes'
 
-      expect(page).to have_content('The exhibit was successfully updated.')
+      expect(page).to have_css('.alert', text: 'The exhibit was successfully updated.', visible: true)
 
       expect(page).not_to have_css 'select#search_field'
     end
@@ -42,7 +42,7 @@ feature 'Search Configuration Administration', js: true do
 
       click_button 'Save changes'
 
-      expect(page).to have_content('The exhibit was successfully updated.')
+      expect(page).to have_css('.alert', text: 'The exhibit was successfully updated.', visible: true)
       expect(page).to have_select 'Search in', with_options: ['My Title Label']
     end
   end
@@ -69,7 +69,7 @@ feature 'Search Configuration Administration', js: true do
       click_button 'Save changes'
       click_link 'Facets'
 
-      expect(page).to have_content('The exhibit was successfully updated.')
+      expect(page).to have_css('.alert', text: 'The exhibit was successfully updated.', visible: true)
 
       expect(page).not_to have_content('Genre')
       expect(page).to have_content('Topic')
@@ -88,7 +88,7 @@ feature 'Search Configuration Administration', js: true do
 
       click_button 'Save changes'
 
-      expect(page).to have_content('The exhibit was successfully updated.')
+      expect(page).to have_css('.alert', text: 'The exhibit was successfully updated.', visible: true)
 
       exhibit.reload
       expect(exhibit.blacklight_config.facet_fields['genre_ssim'].sort).to eq 'index'
@@ -109,7 +109,7 @@ feature 'Search Configuration Administration', js: true do
 
       click_button 'Save changes'
 
-      expect(page).to have_content('The exhibit was successfully updated.')
+      expect(page).to have_css('.alert', text: 'The exhibit was successfully updated.', visible: true)
 
       click_link 'Results'
 
@@ -137,7 +137,7 @@ feature 'Search Configuration Administration', js: true do
 
       click_button 'Save changes'
 
-      expect(page).to have_content('The exhibit was successfully updated.')
+      expect(page).to have_css('.alert', text: 'The exhibit was successfully updated.', visible: true)
 
       click_link 'Results'
 


### PR DESCRIPTION
They shall flap no more! 

This PR:
- treats some squeaky `expect` statements by either
  - nesting them inside of a `within` or
  - adding `visible: true` 
- disables image loading in Chrome headless
- ~~increases the max wait time in CI only~~

See #1974 