### PR TITLE
Add the Search field labels tab to the Translations configuration

### DIFF
--- a/app/views/spotlight/translations/_search_fields.html.erb
+++ b/app/views/spotlight/translations/_search_fields.html.erb
@@ -3,6 +3,34 @@
     <% # Add a hidden field for the language so the redirect knows how to come back here %>
     <%= hidden_field_tag :language, @language %>
 
+    <div class='translation-field-based-search-fields'>
+      <h2 class='translation-subheading'>
+        <%= t('spotlight.exhibits.translations.search_fields.field_based_search_fields.label') %>
+      </h2>
+
+      <% current_exhibit.blacklight_config.search_fields.select { |_, config| config.if }.each do |key, search_config| %>
+        <% translation = Translation.find_or_initialize_by(exhibit: current_exhibit, key: "blacklight.search.fields.search.#{key}", locale: @language) %>
+        <%= f.fields_for :translations, translation do |translation_fields| %>
+          <%= translation_fields.hidden_field :key %>
+          <%= translation_fields.hidden_field :locale %>
+          <div class='form-group translation-form'>
+            <%= translation_fields.label :value, t("spotlight.search.fields.search.#{key}", locale: I18n.default_locale), class: 'control-label col-sm-2' %>
+            <div class='col-md-8 panel panel-body panel-translation'>
+              <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
+              <p class="help-block">
+                <%= search_config.label %>
+              </p>
+            </div>
+            <div class='col-md-2'>
+              <% if translation.value.present? %>
+                <span class='glyphicon glyphicon-ok'></span>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+
     <div class='translation-sort-fields'>
       <h2 class='translation-subheading'>
         <%= t('spotlight.exhibits.translations.search_fields.sort_fields.label') %>

--- a/app/views/spotlight/translations/_search_fields.html.erb
+++ b/app/views/spotlight/translations/_search_fields.html.erb
@@ -1,0 +1,40 @@
+<div role="tabpanel" class="tab-pane" id="search_fields">
+  <%= bootstrap_form_for current_exhibit, url: spotlight.exhibit_translations_path(current_exhibit), layout: :horizontal do |f| %>
+    <% # Add a hidden field for the language so the redirect knows how to come back here %>
+    <%= hidden_field_tag :language, @language %>
+
+    <div class='translation-sort-fields'>
+      <h2 class='translation-subheading'>
+        <%= t('spotlight.exhibits.translations.search_fields.sort_fields.label') %>
+      </h2>
+
+      <% current_exhibit.blacklight_config.sort_fields.each do |key, sort_config| %>
+        <% translation = Translation.find_or_initialize_by(exhibit: current_exhibit, key: "blacklight.search.fields.sort.#{key}", locale: @language) %>
+        <%= f.fields_for :translations, translation do |translation_fields| %>
+          <%= translation_fields.hidden_field :key %>
+          <%= translation_fields.hidden_field :locale %>
+          <div class='form-group translation-form'>
+            <%= translation_fields.label :value, t("spotlight.search.fields.sort.#{key}", locale: I18n.default_locale), class: 'control-label col-sm-2' %>
+            <div class='col-md-8 panel panel-body panel-translation'>
+              <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
+              <p class="help-block">
+                <%= sort_config.label %>
+              </p>
+            </div>
+            <div class='col-md-2'>
+              <% if translation.value.present? %>
+                <span class='glyphicon glyphicon-ok'></span>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+
+    <div class="form-actions">
+      <div class="primary-actions">
+        <%= f.submit nil, class: 'btn btn-primary' %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/spotlight/translations/_search_fields.html.erb
+++ b/app/views/spotlight/translations/_search_fields.html.erb
@@ -31,6 +31,34 @@
       <% end %>
     </div>
 
+    <div class='translation-facet-fields'>
+      <h2 class='translation-subheading'>
+        <%= t('spotlight.exhibits.translations.search_fields.facet_fields.label') %>
+      </h2>
+
+      <% current_exhibit.blacklight_config.facet_fields.each do |key, facet_config| %>
+        <% translation = Translation.find_or_initialize_by(exhibit: current_exhibit, key: "blacklight.search.fields.facet.#{key}", locale: @language) %>
+        <%= f.fields_for :translations, translation do |translation_fields| %>
+          <%= translation_fields.hidden_field :key %>
+          <%= translation_fields.hidden_field :locale %>
+          <div class='form-group translation-form'>
+            <%= translation_fields.label :value, t("spotlight.search.fields.facet.#{key}", locale: I18n.default_locale), class: 'control-label col-sm-2' %>
+            <div class='col-md-8 panel panel-body panel-translation'>
+              <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
+              <p class="help-block">
+                <%= facet_config.label %>
+              </p>
+            </div>
+            <div class='col-md-2'>
+              <% if translation.value.present? %>
+                <span class='glyphicon glyphicon-ok'></span>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+
     <div class='translation-sort-fields'>
       <h2 class='translation-subheading'>
         <%= t('spotlight.exhibits.translations.search_fields.sort_fields.label') %>

--- a/app/views/spotlight/translations/edit.html.erb
+++ b/app/views/spotlight/translations/edit.html.erb
@@ -23,6 +23,11 @@
         </a>
       </li>
       <li>
+        <a href="#search_fields" aria-controls="search_fields" role="tab" data-toggle="tab">
+          <%= t('spotlight.exhibits.translations.search_fields.label') %>
+        </a>
+      </li>
+      <li>
         <a href="#browse" aria-controls="browse" role="tab" data-toggle="tab">
           <%= t('spotlight.exhibits.translations.browse_categories.label') %>
         </a>
@@ -31,6 +36,7 @@
 
     <div class="tab-content">
       <%= render 'general' %>
+      <%= render 'search_fields' %>
       <%= render 'browse_categories' %>
     </div>
   </div>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -259,6 +259,13 @@ en:
           id: id
     search:
       fields:
+        facet:
+          genre_ssim: Genre
+          personal_name_ssm: Personal Names
+          corporate_name_ssm: Corporate Names
+          subject_geographic_ssim: Geographic
+          subject_temporal_ssim: Era
+          language_ssim: Language
         search:
           all_fields: Everything
           title: Title
@@ -498,6 +505,8 @@ en:
             about: About
         search_fields:
           label: Search field labels
+          facet_fields:
+            label: Facet Fields
           field_based_search_fields:
             label: Field-Based Search Fields
           sort_fields:

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -257,6 +257,15 @@ en:
           sort_type_ssi: type
           sort_source_ssi: source
           id: id
+    search:
+      fields:
+        sort:
+          relevance: Relevance
+          title: Title
+          type: Type
+          source: Source
+          identifier: Identifier
+          date: 'Date (new to old)'
     metadata_configurations:
       edit:
         field:
@@ -483,6 +492,10 @@ en:
             browse: Browse
             curated_features: Curated Features
             about: About
+        search_fields:
+          label: Search field labels
+          sort_fields:
+            label: Sort Fields
     main_navigation:
       about: "About"
       browse: "Browse"

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -259,6 +259,10 @@ en:
           id: id
     search:
       fields:
+        search:
+          all_fields: Everything
+          title: Title
+          author: Author
         sort:
           relevance: Relevance
           title: Title
@@ -494,6 +498,8 @@ en:
             about: About
         search_fields:
           label: Search field labels
+          field_based_search_fields:
+            label: Field-Based Search Fields
           sort_fields:
             label: Sort Fields
     main_navigation:

--- a/lib/generators/spotlight/templates/catalog_controller.rb
+++ b/lib/generators/spotlight/templates/catalog_controller.rb
@@ -17,7 +17,7 @@ class CatalogController < ApplicationController
     # solr field configuration for search results/index views
     config.index.title_field = 'full_title_tesim'
 
-    config.add_search_field 'all_fields', label: 'Everything'
+    config.add_search_field 'all_fields', label: I18n.t('spotlight.search.fields.search.all_fields')
 
     config.add_sort_field 'relevance', sort: 'score desc', label: I18n.t('spotlight.search.fields.sort.relevance')
 

--- a/lib/generators/spotlight/templates/catalog_controller.rb
+++ b/lib/generators/spotlight/templates/catalog_controller.rb
@@ -19,7 +19,7 @@ class CatalogController < ApplicationController
 
     config.add_search_field 'all_fields', label: 'Everything'
 
-    config.add_sort_field 'relevance', sort: 'score desc', label: 'Relevance'
+    config.add_sort_field 'relevance', sort: 'score desc', label: I18n.t('spotlight.search.fields.sort.relevance')
 
     config.add_field_configuration_to_solr_request!
 

--- a/spec/features/exhibits/translation_editing_spec.rb
+++ b/spec/features/exhibits/translation_editing_spec.rb
@@ -71,6 +71,27 @@ describe 'Translation editing', type: :feature do
   describe 'Search field labels' do
     before { visit spotlight.edit_exhibit_translations_path(exhibit, language: 'fr') }
 
+    describe 'field-based search fields' do
+      it 'has a text input for each enabled search field' do
+        within '#search_fields .translation-field-based-search-fields' do
+          expect(page).to have_css('input[type="text"]', count: 3)
+        end
+      end
+
+      it 'allows users to translate field-based search fields', js: true do
+        click_link 'Search field labels'
+
+        within('#search_fields', visible: true) do
+          fill_in 'Everything', with: 'Tout'
+          click_button 'Save changes'
+        end
+
+        visit spotlight.exhibit_path(exhibit, locale: 'fr')
+
+        expect(page).to have_css('select#search_field option', text: 'Tout')
+      end
+    end
+
     describe 'sort fields' do
       it 'has a text input for each sort field' do
         within '#search_fields .translation-sort-fields' do

--- a/spec/features/exhibits/translation_editing_spec.rb
+++ b/spec/features/exhibits/translation_editing_spec.rb
@@ -19,7 +19,7 @@ describe 'Translation editing', type: :feature do
         within '.translation-edit-form #general' do
           expect(page).to have_css '.help-block', text: 'Sample'
           expect(page).to have_css '.help-block', text: 'SubSample'
-          fill_in 'Title', with: 'Titre français'
+          fill_in 'Title', id: 'exhibit_translations_attributes_0_value', with: 'Titre français'
           fill_in 'Subtitle', with: 'Sous-titre français'
           click_button 'Save changes'
         end
@@ -64,6 +64,31 @@ describe 'Translation editing', type: :feature do
         expect(exhibit.main_navigations.browse.label).to eq 'parcourir ceci!'
         expect(I18n.t(:'spotlight.curation.nav.home')).to eq 'Maison'
         I18n.locale = I18n.default_locale
+      end
+    end
+  end
+
+  describe 'Search field labels' do
+    before { visit spotlight.edit_exhibit_translations_path(exhibit, language: 'fr') }
+
+    describe 'sort fields' do
+      it 'has a text input for each sort field' do
+        within '#search_fields .translation-sort-fields' do
+          expect(page).to have_css('input[type="text"]', count: 6)
+        end
+      end
+
+      it 'allows users to translation sort fields', js: true do
+        click_link 'Search field labels'
+
+        within('#search_fields', visible: true) do
+          fill_in 'Relevance', with: 'French Relevance'
+          click_button 'Save changes'
+        end
+
+        visit spotlight.search_exhibit_catalog_path(exhibit, q: '*', locale: 'fr')
+
+        expect(page).to have_css('.dropdown-toggle', text: 'Trier par French Relevance', visible: true)
       end
     end
   end

--- a/spec/features/exhibits/translation_editing_spec.rb
+++ b/spec/features/exhibits/translation_editing_spec.rb
@@ -92,6 +92,27 @@ describe 'Translation editing', type: :feature do
       end
     end
 
+    describe 'facet fields' do
+      it 'has a text input for each facet field' do
+        within '#search_fields .translation-facet-fields' do
+          expect(page).to have_css('input[type="text"]', count: 7)
+        end
+      end
+
+      it 'allows users to translate facet fields', js: true do
+        click_link 'Search field labels'
+
+        within('#search_fields', visible: true) do
+          fill_in 'Geographic', with: 'Géographique'
+          click_button 'Save changes'
+        end
+
+        visit spotlight.search_exhibit_catalog_path(exhibit, q: '*', locale: 'fr')
+
+        expect(page).to have_css('h3.facet-field-heading', text: 'Géographique')
+      end
+    end
+
     describe 'sort fields' do
       it 'has a text input for each sort field' do
         within '#search_fields .translation-sort-fields' do

--- a/spec/test_app_templates/catalog_controller.rb
+++ b/spec/test_app_templates/catalog_controller.rb
@@ -90,11 +90,11 @@ class CatalogController < ApplicationController
     config.add_search_field 'title', label: 'Title', solr_parameters: { qf: 'full_title_tesim', pf: 'full_title_tesim' }
     config.add_search_field 'author', label: 'Author', solr_parameters: { qf: '${qf_author}', pf: '${pf_author}' }
 
-    config.add_sort_field 'relevance', sort: 'score desc, sort_title_ssi asc', label: 'Relevance'
-    config.add_sort_field 'title', sort: 'sort_title_ssi asc', label: 'Title'
-    config.add_sort_field 'type', sort: 'sort_type_ssi asc', label: 'Type'
-    config.add_sort_field 'source', sort: 'sort_source_ssi asc', label: 'Source'
-    config.add_sort_field 'identifier', sort: 'id asc', label: 'Identifier'
-    config.add_sort_field 'date', sort: 'sort_date_dtsi desc', label: 'Date (new to old)'
+    config.add_sort_field 'relevance', sort: 'score desc, sort_title_ssi asc', label: I18n.t('spotlight.search.fields.sort.relevance')
+    config.add_sort_field 'title', sort: 'sort_title_ssi asc', label: I18n.t('spotlight.search.fields.sort.title')
+    config.add_sort_field 'type', sort: 'sort_type_ssi asc', label: I18n.t('spotlight.search.fields.sort.type')
+    config.add_sort_field 'source', sort: 'sort_source_ssi asc', label: I18n.t('spotlight.search.fields.sort.source')
+    config.add_sort_field 'identifier', sort: 'id asc', label: I18n.t('spotlight.search.fields.sort.identifier')
+    config.add_sort_field 'date', sort: 'sort_date_dtsi desc', label: I18n.t('spotlight.search.fields.sort.date')
   end
 end

--- a/spec/test_app_templates/catalog_controller.rb
+++ b/spec/test_app_templates/catalog_controller.rb
@@ -52,12 +52,12 @@ class CatalogController < ApplicationController
     #
     # :show may be set to false if you don't want the facet to be drawn in the
     # facet bar
-    config.add_facet_field 'genre_ssim', label: 'Genre', limit: true
-    config.add_facet_field 'personal_name_ssm', label: 'Personal Names', limit: true
-    config.add_facet_field 'corporate_name_ssm', label: 'Corporate Names', limit: true
-    config.add_facet_field 'subject_geographic_ssim', label: 'Geographic'
-    config.add_facet_field 'subject_temporal_ssim', label: 'Era'
-    config.add_facet_field 'language_ssim', label: 'Language'
+    config.add_facet_field 'genre_ssim', label: I18n.t('spotlight.search.fields.facet.genre_ssim'), limit: true
+    config.add_facet_field 'personal_name_ssm', label: I18n.t('spotlight.search.fields.facet.personal_name_ssm'), limit: true
+    config.add_facet_field 'corporate_name_ssm', label: I18n.t('spotlight.search.fields.facet.corporate_name_ssm'), limit: true
+    config.add_facet_field 'subject_geographic_ssim', label: I18n.t('spotlight.search.fields.facet.subject_geographic_ssim')
+    config.add_facet_field 'subject_temporal_ssim', label: I18n.t('spotlight.search.fields.facet.subject_temporal_ssim')
+    config.add_facet_field 'language_ssim', label: I18n.t('spotlight.search.fields.facet.language_ssim')
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request

--- a/spec/test_app_templates/catalog_controller.rb
+++ b/spec/test_app_templates/catalog_controller.rb
@@ -86,9 +86,9 @@ class CatalogController < ApplicationController
     config.add_show_field 'personal_name_ssm', label: 'Personal Names'
     config.add_show_field 'corporate_name_ssm', label: 'Corporate Names'
 
-    config.add_search_field 'all_fields', label: 'Everything'
-    config.add_search_field 'title', label: 'Title', solr_parameters: { qf: 'full_title_tesim', pf: 'full_title_tesim' }
-    config.add_search_field 'author', label: 'Author', solr_parameters: { qf: '${qf_author}', pf: '${pf_author}' }
+    config.add_search_field 'all_fields', label: I18n.t('spotlight.search.fields.search.all_fields')
+    config.add_search_field 'title', label: I18n.t('spotlight.search.fields.search.title'), solr_parameters: { qf: 'full_title_tesim', pf: 'full_title_tesim' }
+    config.add_search_field 'author', label: I18n.t('spotlight.search.fields.search.author'), solr_parameters: { qf: '${qf_author}', pf: '${pf_author}' }
 
     config.add_sort_field 'relevance', sort: 'score desc, sort_title_ssi asc', label: I18n.t('spotlight.search.fields.sort.relevance')
     config.add_sort_field 'title', sort: 'sort_title_ssi asc', label: I18n.t('spotlight.search.fields.sort.title')


### PR DESCRIPTION
Closes #1916 

## Config > Translations > Search field labels 
![search-field-labels](https://user-images.githubusercontent.com/96776/37799923-6d34e870-2dde-11e8-8008-ac1e57b8a4e6.gif)

## Translated elements
### Field-based search fields
<img width="386" alt="translated_field_based_search" src="https://user-images.githubusercontent.com/5402927/37847125-fcf70d7c-2e8c-11e8-9fa1-43e61c8e9362.png">

### Facet fields
<img width="300" alt="translated_facet_fields" src="https://user-images.githubusercontent.com/5402927/37847124-fce06888-2e8c-11e8-9bd6-8b6d765d7263.png">

### Sort fields
<img width="589" alt="translated_sort_fields" src="https://user-images.githubusercontent.com/5402927/37847123-fcbc92c8-2e8c-11e8-8776-5a43f2ddfcc6.png">



