### PR TITLE
Remove our has_many :owned_taggings definition.

### DIFF
--- a/app/models/spotlight/exhibit.rb
+++ b/app/models/spotlight/exhibit.rb
@@ -34,7 +34,6 @@ module Spotlight
     has_many :custom_fields, dependent: :delete_all
     has_many :feature_pages, extend: FriendlyId::FinderMethods
     has_many :main_navigations, dependent: :delete_all
-    has_many :owned_taggings, class_name: 'ActsAsTaggableOn::Tagging', as: :tagger
     has_many :reindexing_log_entries, dependent: :destroy
     has_many :resources
     has_many :roles, as: :resource, dependent: :delete_all


### PR DESCRIPTION
This is already defined by calling acts_as_tagger and there is a rails 5.1 issue that throws an error when redefining these associations.

Closes #1944 
Closes sul-dlss/exhibits#1125