### PR TITLE
Translate 'Home' breadcrumb

### DIFF
--- a/app/controllers/spotlight/browse_controller.rb
+++ b/app/controllers/spotlight/browse_controller.rb
@@ -56,7 +56,7 @@ module Spotlight
     end
 
     def attach_breadcrumbs
-      add_breadcrumb t(:'spotlight.exhibits.breadcrumb', title: @exhibit.title), @exhibit
+      add_breadcrumb t(:'spotlight.curation.nav.home', title: @exhibit.title), @exhibit
       add_breadcrumb(@exhibit.main_navigations.browse.label_or_default, exhibit_browse_index_path(@exhibit))
     end
 

--- a/app/controllers/spotlight/pages_controller.rb
+++ b/app/controllers/spotlight/pages_controller.rb
@@ -129,9 +129,9 @@ module Spotlight
 
     def attach_breadcrumbs
       if view_context.current_page? '/'
-        add_breadcrumb t(:'spotlight.exhibits.breadcrumb', title: current_exhibit.title), main_app.root_path
+        add_breadcrumb t(:'spotlight.curation.nav.home', title: current_exhibit.title), main_app.root_path
       else
-        add_breadcrumb t(:'spotlight.exhibits.breadcrumb', title: current_exhibit.title), spotlight.exhibit_root_path(current_exhibit)
+        add_breadcrumb t(:'spotlight.curation.nav.home', title: current_exhibit.title), spotlight.exhibit_root_path(current_exhibit)
       end
     end
 


### PR DESCRIPTION
Closes #1953

This PR changes the i18n key for the "Home" breadcrumb so that it can utilize translations provided by the curator. 

### About page
<img width="428" alt="about_page" src="https://user-images.githubusercontent.com/5402927/37725348-0732ef7a-2cf0-11e8-935f-ab59926b060e.png">

### Browse categories
<img width="441" alt="browse_categories" src="https://user-images.githubusercontent.com/5402927/37725349-07929380-2cf0-11e8-84f3-9e1b63515425.png">

### Feature page
<img width="485" alt="feature_page" src="https://user-images.githubusercontent.com/5402927/37725350-07d60e44-2cf0-11e8-8844-a0f12a548fd9.png">
