### PR TITLE
Redirect to the same Configuration > General tab after forms are saved

### DIFF
--- a/app/controllers/spotlight/exhibits_controller.rb
+++ b/app/controllers/spotlight/exhibits_controller.rb
@@ -3,6 +3,7 @@ module Spotlight
   # Administrative CRUD actions for an exhibit
   class ExhibitsController < Spotlight::ApplicationController
     before_action :authenticate_user!, except: [:index]
+    before_action :set_tab, only: [:edit, :update]
     include Blacklight::SearchHelper
 
     load_and_authorize_resource
@@ -63,7 +64,9 @@ module Spotlight
 
     def update
       if @exhibit.update(exhibit_params)
-        redirect_to edit_exhibit_path(@exhibit), notice: t(:'helpers.submit.exhibit.updated', model: @exhibit.class.model_name.human.downcase)
+        redirect_to edit_exhibit_path(@exhibit, tab: @tab),
+                    notice: t(:'helpers.submit.exhibit.updated',
+                              model: @exhibit.class.model_name.human.downcase)
       else
         flash[:alert] = @exhibit.errors.full_messages.join('<br>'.html_safe)
         render action: :edit
@@ -92,6 +95,10 @@ module Spotlight
         contact_emails_attributes: [:id, :email],
         languages_attributes: [:id, :public]
       )
+    end
+
+    def set_tab
+      @tab = params[:tab] || nil
     end
 
     def create_params

--- a/app/controllers/spotlight/filters_controller.rb
+++ b/app/controllers/spotlight/filters_controller.rb
@@ -11,14 +11,14 @@ module Spotlight
       else
         flash[:alert] = @filter.errors.full_messages.join('<br/>'.html_safe)
       end
-      redirect_to spotlight.edit_exhibit_path @exhibit, anchor: 'filter'
+      redirect_to spotlight.edit_exhibit_path @exhibit, tab: 'filter'
     end
 
     def update
       unless @filter.update(filter_params)
         flash[:alert] = @filter.errors.full_messages.join('<br/>'.html_safe)
       end
-      redirect_to spotlight.edit_exhibit_path @exhibit, anchor: 'filter'
+      redirect_to spotlight.edit_exhibit_path @exhibit, tab: 'filter'
     end
 
     def filter_params

--- a/app/controllers/spotlight/languages_controller.rb
+++ b/app/controllers/spotlight/languages_controller.rb
@@ -11,14 +11,14 @@ module Spotlight
       else
         flash[:alert] = @language.errors.full_messages.join('<br/>'.html_safe)
       end
-      redirect_to spotlight.edit_exhibit_path @exhibit, anchor: 'language'
+      redirect_to spotlight.edit_exhibit_path @exhibit, tab: 'language'
     end
 
     def destroy
       @language.destroy
 
       redirect_to(
-        spotlight.edit_exhibit_path(@exhibit, anchor: 'language'),
+        spotlight.edit_exhibit_path(@exhibit, tab: 'language'),
         notice: t(:'helpers.submit.language.destroyed', model: @language.model_name.human.downcase)
       )
     end

--- a/app/views/spotlight/exhibits/_export.html.erb
+++ b/app/views/spotlight/exhibits/_export.html.erb
@@ -1,4 +1,4 @@
-<div role="tabpanel" class="tab-pane" id="export">        
+<div role="tabpanel" class="tab-pane <%= 'active' if @tab == 'export' %>" id="export">        
   <div class="row col-md-12">
     <p class="instructions"><%= t :'.instructions' %></p>
     <div class="primary-actions">

--- a/app/views/spotlight/exhibits/_import.html.erb
+++ b/app/views/spotlight/exhibits/_import.html.erb
@@ -1,9 +1,10 @@
-<div role="tabpanel" class="tab-pane" id="import">
+<div role="tabpanel" class="tab-pane <%= 'active' if @tab == 'import' %>" id="import">
   <%= bootstrap_form_for [:import, current_exhibit], html: { class: 'clearfix', multipart: true } do |f| %>
     <div class="row col-md-12">
       <p class="instructions"><%= t :'.instructions' %></p>
       <div class="form-group">
         <%= file_field_tag :file, class: 'form-control' %>
+        <%= hidden_field_tag :tab, 'import' %>
       </div>
       <div class="form-actions">
         <div class="primary-actions">

--- a/app/views/spotlight/exhibits/_languages.html.erb
+++ b/app/views/spotlight/exhibits/_languages.html.erb
@@ -1,9 +1,10 @@
-<div role="tabpanel" class="tab-pane" id="language">
+<div role="tabpanel" class="tab-pane <%= 'active' if @tab == 'language' %>" id="language">
   <p class="instructions"><%= t :'spotlight.exhibits.languages.selection_instructions' %></p>
 
   <%= bootstrap_form_for [current_exhibit, Spotlight::Language.new], layout: :horizontal do |f| %>
     <div class='col-md-6'>
       <%= f.select('locale', add_exhibit_language_dropdown_options, prompt: t('.selection_prompt')) %>
+      <%= hidden_field_tag :tab, 'language' %>
     </div>
     <%= f.submit nil, class: 'btn btn-primary' %>
   <% end %>
@@ -44,6 +45,7 @@
       </div>
       <div class="form-actions">
         <div class="primary-actions">
+          <%= hidden_field_tag :tab, 'language' %>
           <%= f.submit nil, class: 'btn btn-primary' %>
         </div>
       </div>

--- a/app/views/spotlight/exhibits/edit.html.erb
+++ b/app/views/spotlight/exhibits/edit.html.erb
@@ -3,26 +3,26 @@
   <%= configuration_page_title %>
   <div role="tabpanel">
     <ul class="nav nav-tabs" role="tablist">
-      <li role="presentation" class="active">
+      <li role="presentation" class="<%= 'active' if @tab.blank? %>">
         <a href="#basic" aria-controls="basic" role="tab" data-toggle="tab"><%= t(:'.basic_settings.heading') %></a>
       </li>
       <% if can? :manage, current_exhibit.languages.first_or_initialize %>
-        <li role="presentation">
+        <li role="presentation" class="<%= 'active' if @tab == 'language' %>">
           <a href="#language" aria-controls="language" role="tab" data-toggle="tab"><%= t(:'spotlight.exhibits.languages.heading') %></a>
         </li>
       <% end %>
       <% if can? :edit, current_exhibit.filters.first_or_initialize %>
-        <li role="presentation">
+        <li role="presentation" class="<%= 'active' if @tab == 'filter' %>">
           <a href="#filter" aria-controls="filter" role="tab" data-toggle="tab"><%= t(:'spotlight.exhibits.filter.heading') %></a>
         </li>
       <% end %>
       <% if can? :import, current_exhibit %>
-        <li role="presentation">
+        <li role="presentation" class="<%= 'active' if @tab == 'import' %>">
           <a href="#import" aria-controls="import" role="tab" data-toggle="tab"><%= t(:'spotlight.exhibits.import.heading') %></a>
         </li>
       <% end %>
       <% if can? :export, current_exhibit %>
-        <li role="presentation">
+        <li role="presentation" class="<%= 'active' if @tab == 'export' %>">
           <a href="#export" aria-controls="export" role="tab" data-toggle="tab"><%= t(:'spotlight.exhibits.export.heading') %></a>
         </li>
       <% end %>
@@ -33,7 +33,7 @@
       <% end %>
     </ul>
     <div class="tab-content">
-      <div role="tabpanel" class="tab-pane active" id="basic">
+      <div role="tabpanel" class="tab-pane <%= 'active' if @tab.blank? %>" id="basic">
         <%= render 'form' %>
       </div>
       <%= render 'languages' if can? :manage, current_exhibit.languages.first_or_initialize %>

--- a/app/views/spotlight/filters/_form.html.erb
+++ b/app/views/spotlight/filters/_form.html.erb
@@ -1,9 +1,10 @@
-<div role="tabpanel" class="tab-pane" id="filter">
+<div role="tabpanel" class="tab-pane <%= 'active' if @tab == 'filter' %>" id="filter">
   <%= bootstrap_form_for [@exhibit, @exhibit.filters.first_or_initialize], layout: :horizontal, label_col: 'col-md-2', control_col: 'col-md-10', html: {class: "row"} do |f| %>
     <p class="instructions"><%= t :'spotlight.exhibits.filter.instructions' %></p>
 
     <%= f.text_field :field %>
     <%= f.text_field :value %>
+    <%= hidden_field_tag :tab, 'filter' %>
 
     <div class="form-actions">
       <div class="primary-actions">

--- a/spec/controllers/spotlight/filters_controller_spec.rb
+++ b/spec/controllers/spotlight/filters_controller_spec.rb
@@ -21,13 +21,13 @@ describe Spotlight::FiltersController do
 
       it 'is successful' do
         post :create, params: { exhibit_id: exhibit, filter: { field: 'foo_ssi', value: 'bar' } }
-        expect(response).to redirect_to edit_exhibit_path(exhibit, anchor: 'filter')
+        expect(response).to redirect_to edit_exhibit_path(exhibit, tab: 'filter')
         expect(assigns[:exhibit].solr_data).to eq('foo_ssi' => 'bar')
       end
 
       it 'valids filter values' do
         post :create, params: { exhibit_id: exhibit, filter: { field: 'foo_ssi', value: '' } }
-        expect(response).to redirect_to edit_exhibit_path(exhibit, anchor: 'filter')
+        expect(response).to redirect_to edit_exhibit_path(exhibit, tab: 'filter')
         expect(flash[:alert]).to include "Value can't be blank"
       end
     end
@@ -54,13 +54,13 @@ describe Spotlight::FiltersController do
 
       it 'is successful' do
         patch :update, params: { exhibit_id: exhibit, id: exhibit_filter, filter: { field: 'foo_ssi', value: 'bar' } }
-        expect(response).to redirect_to edit_exhibit_path(exhibit, anchor: 'filter')
+        expect(response).to redirect_to edit_exhibit_path(exhibit, tab: 'filter')
         expect(assigns[:exhibit].solr_data).to eq('foo_ssi' => 'bar')
       end
 
       it 'valids filter values' do
         patch :update, params: { exhibit_id: exhibit, id: exhibit_filter, filter: { field: 'foo_ssi', value: '' } }
-        expect(response).to redirect_to edit_exhibit_path(exhibit, anchor: 'filter')
+        expect(response).to redirect_to edit_exhibit_path(exhibit, tab: 'filter')
         expect(flash[:alert]).to include "Value can't be blank"
       end
     end

--- a/spec/controllers/spotlight/languages_controller_spec.rb
+++ b/spec/controllers/spotlight/languages_controller_spec.rb
@@ -17,14 +17,14 @@ describe Spotlight::LanguagesController do
 
       it 'is successful' do
         post :create, params: { exhibit_id: exhibit, language: { locale: 'es' } }
-        expect(response).to redirect_to edit_exhibit_path(exhibit, anchor: 'language')
+        expect(response).to redirect_to edit_exhibit_path(exhibit, tab: 'language')
         expect(assigns[:exhibit].languages.first.locale).to eq 'es'
         expect(flash[:notice]).to eq 'The language was created.'
       end
 
       it 'validates language params' do
         post :create, params: { exhibit_id: exhibit, language: { locale: nil } }
-        expect(response).to redirect_to edit_exhibit_path(exhibit, anchor: 'language')
+        expect(response).to redirect_to edit_exhibit_path(exhibit, tab: 'language')
         expect(flash[:alert]).to include "Language can't be blank"
       end
     end
@@ -47,7 +47,7 @@ describe Spotlight::LanguagesController do
 
       it 'is successful' do
         delete :destroy, params: { exhibit_id: exhibit, id: language }
-        expect(response).to redirect_to edit_exhibit_path(exhibit, anchor: 'language')
+        expect(response).to redirect_to edit_exhibit_path(exhibit, tab: 'language')
         expect(assigns[:exhibit].languages.count).to eq 0
         expect(flash[:notice]).to eq 'The language was deleted.'
       end


### PR DESCRIPTION
Fixes #1932 

## Approach:
1. Pass a `tab` parameter through a hidden_field on each form within Configuration > General
2. Pass the `tab` parameter to the controller action's redirect 
2. In the view, apply the `active` class to the nav tab and `div.tab-content` that have an id that matches the `tab` param

Note: h/t to @mejackreed for providing [an example of this approach](https://github.com/projectblacklight/spotlight/pull/1931/files#diff-059f2c780562af6d663a2f0d5cd9038bR9)

### Before
`http://test.host/spotlight/exhibit-title-714/edit#language`
### After
`http://test.host/spotlight/exhibit-title-714/edit?tab=language`

## Config > General tabs

- Basic settings
- Languages
- Filter
- Import (unchanged; redirects to exhibit dashboard)
- Export (unchanged; stays on the same page after downloading)
- Delete (unchanged; redirects to exhibits#index)
