### PR TITLE
Add ability to translate title/description of browse categories

### DIFF
--- a/app/assets/stylesheets/spotlight/_translations.scss
+++ b/app/assets/stylesheets/spotlight/_translations.scss
@@ -1,3 +1,9 @@
+.translation-edit-form {
+  .glyphicon-ok {
+    color: $translation-available-color;
+  }
+}
+
 .translation-subheading {
   border-bottom: 1px solid $navbar-default-border;
   margin-bottom: 20px;
@@ -9,9 +15,21 @@
   }
 
   .glyphicon-ok {
-    color: $translation-available-color;
     padding-top: $panel-body-padding + $padding-base-vertical;
   }
+}
+
+.tanslation-description-toggle {
+  margin: 0;
+  padding: 0;
+
+  &.collapsed {
+    .caret {
+      transform: rotate(-90deg);
+    }
+  }
+
+  label { cursor: pointer; }
 }
 
 .panel-translation {

--- a/app/controllers/spotlight/translations_controller.rb
+++ b/app/controllers/spotlight/translations_controller.rb
@@ -9,6 +9,7 @@ module Spotlight
 
     def update
       if current_exhibit.update(exhibit_params)
+        I18n.reload! # reload since we're memoizing
         notice = t(:'helpers.submit.spotlight_default.updated', model: current_exhibit.class.model_name.human.downcase)
         redirect_to edit_exhibit_translations_path(current_exhibit, params: { language: @language }), notice: notice
       else

--- a/app/models/spotlight/search.rb
+++ b/app/models/spotlight/search.rb
@@ -2,6 +2,7 @@ module Spotlight
   ##
   # Exhibit saved searches
   class Search < ActiveRecord::Base
+    include Spotlight::Translatables
     extend FriendlyId
     friendly_id :title, use: [:slugged, :scoped, :finders, :history], scope: :exhibit
 
@@ -11,6 +12,9 @@ module Spotlight
     default_scope { order('weight ASC') }
     scope :published, -> { where(published: true) }
     validates :title, presence: true
+
+    translates :title, :long_description
+
     has_paper_trail
 
     belongs_to :masthead, dependent: :destroy, optional: true

--- a/app/views/spotlight/translations/_browse_categories.html.erb
+++ b/app/views/spotlight/translations/_browse_categories.html.erb
@@ -1,0 +1,68 @@
+<div role="tabpanel" class="tab-pane" id="browse">
+  <%= bootstrap_form_for current_exhibit, url: spotlight.exhibit_translations_path(current_exhibit), layout: :horizontal do |f| %>
+    <% # Add a hidden field for the language so the redirect knows how to come back here %>
+    <%= hidden_field_tag :language, @language %>
+    <div class="row">
+      <div class="col-xs-4 text-right">
+        <strong>
+          <%= t :'spotlight.exhibits.translations.browse_categories.default_language_column_label' %>
+        </strong>
+      </div>
+      <div class="col-xs-7">
+        <strong>
+          <%= t :'spotlight.exhibits.translations.browse_categories.translation_column_label', language: t("locales.#{@language}")  %>
+        </strong>
+      </div>
+    </div>
+
+    <% current_exhibit.searches.each do |search| %>
+      <% title_translation = Translation.find_or_initialize_by(exhibit: current_exhibit, key: "#{search.slug}.title", locale: @language) %>
+      <%= f.fields_for :translations, title_translation do |translation_fields| %>
+        <%= translation_fields.hidden_field :key %>
+        <%= translation_fields.hidden_field :locale %>
+        <div class="form-group">
+          <%= translation_fields.label :value, search[:title], class: 'control-label col-xs-4' %>
+          <div class="col-xs-7">
+            <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
+          </div>
+          <div class="col-xs-1">
+            <% if title_translation.value.present? %>
+              <span class='glyphicon glyphicon-ok'></span>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+
+      <% description_translation = Translation.find_or_initialize_by(exhibit: current_exhibit, key: "#{search.slug}.long_description", locale: @language) %>
+      <% if search[:long_description] || description_translation.persisted? %>
+        <div class="form-group">
+          <div class="col-xs-7 col-xs-offset-4">
+            <%= f.fields_for :translations, description_translation do |translation_fields| %>
+              <%= button_tag 'type' => 'button', class: 'btn btn-text collapsed tanslation-description-toggle', 'data-toggle': 'collapse', 'data-target': "#browse_category_description_#{search.id}", 'aria-expanded': 'false', 'aria-controls': "#browse_category_description_#{search.id}" do %>
+                <%= translation_fields.label :value, t(:'spotlight.exhibits.translations.browse_categories.description_label') %>
+                <span class="caret"></span>
+              <% end %>
+              <%= translation_fields.hidden_field :key %>
+              <%= translation_fields.hidden_field :locale %>
+              <div id="browse_category_description_<%= search.id %>" class="panel panel-body collapse panel-translation">
+                <%= translation_fields.text_area_without_bootstrap :value, class: 'form-control' %>
+                <p class="help-block"><%= search[:long_description] %></p>
+              </div>
+            <% end %>
+          </div>
+          <div class="col-xs-1">
+            <% if description_translation.value.present? %>
+              <span class='glyphicon glyphicon-ok'></span>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
+
+    <div class="form-actions">
+      <div class="primary-actions">
+        <%= f.submit nil, class: 'btn btn-primary' %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/spotlight/translations/_general.html.erb
+++ b/app/views/spotlight/translations/_general.html.erb
@@ -1,0 +1,75 @@
+<div role="tabpanel" class="tab-pane active" id="general">
+  <%= bootstrap_form_for current_exhibit, url: spotlight.exhibit_translations_path(current_exhibit), layout: :horizontal do |f| %>
+    <% # Add a hidden field for the language so the redirect knows how to come back here %>
+    <%= hidden_field_tag :language, @language %>
+
+    <div class='translation-basic-settings'>
+      <h2 class='translation-subheading'>
+        <%= t('spotlight.exhibits.translations.general.basic_settings.label') %>
+      </h2>
+
+      <% translation = Translation.find_or_initialize_by(exhibit: current_exhibit, key: "#{current_exhibit.slug}.title", locale: @language) %>
+      <%= f.fields_for :translations, translation do |translation_fields| %>
+        <%= translation_fields.hidden_field :key %>
+        <%= translation_fields.hidden_field :locale %>
+        <div class='form-group translation-form translation-basic-settings-title'>
+          <%= translation_fields.label :value, t('spotlight.exhibits.translations.general.basic_settings.title'), class: 'control-label col-sm-2' %>
+          <div class='col-md-8 panel panel-body panel-translation'>
+            <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
+            <p class="help-block">
+              <%= current_exhibit[:title] %>
+            </p>
+          </div>
+          <div class='col-md-2'>
+            <% if translation.value.present? %>
+              <span class='glyphicon glyphicon-ok'></span>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+      <% translation = Translation.find_or_initialize_by(exhibit: current_exhibit, key: "#{current_exhibit.slug}.subtitle", locale: @language) %>
+      <%= f.fields_for :translations, translation do |translation_fields| %>
+        <%= translation_fields.hidden_field :key %>
+        <%= translation_fields.hidden_field :locale %>
+        <div class='form-group translation-form translation-basic-settings-subtitle'>
+          <%= translation_fields.label :value, t('spotlight.exhibits.translations.general.basic_settings.subtitle'), class: 'control-label col-sm-2' %>
+          <div class='col-md-8 panel panel-body panel-translation'>
+            <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
+            <p class="help-block">
+              <%= current_exhibit[:subtitle] %>
+            </p>
+          </div>
+          <div class='col-md-2'>
+            <% if translation.value.present? %>
+              <span class='glyphicon glyphicon-ok'></span>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+      <% translation = Translation.find_or_initialize_by(exhibit: current_exhibit, key: "#{current_exhibit.slug}.description", locale: @language) %>
+      <%= f.fields_for :translations, translation do |translation_fields| %>
+        <%= translation_fields.hidden_field :key %>
+        <%= translation_fields.hidden_field :locale %>
+        <div class='form-group translation-form translation-basic-settings-description'>
+          <%= translation_fields.label :value, t('spotlight.exhibits.translations.general.basic_settings.description'), class: 'control-label col-sm-2' %>
+          <div class='col-md-8 panel panel-body panel-translation'>
+            <%= translation_fields.text_area_without_bootstrap :value, class: 'form-control' %>
+            <p class="help-block">
+              <%= current_exhibit.description %>
+            </p>
+          </div>
+          <div class='col-md-2'>
+            <% if translation.value.present? %>
+              <span class='glyphicon glyphicon-ok'></span>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+    <div class="form-actions">
+      <div class="primary-actions">
+        <%= f.submit nil, class: 'btn btn-primary' %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/spotlight/translations/edit.html.erb
+++ b/app/views/spotlight/translations/edit.html.erb
@@ -2,7 +2,7 @@
 
 <div class='col-md-9 translation-edit-form'>
   <%= curation_page_title t('spotlight.exhibits.translations.title') %>
-  
+
   <div class='text-center'>
     <ul class='nav nav-pills inline-block'>
       <% current_exhibit.available_locales.each do |language| %>
@@ -15,85 +15,17 @@
     </ul>
   </div>
 
-  <ul class='nav nav-tabs'>
-    <li>
-      <a href='#'>
-        <%= t('spotlight.exhibits.translations.general.label') %>
-      </a>
-    </li>
-  </ul>
+  <div role="tabpanel">
+    <ul class='nav nav-tabs' role="tablist">
+      <li role="presentation" class="active">
+        <a href='#general' aria-controls="general" role="tab" data-toggle="tab">
+          <%= t('spotlight.exhibits.translations.general.label') %>
+        </a>
+      </li>
+    </ul>
 
-  <%= bootstrap_form_for current_exhibit, url: spotlight.exhibit_translations_path(current_exhibit), layout: :horizontal do |f| %>
-    <% # Add a hidden field for the language so the redirect knows how to come back here %>
-    <%= hidden_field_tag :language, @language %>
-    
-    <div class='translation-basic-settings'>
-      <h2 class='translation-subheading'>
-        <%= t('spotlight.exhibits.translations.general.basic_settings.label') %>
-      </h2>
-      
-      <% translation = Translation.find_or_initialize_by(exhibit: current_exhibit, key: "#{current_exhibit.slug}.title", locale: @language) %>
-      <%= f.fields_for :translations, translation do |translation_fields| %>
-        <%= translation_fields.hidden_field :key %>
-        <%= translation_fields.hidden_field :locale %>
-        <div class='form-group translation-form translation-basic-settings-title'>
-          <%= translation_fields.label :value, t('spotlight.exhibits.translations.general.basic_settings.title'), class: 'control-label col-sm-2' %>
-          <div class='col-md-8 panel panel-body panel-translation'>
-            <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
-            <p class="help-block">
-              <%= current_exhibit.title %>
-            </p>
-          </div>
-          <div class='col-md-2'>
-            <% if translation.value.present? %>
-              <span class='glyphicon glyphicon-ok'></span>
-            <% end %>
-          </div>
-        </div>
-      <% end %>
-      <% translation = Translation.find_or_initialize_by(exhibit: current_exhibit, key: "#{current_exhibit.slug}.subtitle", locale: @language) %>
-      <%= f.fields_for :translations, translation do |translation_fields| %>
-        <%= translation_fields.hidden_field :key %>
-        <%= translation_fields.hidden_field :locale %>
-        <div class='form-group translation-form translation-basic-settings-subtitle'>
-          <%= translation_fields.label :value, t('spotlight.exhibits.translations.general.basic_settings.subtitle'), class: 'control-label col-sm-2' %>
-          <div class='col-md-8 panel panel-body panel-translation'>
-            <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
-            <p class="help-block">
-              <%= current_exhibit.subtitle %>
-            </p>
-          </div>
-          <div class='col-md-2'>
-            <% if translation.value.present? %>
-              <span class='glyphicon glyphicon-ok'></span>
-            <% end %>
-          </div>
-        </div>
-      <% end %>
-      <% translation = Translation.find_or_initialize_by(exhibit: current_exhibit, key: "#{current_exhibit.slug}.description", locale: @language) %>
-      <%= f.fields_for :translations, translation do |translation_fields| %>
-        <%= translation_fields.hidden_field :key %>
-        <%= translation_fields.hidden_field :locale %>
-        <div class='form-group translation-form translation-basic-settings-description'>
-          <%= translation_fields.label :value, t('spotlight.exhibits.translations.general.basic_settings.description'), class: 'control-label col-sm-2' %>
-          <div class='col-md-8 panel panel-body panel-translation'>
-            <%= translation_fields.text_area_without_bootstrap :value, class: 'form-control' %>
-            <p class="help-block">
-              <%= current_exhibit.description %>
-            </p>
-          </div>
-          <div class='col-md-2'>
-            <% if translation.value.present? %>
-              <span class='glyphicon glyphicon-ok'></span>
-            <% end %>
-          </div>
-        </div>
-      <% end %>
+    <div class="tab-content">
+      <%= render 'general' %>
     </div>
-    <div class="form-actions">
-      <div class="primary-actions">
-        <%= f.submit nil, class: 'btn btn-primary' %>
-      </div>
-    </div>
-  <% end %>
+  </div>
 </div>

--- a/app/views/spotlight/translations/edit.html.erb
+++ b/app/views/spotlight/translations/edit.html.erb
@@ -22,10 +22,16 @@
           <%= t('spotlight.exhibits.translations.general.label') %>
         </a>
       </li>
+      <li>
+        <a href="#browse" aria-controls="browse" role="tab" data-toggle="tab">
+          <%= t('spotlight.exhibits.translations.browse_categories.label') %>
+        </a>
+      </li>
     </ul>
 
     <div class="tab-content">
       <%= render 'general' %>
+      <%= render 'browse_categories' %>
     </div>
   </div>
 </div>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -451,7 +451,7 @@ en:
           confirm: "Are you sure you want to remove this language?"
         no_languages_help_text: 'No languages have been added for translation. To add a language, make a selection above.'
         remove: 'Remove'
-        selection_prompt: 'Select language...' 
+        selection_prompt: 'Select language...'
         table_heading:
           language: Language
           public: Public
@@ -465,6 +465,11 @@ en:
         all: All
       translations:
         title: Translations
+        browse_categories:
+          default_language_column_label: English language title
+          description_label: Description
+          label: Browse categories
+          translation_column_label: "%{language} translation"
         general:
           label: General
           basic_settings:

--- a/spec/features/exhibits/translation_editing_spec.rb
+++ b/spec/features/exhibits/translation_editing_spec.rb
@@ -5,14 +5,17 @@ describe 'Translation editing', type: :feature do
     FactoryBot.create(:language, exhibit: exhibit, locale: 'sq')
     FactoryBot.create(:language, exhibit: exhibit, locale: 'fr')
     login_as admin
-    visit spotlight.edit_exhibit_translations_path(exhibit, language: 'fr')
   end
   describe 'general' do
+    before do
+      visit spotlight.edit_exhibit_translations_path(exhibit, language: 'fr')
+    end
+
     it 'selects the correct language' do
       expect(page).to have_css '.nav-pills li.active', text: 'French'
     end
     it 'successfully adds translations' do
-      within '.translation-edit-form' do
+      within '.translation-edit-form #general' do
         expect(page).to have_css '.help-block', text: 'Sample'
         expect(page).to have_css '.help-block', text: 'SubSample'
         fill_in 'Title', with: 'Titre français'
@@ -31,6 +34,55 @@ describe 'Translation editing', type: :feature do
       within '.translation-basic-settings-description' do
         expect(page).to_not have_css 'span.glyphicon.glyphicon-ok'
       end
+    end
+  end
+
+  describe 'Browse categories' do
+    before do
+      FactoryBot.create(:search, exhibit: exhibit, title: 'Browse Category 1')
+
+      visit spotlight.edit_exhibit_translations_path(exhibit, language: 'fr')
+    end
+
+    it 'has a title for every browse category' do
+      within '#browse' do
+        expect(page).to have_css('input[type="text"]', count: 2)
+        expect(page).to have_field 'All Exhibit Items'
+        expect(page).to have_field 'Browse Category 1'
+      end
+    end
+
+    it 'only renders a description field if search has one' do
+      within '#browse #browse_category_description_1' do
+        expect(page).to have_css('textarea', count: 1)
+
+        expect(page).to have_css('.help-block', 'All items in this exhibit.')
+      end
+    end
+
+    it 'persists changes', js: true do
+      click_link 'Browse categories'
+
+      within('#browse', visible: true) do
+        fill_in 'All Exhibit Items', with: "Tous les objets d'exposition"
+
+        click_button 'Description'
+
+        textarea = page.find('textarea')
+        textarea.set('Tous les articles de cette exposition.')
+
+        click_button 'Save changes'
+      end
+
+      expect(page).to have_css('.flash_messages', text: 'The exhibit was successfully updated.')
+
+      expect(exhibit.searches.first.title).to eq 'All Exhibit Items'
+      expect(exhibit.searches.first.long_description).to eq 'All items in this exhibit.'
+
+      I18n.locale = :fr
+      expect(exhibit.searches.first.title).to eq "Tous les objets d'exposition"
+      expect(exhibit.searches.first.long_description).to eq 'Tous les articles de cette exposition.'
+      I18n.locale = I18n.default_locale
     end
   end
 end


### PR DESCRIPTION
Closes #1917 

## Open Questions
- What should we do if there are no browse categories? (Don't show the tab / Put some explanation/help text as the tab content?)
- I'm using the browse category's `slug` as part of the key (similar to how we do w/ the exhibit) so it can be fetched appropriately by the `Translatables` mixin.  This has the potential of causing an issue if you were to name a browse category the same thing as your exhibit. A few ways that we could solve this is adding some sort of normalization of the class name into the key or to have the Translation have a polymorphic relationship (not sure how that will play w/ how we've set things up so far though).
- Another issue w/ using the `slug` is that if a browse category is renamed, its slug is updated (this will break all translation keys as-is).  We've run into this in pages that include the Browse Category widget as well.  This makes me wonder if we should make the slugs static (similar to what we do w/ the exhibits themselves).


<img width="886" alt="admin-ui" src="https://user-images.githubusercontent.com/96776/37491941-a3f8cf34-285c-11e8-94dd-ada4548940f6.png">

<img width="1185" alt="user-facing" src="https://user-images.githubusercontent.com/96776/37447598-0eaeb7c6-27e0-11e8-8184-4e8073d4ec26.png">
