### PR TITLE
Revert "Temporarily pin to using a devise version under 4.4.2 due to …

### DIFF
--- a/blacklight-spotlight.gemspec
+++ b/blacklight-spotlight.gemspec
@@ -32,7 +32,7 @@ these collections.)
   s.add_dependency 'breadcrumbs_on_rails', '~> 3.0'
   s.add_dependency 'blacklight-gallery', '>= 0.3.0'
   s.add_dependency 'blacklight-oembed', '>= 0.0.3'
-  s.add_dependency 'devise', '< 4.4.2' # Temporarily define a less than 4.4.2 version should be '>= 3.0'
+  s.add_dependency 'devise', '>= 3.0'
   s.add_dependency 'devise_invitable', '~> 1.6'
   s.add_dependency 'roar', '~> 1.1'
   s.add_dependency 'roar-rails'


### PR DESCRIPTION
…bug upstream."

This reverts commit ce3ab89728ee5231047bee68244a262ec6440f54.