### PR TITLE
adds main menu navigation translation functionality

### DIFF
--- a/app/models/spotlight/exhibit.rb
+++ b/app/models/spotlight/exhibit.rb
@@ -20,7 +20,7 @@ module Spotlight
 
     extend FriendlyId
     friendly_id :title, use: [:slugged, :finders]
-    validates :title, presence: true
+    validates :title, presence: true, if: -> { I18n.locale == I18n.default_locale }
     validates :slug, uniqueness: true
     validates :theme, inclusion: { in: Spotlight::Engine.config.exhibit_themes }, allow_blank: true
 

--- a/app/models/spotlight/main_navigation.rb
+++ b/app/models/spotlight/main_navigation.rb
@@ -2,11 +2,15 @@ module Spotlight
   ##
   # Exhibit navbar links
   class MainNavigation < ActiveRecord::Base
+    include Spotlight::Translatables
+
     belongs_to :exhibit, touch: true
     default_scope { order('weight ASC') }
     scope :browse, -> { find_by(nav_type: 'browse') }
     scope :about, -> { find_by(nav_type: 'about') }
+    scope :curated_features, -> { find_by(nav_type: 'curated_features') }
     scope :displayable, -> { where(display: true) }
+    translates :label
 
     def displayable?
       display?
@@ -22,6 +26,14 @@ module Spotlight
 
     def default_label
       I18n.t(:"spotlight.main_navigation.#{nav_type}")
+    end
+
+    private
+
+    ##
+    # Allows us to scope translations namespace.
+    def slug
+      ['main_navigation', nav_type].join('.')
     end
   end
 end

--- a/app/views/spotlight/translations/_general.html.erb
+++ b/app/views/spotlight/translations/_general.html.erb
@@ -66,6 +66,88 @@
         </div>
       <% end %>
     </div>
+    <div class='translation-main-menu'>
+      <h2 class='translation-subheading'>
+        <%= t('spotlight.exhibits.translations.general.main_menu.label') %>
+      </h2>
+
+      <% translation = Translation.find_or_initialize_by(exhibit: current_exhibit, key: "spotlight.curation.nav.home", locale: @language) %>
+      <%= f.fields_for :translations, translation do |translation_fields| %>
+        <%= translation_fields.hidden_field :key %>
+        <%= translation_fields.hidden_field :locale %>
+        <div class='form-group translation-form translation-main-menu-home'>
+          <%= translation_fields.label :value, t('spotlight.exhibits.translations.general.basic_settings.home'), class: 'control-label col-sm-2' %>
+          <div class='col-md-8 panel panel-body panel-translation'>
+            <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
+            <p class="help-block">
+              <%= t(:'spotlight.curation.nav.home') %>
+            </p>
+          </div>
+          <div class='col-md-2'>
+            <% if translation.value.present? %>
+              <span class='glyphicon glyphicon-ok'></span>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+      <% translation = Translation.find_or_initialize_by(exhibit: current_exhibit, key: "main_navigation.browse.label", locale: @language) %>
+      <%= f.fields_for :translations, translation do |translation_fields| %>
+        <%= translation_fields.hidden_field :key %>
+        <%= translation_fields.hidden_field :locale %>
+        <div class='form-group translation-form translation-main-menu-browse'>
+          <%= translation_fields.label :value, t('spotlight.exhibits.translations.main_menu.browse'), class: 'control-label col-sm-2' %>
+          <div class='col-md-8 panel panel-body panel-translation'>
+            <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
+            <p class="help-block">
+              <%= current_exhibit.main_navigations.browse.label %>
+            </p>
+          </div>
+          <div class='col-md-2'>
+            <% if translation.value.present? %>
+              <span class='glyphicon glyphicon-ok'></span>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+      <% translation = Translation.find_or_initialize_by(exhibit: current_exhibit, key: "main_navigation.curated_features.label", locale: @language) %>
+      <%= f.fields_for :translations, translation do |translation_fields| %>
+        <%= translation_fields.hidden_field :key %>
+        <%= translation_fields.hidden_field :locale %>
+        <div class='form-group translation-form translation-main-menu-curated-features'>
+          <%= translation_fields.label :value, t('spotlight.exhibits.translations.main_menu.curated_features'), class: 'control-label col-sm-2' %>
+          <div class='col-md-8 panel panel-body panel-translation'>
+            <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
+            <p class="help-block">
+              <%= current_exhibit.main_navigations.curated_features.label %>
+            </p>
+          </div>
+          <div class='col-md-2'>
+            <% if translation.value.present? %>
+              <span class='glyphicon glyphicon-ok'></span>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+      <% translation = Translation.find_or_initialize_by(exhibit: current_exhibit, key: "main_navigation.about.label", locale: @language) %>
+      <%= f.fields_for :translations, translation do |translation_fields| %>
+        <%= translation_fields.hidden_field :key %>
+        <%= translation_fields.hidden_field :locale %>
+        <div class='form-group translation-form translation-main-menu-about'>
+          <%= translation_fields.label :value, t('spotlight.exhibits.translations.main_menu.about'), class: 'control-label col-sm-2' %>
+          <div class='col-md-8 panel panel-body panel-translation'>
+            <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
+            <p class="help-block">
+              <%= current_exhibit.main_navigations.about.label %>
+            </p>
+          </div>
+          <div class='col-md-2'>
+            <% if translation.value.present? %>
+              <span class='glyphicon glyphicon-ok'></span>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    </div>
     <div class="form-actions">
       <div class="primary-actions">
         <%= f.submit nil, class: 'btn btn-primary' %>

--- a/app/views/spotlight/translations/_general.html.erb
+++ b/app/views/spotlight/translations/_general.html.erb
@@ -80,7 +80,7 @@
           <div class='col-md-8 panel panel-body panel-translation'>
             <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
             <p class="help-block">
-              <%= t(:'spotlight.curation.nav.home') %>
+              <%= t(:'spotlight.curation.nav.home', locale: I18n.default_locale) %>
             </p>
           </div>
           <div class='col-md-2'>
@@ -99,7 +99,7 @@
           <div class='col-md-8 panel panel-body panel-translation'>
             <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
             <p class="help-block">
-              <%= current_exhibit.main_navigations.browse.label %>
+              <%= current_exhibit.main_navigations.browse[:label].presence || current_exhibit.main_navigations.browse.default_label %>
             </p>
           </div>
           <div class='col-md-2'>
@@ -118,7 +118,7 @@
           <div class='col-md-8 panel panel-body panel-translation'>
             <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
             <p class="help-block">
-              <%= current_exhibit.main_navigations.curated_features.label %>
+              <%= current_exhibit.main_navigations.curated_features[:label].presence || current_exhibit.main_navigations.curated_features.default_label %>
             </p>
           </div>
           <div class='col-md-2'>
@@ -137,7 +137,7 @@
           <div class='col-md-8 panel panel-body panel-translation'>
             <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
             <p class="help-block">
-              <%= current_exhibit.main_navigations.about.label %>
+              <%= current_exhibit.main_navigations.about[:label].presence || current_exhibit.main_navigations.about.default_label %>
             </p>
           </div>
           <div class='col-md-2'>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -477,6 +477,12 @@ en:
             title: Title
             subtitle: Subtitle
             description: Description
+          main_menu:
+            label: Main Menu
+            home: Home
+            browse: Browse
+            curated_features: Curated Features
+            about: About
     main_navigation:
       about: "About"
       browse: "Browse"

--- a/spec/factories/main_navigation.rb
+++ b/spec/factories/main_navigation.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :main_navigation, class: Spotlight::MainNavigation do
+    exhibit
+    nav_type 'browse'
+    display true
+  end
+end

--- a/spec/features/exhibits/translation_editing_spec.rb
+++ b/spec/features/exhibits/translation_editing_spec.rb
@@ -14,25 +14,56 @@ describe 'Translation editing', type: :feature do
     it 'selects the correct language' do
       expect(page).to have_css '.nav-pills li.active', text: 'French'
     end
-    it 'successfully adds translations' do
-      within '.translation-edit-form #general' do
-        expect(page).to have_css '.help-block', text: 'Sample'
-        expect(page).to have_css '.help-block', text: 'SubSample'
-        fill_in 'Title', with: 'Titre français'
-        fill_in 'Subtitle', with: 'Sous-titre français'
-        click_button 'Save changes'
+    describe 'basic settings' do
+      it 'successfully adds translations' do
+        within '.translation-edit-form #general' do
+          expect(page).to have_css '.help-block', text: 'Sample'
+          expect(page).to have_css '.help-block', text: 'SubSample'
+          fill_in 'Title', with: 'Titre français'
+          fill_in 'Subtitle', with: 'Sous-titre français'
+          click_button 'Save changes'
+        end
+        expect(page).to have_css '.flash_messages', text: 'The exhibit was successfully updated.'
+        within '.translation-basic-settings-title' do
+          expect(page).to have_css 'input[value="Titre français"]'
+          expect(page).to have_css 'span.glyphicon.glyphicon-ok'
+        end
+        within '.translation-basic-settings-subtitle' do
+          expect(page).to have_css 'input[value="Sous-titre français"]'
+          expect(page).to have_css 'span.glyphicon.glyphicon-ok'
+        end
+        within '.translation-basic-settings-description' do
+          expect(page).to_not have_css 'span.glyphicon.glyphicon-ok'
+        end
       end
-      expect(page).to have_css '.flash_messages', text: 'The exhibit was successfully updated.'
-      within '.translation-basic-settings-title' do
-        expect(page).to have_css 'input[value="Titre français"]'
-        expect(page).to have_css 'span.glyphicon.glyphicon-ok'
-      end
-      within '.translation-basic-settings-subtitle' do
-        expect(page).to have_css 'input[value="Sous-titre français"]'
-        expect(page).to have_css 'span.glyphicon.glyphicon-ok'
-      end
-      within '.translation-basic-settings-description' do
-        expect(page).to_not have_css 'span.glyphicon.glyphicon-ok'
+    end
+    describe 'main menu' do
+      it 'successfully adds translations' do
+        within '.translation-edit-form #general' do
+          expect(page).to have_css '.help-block', text: 'Home'
+          fill_in 'Home', with: 'Maison'
+          fill_in 'Browse', with: 'parcourir ceci!'
+          click_button 'Save changes'
+        end
+        expect(page).to have_css '.flash_messages', text: 'The exhibit was successfully updated.'
+        within '.translation-main-menu-home' do
+          expect(page).to have_css 'input[value="Maison"]'
+          expect(page).to have_css 'span.glyphicon.glyphicon-ok'
+        end
+        within '.translation-main-menu-browse' do
+          expect(page).to have_css 'input[value="parcourir ceci!"]'
+          expect(page).to have_css 'span.glyphicon.glyphicon-ok'
+        end
+        within '.translation-main-menu-curated-features' do
+          expect(page).to_not have_css 'span.glyphicon.glyphicon-ok'
+        end
+        within '.translation-main-menu-about' do
+          expect(page).to_not have_css 'span.glyphicon.glyphicon-ok'
+        end
+        I18n.locale = :fr
+        expect(exhibit.main_navigations.browse.label).to eq 'parcourir ceci!'
+        expect(I18n.t(:'spotlight.curation.nav.home')).to eq 'Maison'
+        I18n.locale = I18n.default_locale
       end
     end
   end

--- a/spec/models/spotlight/exhibit_spec.rb
+++ b/spec/models/spotlight/exhibit_spec.rb
@@ -16,6 +16,24 @@ describe Spotlight::Exhibit, type: :model do
     subject.save!
     expect(subject.description).to eq 'Test description'
   end
+
+  describe 'validations' do
+    it 'validates the presence of the title' do
+      exhibit.title = ''
+      expect do
+        exhibit.save
+      end.to change { exhibit.errors[:title].count }.by(1)
+    end
+
+    it 'does not validate the presence of the title under a non-default locale' do
+      expect(I18n).to receive(:locale).and_return(:fr)
+      exhibit.title = ''
+      expect do
+        exhibit.save
+      end.not_to(change { exhibit.errors[:title].count })
+    end
+  end
+
   describe 'contact_emails' do
     before do
       subject.contact_emails_attributes = [{ 'email' => 'chris@example.com' }, { 'email' => 'jesse@stanford.edu' }]


### PR DESCRIPTION
Closes #1936 

Adds "main menu" translations to "General" translations.

*Note to reviewer* You may need to enable browse categories, about pages

![menutranslation](https://user-images.githubusercontent.com/1656824/37549411-598efcea-2945-11e8-8192-84b4bd224b44.gif)
