### PR TITLE
add basic implementation of general edit form

### DIFF
--- a/app/assets/stylesheets/spotlight/_spotlight.scss
+++ b/app/assets/stylesheets/spotlight/_spotlight.scss
@@ -30,6 +30,8 @@
 @import "spotlight/report_a_problem";
 @import "spotlight/exhibits_index";
 @import "spotlight/collapse_toggle";
+@import "spotlight/translations";
+@import "spotlight/utilities";
 
 
 

--- a/app/assets/stylesheets/spotlight/_translations.scss
+++ b/app/assets/stylesheets/spotlight/_translations.scss
@@ -1,0 +1,25 @@
+.translation-subheading {
+  border-bottom: 1px solid $navbar-default-border;
+  margin-bottom: 20px;
+}
+
+.form-group.translation-form {
+  .control-label {
+    padding-top: $panel-body-padding + $padding-base-vertical;
+  }
+
+  .glyphicon-ok {
+    color: $translation-available-color;
+    padding-top: $panel-body-padding + $padding-base-vertical;
+  }
+}
+
+.panel-translation {
+  background-color: $translation-panel-bg;
+  padding-bottom: 0;
+
+  .help-block {
+    color: $translation-help-color;
+    padding-left: 12px;
+  }
+}

--- a/app/assets/stylesheets/spotlight/_utilities.scss
+++ b/app/assets/stylesheets/spotlight/_utilities.scss
@@ -1,0 +1,3 @@
+.inline-block {
+  display: inline-block;
+}

--- a/app/assets/stylesheets/spotlight/_variables.scss
+++ b/app/assets/stylesheets/spotlight/_variables.scss
@@ -36,3 +36,8 @@ $navbar-transparent-brand-hover-bg: transparent !default;
 $navbar-transparent-toggle-hover-bg: $navbar-default-toggle-hover-bg !default;
 $navbar-transparent-toggle-icon-bar-bg: $navbar-default-toggle-icon-bar-bg !default;
 $navbar-transparent-toggle-border-color: $navbar-default-toggle-border-color !default;
+
+// Translations
+$translation-available-color: #80bf77;
+$translation-panel-bg: #f5f5f5;
+$translation-help-color: #555;

--- a/app/controllers/spotlight/translations_controller.rb
+++ b/app/controllers/spotlight/translations_controller.rb
@@ -1,0 +1,29 @@
+module Spotlight
+  ##
+  # Base CRUD controller for translations
+  class TranslationsController < Spotlight::ApplicationController
+    before_action :authenticate_user!, :set_language
+    load_and_authorize_resource :exhibit, class: Spotlight::Exhibit
+
+    def edit; end
+
+    def update
+      if current_exhibit.update(exhibit_params)
+        notice = t(:'helpers.submit.spotlight_default.updated', model: current_exhibit.class.model_name.human.downcase)
+        redirect_to edit_exhibit_translations_path(current_exhibit, params: { language: @language }), notice: notice
+      else
+        render 'edit'
+      end
+    end
+
+    private
+
+    def exhibit_params
+      params.require(:exhibit).permit(translations_attributes: [:id, :locale, :key, :value])
+    end
+
+    def set_language
+      @language = params[:language] || current_exhibit.available_locales.first
+    end
+  end
+end

--- a/app/models/concerns/spotlight/translatables.rb
+++ b/app/models/concerns/spotlight/translatables.rb
@@ -1,0 +1,30 @@
+module Spotlight
+  # Mixin for adding translatable ActiveRecord accessors
+  module Translatables
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def translates(*attr_names)
+        attr_names.map(&:to_sym)
+        attr_names.map(&method(:define_translated_attr_reader))
+      end
+
+      ##
+      # Set up a reader for the specified attribute that uses the I18n backend,
+      # and defaults to the ActiveRecord value
+      def define_translated_attr_reader(attr_name)
+        define_method(:"#{attr_name}") do
+          I18n.translate(attr_name, scope: slug, default: attr_translation(attr_name))
+        end
+      end
+    end
+
+    private
+
+    ##
+    # Will return the default ActiveRecord value for the value
+    def attr_translation(attr_name)
+      self[attr_name]
+    end
+  end
+end

--- a/app/models/spotlight/ability.rb
+++ b/app/models/spotlight/ability.rb
@@ -26,7 +26,8 @@ module Spotlight
         Spotlight::Resource,
         Spotlight::Page,
         Spotlight::Contact,
-        Spotlight::CustomField
+        Spotlight::CustomField,
+        Translation
       ], exhibit_id: user.exhibit_roles.pluck(:resource_id)
 
       can :manage, Spotlight::Lock, by: user

--- a/app/models/spotlight/exhibit.rb
+++ b/app/models/spotlight/exhibit.rb
@@ -54,7 +54,7 @@ module Spotlight
     belongs_to :thumbnail, class_name: 'Spotlight::ExhibitThumbnail', dependent: :destroy, optional: true
 
     accepts_nested_attributes_for :about_pages, :attachments, :contacts, :custom_fields, :feature_pages, :languages,
-                                  :main_navigations, :owned_taggings, :resources, :searches, :solr_document_sidecars
+                                  :main_navigations, :owned_taggings, :resources, :searches, :solr_document_sidecars, :translations
     accepts_nested_attributes_for :blacklight_configuration, :home_page, :filters, update_only: true
     accepts_nested_attributes_for :masthead, :thumbnail, update_only: true, reject_if: proc { |attr| attr['iiif_tilesource'].blank? }
     accepts_nested_attributes_for :contact_emails, reject_if: proc { |attr| attr['email'].blank? }

--- a/app/models/spotlight/exhibit.rb
+++ b/app/models/spotlight/exhibit.rb
@@ -6,6 +6,9 @@ module Spotlight
     include Spotlight::ExhibitAnalytics
     include Spotlight::ExhibitDefaults
     include Spotlight::ExhibitDocuments
+    include Spotlight::Translatables
+
+    translates :title, :subtitle
 
     has_paper_trail
 

--- a/app/views/spotlight/shared/_curation_sidebar.html.erb
+++ b/app/views/spotlight/shared/_curation_sidebar.html.erb
@@ -13,4 +13,9 @@
   <% if can? :manage, Spotlight::AboutPage.new(exhibit: current_exhibit) %>
   <li><%= link_to t(:'spotlight.curation.sidebar.about_pages'), spotlight.exhibit_about_pages_path(current_exhibit), 'data-no-turbolink' => true %></li>
   <% end %>
+  <% if (can? :manage, current_exhibit.translations.first_or_initialize) && current_exhibit.languages.any? %>
+    <li>
+      <%= link_to t(:'spotlight.curation.sidebar.translations'), spotlight.edit_exhibit_translations_path(current_exhibit), 'data-no-turbolink' => true %>
+    </li>
+  <% end %>
 </ul>

--- a/app/views/spotlight/translations/edit.html.erb
+++ b/app/views/spotlight/translations/edit.html.erb
@@ -1,0 +1,96 @@
+<%= render 'spotlight/shared/exhibit_sidebar' %>
+
+<div class='col-md-9 translation-edit-form'>
+  <%= curation_page_title t('spotlight.exhibits.translations.title') %>
+  
+  <div class='text-center'>
+    <ul class='nav nav-pills inline-block'>
+      <% current_exhibit.available_locales.each do |language| %>
+        <li role="presentation" class="<%= 'active' if @language == language %>">
+          <%= link_to spotlight.edit_exhibit_translations_path(current_exhibit, language: language) do %>
+            <%= t("locales.#{language.downcase}") %>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+
+  <ul class='nav nav-tabs'>
+    <li>
+      <a href='#'>
+        <%= t('spotlight.exhibits.translations.general.label') %>
+      </a>
+    </li>
+  </ul>
+
+  <h2 class='translation-subheading'>
+    <%= t('spotlight.exhibits.translations.general.basic_settings.label') %>
+  </h2>
+  
+  <%= bootstrap_form_for current_exhibit, url: spotlight.exhibit_translations_path(current_exhibit), layout: :horizontal do |f| %>
+    <% # Add a hidden field for the language so the redirect knows how to come back here %>
+    <%= hidden_field_tag :language, @language %>
+    <% translation = Translation.find_or_initialize_by(exhibit: current_exhibit, key: "#{current_exhibit.slug}.title", locale: @language) %>
+    <%= f.fields_for :translations, translation do |translation_fields| %>
+      <%= translation_fields.hidden_field :key %>
+      <%= translation_fields.hidden_field :locale %>
+      <div class='form-group translation-form'>
+        <%= translation_fields.label :value, t('spotlight.exhibits.translations.general.basic_settings.title'), class: 'control-label col-sm-2' %>
+        <div class='col-md-8 panel panel-body panel-translation'>
+          <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
+          <p class="help-block">
+            <%= current_exhibit.title %>
+          </p>
+        </div>
+        <div class='col-md-2'>
+          <% if translation.value.present? %>
+            <span class='glyphicon glyphicon-ok'></span>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+    <% translation = Translation.find_or_initialize_by(exhibit: current_exhibit, key: "#{current_exhibit.slug}.subtitle", locale: @language) %>
+    <%= f.fields_for :translations, translation do |translation_fields| %>
+      <%= translation_fields.hidden_field :key %>
+      <%= translation_fields.hidden_field :locale %>
+      <div class='form-group translation-form'>
+        <%= translation_fields.label :value, t('spotlight.exhibits.translations.general.basic_settings.subtitle'), class: 'control-label col-sm-2' %>
+        <div class='col-md-8 panel panel-body panel-translation'>
+          <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
+          <p class="help-block">
+            <%= current_exhibit.subtitle %>
+          </p>
+        </div>
+        <div class='col-md-2'>
+          <% if translation.value.present? %>
+            <span class='glyphicon glyphicon-ok'></span>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+    <% translation = Translation.find_or_initialize_by(exhibit: current_exhibit, key: "#{current_exhibit.slug}.description", locale: @language) %>
+    <%= f.fields_for :translations, translation do |translation_fields| %>
+      <%= translation_fields.hidden_field :key %>
+      <%= translation_fields.hidden_field :locale %>
+      <div class='form-group translation-form'>
+        <%= translation_fields.label :value, t('spotlight.exhibits.translations.general.basic_settings.description'), class: 'control-label col-sm-2' %>
+        <div class='col-md-8 panel panel-body panel-translation'>
+          <%= translation_fields.text_area_without_bootstrap :value, class: 'form-control' %>
+          <p class="help-block">
+            <%= current_exhibit.description %>
+          </p>
+        </div>
+        <div class='col-md-2'>
+          <% if translation.value.present? %>
+            <span class='glyphicon glyphicon-ok'></span>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+    <div class="form-actions">
+      <div class="primary-actions">
+        <%= f.submit nil, class: 'btn btn-primary' %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/spotlight/translations/edit.html.erb
+++ b/app/views/spotlight/translations/edit.html.erb
@@ -23,70 +23,73 @@
     </li>
   </ul>
 
-  <h2 class='translation-subheading'>
-    <%= t('spotlight.exhibits.translations.general.basic_settings.label') %>
-  </h2>
-  
   <%= bootstrap_form_for current_exhibit, url: spotlight.exhibit_translations_path(current_exhibit), layout: :horizontal do |f| %>
     <% # Add a hidden field for the language so the redirect knows how to come back here %>
     <%= hidden_field_tag :language, @language %>
-    <% translation = Translation.find_or_initialize_by(exhibit: current_exhibit, key: "#{current_exhibit.slug}.title", locale: @language) %>
-    <%= f.fields_for :translations, translation do |translation_fields| %>
-      <%= translation_fields.hidden_field :key %>
-      <%= translation_fields.hidden_field :locale %>
-      <div class='form-group translation-form'>
-        <%= translation_fields.label :value, t('spotlight.exhibits.translations.general.basic_settings.title'), class: 'control-label col-sm-2' %>
-        <div class='col-md-8 panel panel-body panel-translation'>
-          <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
-          <p class="help-block">
-            <%= current_exhibit.title %>
-          </p>
+    
+    <div class='translation-basic-settings'>
+      <h2 class='translation-subheading'>
+        <%= t('spotlight.exhibits.translations.general.basic_settings.label') %>
+      </h2>
+      
+      <% translation = Translation.find_or_initialize_by(exhibit: current_exhibit, key: "#{current_exhibit.slug}.title", locale: @language) %>
+      <%= f.fields_for :translations, translation do |translation_fields| %>
+        <%= translation_fields.hidden_field :key %>
+        <%= translation_fields.hidden_field :locale %>
+        <div class='form-group translation-form translation-basic-settings-title'>
+          <%= translation_fields.label :value, t('spotlight.exhibits.translations.general.basic_settings.title'), class: 'control-label col-sm-2' %>
+          <div class='col-md-8 panel panel-body panel-translation'>
+            <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
+            <p class="help-block">
+              <%= current_exhibit.title %>
+            </p>
+          </div>
+          <div class='col-md-2'>
+            <% if translation.value.present? %>
+              <span class='glyphicon glyphicon-ok'></span>
+            <% end %>
+          </div>
         </div>
-        <div class='col-md-2'>
-          <% if translation.value.present? %>
-            <span class='glyphicon glyphicon-ok'></span>
-          <% end %>
+      <% end %>
+      <% translation = Translation.find_or_initialize_by(exhibit: current_exhibit, key: "#{current_exhibit.slug}.subtitle", locale: @language) %>
+      <%= f.fields_for :translations, translation do |translation_fields| %>
+        <%= translation_fields.hidden_field :key %>
+        <%= translation_fields.hidden_field :locale %>
+        <div class='form-group translation-form translation-basic-settings-subtitle'>
+          <%= translation_fields.label :value, t('spotlight.exhibits.translations.general.basic_settings.subtitle'), class: 'control-label col-sm-2' %>
+          <div class='col-md-8 panel panel-body panel-translation'>
+            <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
+            <p class="help-block">
+              <%= current_exhibit.subtitle %>
+            </p>
+          </div>
+          <div class='col-md-2'>
+            <% if translation.value.present? %>
+              <span class='glyphicon glyphicon-ok'></span>
+            <% end %>
+          </div>
         </div>
-      </div>
-    <% end %>
-    <% translation = Translation.find_or_initialize_by(exhibit: current_exhibit, key: "#{current_exhibit.slug}.subtitle", locale: @language) %>
-    <%= f.fields_for :translations, translation do |translation_fields| %>
-      <%= translation_fields.hidden_field :key %>
-      <%= translation_fields.hidden_field :locale %>
-      <div class='form-group translation-form'>
-        <%= translation_fields.label :value, t('spotlight.exhibits.translations.general.basic_settings.subtitle'), class: 'control-label col-sm-2' %>
-        <div class='col-md-8 panel panel-body panel-translation'>
-          <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
-          <p class="help-block">
-            <%= current_exhibit.subtitle %>
-          </p>
+      <% end %>
+      <% translation = Translation.find_or_initialize_by(exhibit: current_exhibit, key: "#{current_exhibit.slug}.description", locale: @language) %>
+      <%= f.fields_for :translations, translation do |translation_fields| %>
+        <%= translation_fields.hidden_field :key %>
+        <%= translation_fields.hidden_field :locale %>
+        <div class='form-group translation-form translation-basic-settings-description'>
+          <%= translation_fields.label :value, t('spotlight.exhibits.translations.general.basic_settings.description'), class: 'control-label col-sm-2' %>
+          <div class='col-md-8 panel panel-body panel-translation'>
+            <%= translation_fields.text_area_without_bootstrap :value, class: 'form-control' %>
+            <p class="help-block">
+              <%= current_exhibit.description %>
+            </p>
+          </div>
+          <div class='col-md-2'>
+            <% if translation.value.present? %>
+              <span class='glyphicon glyphicon-ok'></span>
+            <% end %>
+          </div>
         </div>
-        <div class='col-md-2'>
-          <% if translation.value.present? %>
-            <span class='glyphicon glyphicon-ok'></span>
-          <% end %>
-        </div>
-      </div>
-    <% end %>
-    <% translation = Translation.find_or_initialize_by(exhibit: current_exhibit, key: "#{current_exhibit.slug}.description", locale: @language) %>
-    <%= f.fields_for :translations, translation do |translation_fields| %>
-      <%= translation_fields.hidden_field :key %>
-      <%= translation_fields.hidden_field :locale %>
-      <div class='form-group translation-form'>
-        <%= translation_fields.label :value, t('spotlight.exhibits.translations.general.basic_settings.description'), class: 'control-label col-sm-2' %>
-        <div class='col-md-8 panel panel-body panel-translation'>
-          <%= translation_fields.text_area_without_bootstrap :value, class: 'form-control' %>
-          <p class="help-block">
-            <%= current_exhibit.description %>
-          </p>
-        </div>
-        <div class='col-md-2'>
-          <% if translation.value.present? %>
-            <span class='glyphicon glyphicon-ok'></span>
-          <% end %>
-        </div>
-      </div>
-    <% end %>
+      <% end %>
+    </div>
     <div class="form-actions">
       <div class="primary-actions">
         <%= f.submit nil, class: 'btn btn-primary' %>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -463,6 +463,15 @@ en:
         resend: Resend confirmation?
       tags:
         all: All
+      translations:
+        title: Translations
+        general:
+          label: General
+          basic_settings:
+            label: Basic Settings
+            title: Title
+            subtitle: Subtitle
+            description: Description
     main_navigation:
       about: "About"
       browse: "Browse"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -120,6 +120,7 @@ Spotlight::Engine.routes.draw do
       end
     end
     post 'solr/update' => 'solr#update'
+    resource :translations, only: [:edit, :update]
   end
 
   get '/:exhibit_id' => 'home_pages#show', as: :exhibit_root

--- a/lib/generators/spotlight/templates/config/initializers/translation.rb
+++ b/lib/generators/spotlight/templates/config/initializers/translation.rb
@@ -8,12 +8,12 @@ if Translation.table_exists?
   # Sets up the new Spotlight Translation backend, backed by ActiveRecord. To
   # turn on the ActiveRecord backend, uncomment the following lines.
 
-  # I18n.backend = I18n::Backend::ActiveRecord.new
+  I18n.backend = I18n::Backend::ActiveRecord.new
   I18n::Backend::ActiveRecord.send(:include, I18n::Backend::Memoize)
   Translation.send(:include, Spotlight::CustomTranslationExtension)
   I18n::Backend::Simple.send(:include, I18n::Backend::Memoize)
   I18n::Backend::Simple.send(:include, I18n::Backend::Pluralization)
   I18n::Backend::Simple.send(:include, I18n::Backend::Fallbacks)
 
-  # I18n.backend = I18n::Backend::Chain.new(I18n.backend, I18n::Backend::Simple.new)
+  I18n.backend = I18n::Backend::Chain.new(I18n.backend, I18n::Backend::Simple.new)
 end

--- a/spec/controllers/spotlight/translations_controller_spec.rb
+++ b/spec/controllers/spotlight/translations_controller_spec.rb
@@ -1,0 +1,51 @@
+describe Spotlight::TranslationsController do
+  routes { Spotlight::Engine.routes }
+
+  describe '#edit' do
+    let(:exhibit) { FactoryBot.create(:exhibit) }
+
+    context 'when not signed in' do
+      it 'is not successful' do
+        get :edit, params: { exhibit_id: exhibit }
+        expect(response).to redirect_to main_app.new_user_session_path
+      end
+    end
+
+    context 'when signed in as curator' do
+      before { sign_in user }
+      let(:user) { FactoryBot.create(:exhibit_curator, exhibit: exhibit) }
+      it 'is successful' do
+        get :edit, params: { exhibit_id: exhibit }
+        expect(response).to render_template(:edit)
+        expect(response).to be_successful
+      end
+    end
+  end
+
+  describe '#update' do
+    let(:exhibit) { FactoryBot.create(:exhibit) }
+
+    context 'when not signed in' do
+      it 'is not successful' do
+        patch :update, params: { exhibit_id: exhibit, exhibit: { translations_attributes: { id: 0, key: 'test' } } }
+        expect(response).to redirect_to main_app.new_user_session_path
+      end
+    end
+
+    context 'when signed in as curator' do
+      before { sign_in user }
+      let(:user) { FactoryBot.create(:exhibit_curator, exhibit: exhibit) }
+      let(:translation) { FactoryBot.create(:translation, exhibit: exhibit, value: 'foo') }
+      it 'updates successfully' do
+        patch :update, params: {
+          exhibit_id: exhibit,
+          exhibit: { translations_attributes: { id: translation, value: 'bar' } },
+          language: 'fr'
+        }
+        expect(response).to redirect_to edit_exhibit_translations_path(exhibit, language: 'fr')
+        translation.reload
+        expect(translation.value).to eq 'bar'
+      end
+    end
+  end
+end

--- a/spec/features/exhibits/language_create_edit_spec.rb
+++ b/spec/features/exhibits/language_create_edit_spec.rb
@@ -30,6 +30,7 @@ describe 'Language', type: :feature do
         click_button 'Save changes'
       end
       expect(page).to have_css '.flash_messages', text: 'The exhibit was successfully updated.'
+      expect(exhibit.languages.last).to be_public
     end
   end
   describe 'deleting' do

--- a/spec/features/exhibits/translation_editing_spec.rb
+++ b/spec/features/exhibits/translation_editing_spec.rb
@@ -1,0 +1,36 @@
+describe 'Translation editing', type: :feature do
+  let(:exhibit) { FactoryBot.create(:exhibit, title: 'Sample', subtitle: 'SubSample') }
+  let(:admin) { FactoryBot.create(:exhibit_admin, exhibit: exhibit) }
+  before do
+    FactoryBot.create(:language, exhibit: exhibit, locale: 'sq')
+    FactoryBot.create(:language, exhibit: exhibit, locale: 'fr')
+    login_as admin
+    visit spotlight.edit_exhibit_translations_path(exhibit, language: 'fr')
+  end
+  describe 'general' do
+    it 'selects the correct language' do
+      expect(page).to have_css '.nav-pills li.active', text: 'French'
+    end
+    it 'successfully adds translations' do
+      within '.translation-edit-form' do
+        expect(page).to have_css '.help-block', text: 'Sample'
+        expect(page).to have_css '.help-block', text: 'SubSample'
+        fill_in 'Title', with: 'Titre français'
+        fill_in 'Subtitle', with: 'Sous-titre français'
+        click_button 'Save changes'
+      end
+      expect(page).to have_css '.flash_messages', text: 'The exhibit was successfully updated.'
+      within '.translation-basic-settings-title' do
+        expect(page).to have_css 'input[value="Titre français"]'
+        expect(page).to have_css 'span.glyphicon.glyphicon-ok'
+      end
+      within '.translation-basic-settings-subtitle' do
+        expect(page).to have_css 'input[value="Sous-titre français"]'
+        expect(page).to have_css 'span.glyphicon.glyphicon-ok'
+      end
+      within '.translation-basic-settings-description' do
+        expect(page).to_not have_css 'span.glyphicon.glyphicon-ok'
+      end
+    end
+  end
+end

--- a/spec/models/spotlight/ability_spec.rb
+++ b/spec/models/spotlight/ability_spec.rb
@@ -10,6 +10,7 @@ describe Spotlight::Ability, type: :model do
   let(:page) { FactoryBot.create(:feature_page, exhibit: exhibit) }
   let(:language) { FactoryBot.create(:language, exhibit: exhibit) }
   let(:public_language) { FactoryBot.create(:language, exhibit: exhibit, public: true) }
+  let(:translation) { FactoryBot.create(:translation, exhibit: exhibit) }
   subject { Ability.new(user) }
 
   describe 'a user with no roles' do
@@ -66,6 +67,11 @@ describe Spotlight::Ability, type: :model do
     it { is_expected.to be_able_to(:update_all, Spotlight::Page) }
     it { is_expected.to be_able_to(:update, page) }
     it { is_expected.to be_able_to(:destroy, page) }
+
+    it { is_expected.to be_able_to(:create, Translation) }
+    it { is_expected.to be_able_to(:update_all, Translation) }
+    it { is_expected.to be_able_to(:update, translation) }
+    it { is_expected.to be_able_to(:destroy, translation) }
 
     it { is_expected.to be_able_to(:tag, exhibit) }
 

--- a/spec/models/spotlight/exhibit_spec.rb
+++ b/spec/models/spotlight/exhibit_spec.rb
@@ -299,4 +299,26 @@ describe Spotlight::Exhibit, type: :model do
   it 'is expected to be versioned' do
     is_expected.to be_versioned
   end
+  describe 'translatable fields' do
+    let(:persisted_exhibit) { FactoryBot.create(:exhibit, title: 'Sample', subtitle: 'SubSample') }
+    before do
+      FactoryBot.create(:translation, locale: 'fr', exhibit: persisted_exhibit, key: "#{persisted_exhibit.slug}.title", value: 'Titre français')
+      FactoryBot.create(:translation, locale: 'fr', exhibit: persisted_exhibit, key: "#{persisted_exhibit.slug}.subtitle", value: 'Sous-titre français')
+    end
+    after do
+      I18n.locale = 'en'
+    end
+    it 'has a translatable title' do
+      expect(persisted_exhibit.title).to eq 'Sample'
+      I18n.locale = 'fr'
+      persisted_exhibit.reload
+      expect(persisted_exhibit.title).to eq 'Titre français'
+    end
+    it 'has a translatable subtitle' do
+      expect(persisted_exhibit.subtitle).to eq 'SubSample'
+      I18n.locale = 'fr'
+      persisted_exhibit.reload
+      expect(persisted_exhibit.subtitle).to eq 'Sous-titre français'
+    end
+  end
 end


### PR DESCRIPTION
Work outlined in #1914 

![translations2](https://user-images.githubusercontent.com/1656824/37375371-e13d2c2e-26e4-11e8-807e-dc690e8c62de.gif)


Fixes #1914. Unresolved items have been split off as additional tickets.

## Update guide
Make sure to update your `config/initializers/translation.rb` file to turn on the i18n-active_record backend.


## Fixture data
None, just create an exhibit




This is a proof of concept with some lingering questions: ✅ 

 - [x] How should the model attributes be translated throughout the application? Should we do something dynamic [like Globalize](https://github.com/globalize/globalize/blob/master/lib/globalize/active_record/act_macro.rb#L30-L51)?
 - [x] How do I know what the default language values are for some of the AR attributes (`title`, `subtitle`)? related to ^^ *Answer: Do not care at the moment*
 - [x] ~~These forms are going to be painful to build. What type of custom helpers/models can we build to help with this? https://github.com/projectblacklight/spotlight/compare/i18n-%F0%9F%8C%9D...add-general-edit-form?expand=1#diff-44ee77aa16a75e066de55c5be5448a46R28~~ split out to #1934
 - [x] ~~Should we put uniqueness validations on locale keys by language + exhibit?~~ Split off https://github.com/projectblacklight/spotlight/issues/1933
 - [x] ~~I'm using nest attributes here.. so after saving it redirects to `edit_exhibit_path`~~ resolved with controller changes
