### PR TITLE
Add progress counter to Translations tabs

### DIFF
--- a/app/assets/javascripts/spotlight/translation_progress.js
+++ b/app/assets/javascripts/spotlight/translation_progress.js
@@ -1,0 +1,19 @@
+Spotlight.onLoad(function() {
+  $('[data-behavior="translation-progress"]').translationProgress();
+});
+
+(function($) {
+  $.fn.translationProgress = function() {
+    var translationTabs = this;
+    $(translationTabs).each(function(){
+      var currentTab = $(this);
+      var tabName = $(this).attr('aria-controls');
+      var translationFields = $('#' + tabName).find('[data-translation-progress-item="true"]');
+      var completedTranslations = $('#' + tabName).find('[data-translation-present="true"]');
+
+      currentTab.find('span').text(completedTranslations.length + '/' + translationFields.length);
+    });
+
+    return this;
+  };
+})(jQuery);

--- a/app/views/spotlight/translations/_browse_categories.html.erb
+++ b/app/views/spotlight/translations/_browse_categories.html.erb
@@ -20,14 +20,14 @@
       <%= f.fields_for :translations, title_translation do |translation_fields| %>
         <%= translation_fields.hidden_field :key %>
         <%= translation_fields.hidden_field :locale %>
-        <div class="form-group">
+        <div data-translation-progress-item="true" class="form-group">
           <%= translation_fields.label :value, search[:title], class: 'control-label col-xs-4' %>
           <div class="col-xs-7">
             <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
           </div>
           <div class="col-xs-1">
             <% if title_translation.value.present? %>
-              <span class='glyphicon glyphicon-ok'></span>
+              <span data-translation-present="true" class='glyphicon glyphicon-ok'></span>
             <% end %>
           </div>
         </div>
@@ -35,7 +35,7 @@
 
       <% description_translation = Translation.find_or_initialize_by(exhibit: current_exhibit, key: "#{search.slug}.long_description", locale: @language) %>
       <% if search[:long_description] || description_translation.persisted? %>
-        <div class="form-group">
+        <div data-translation-progress-item="true" class="form-group">
           <div class="col-xs-7 col-xs-offset-4">
             <%= f.fields_for :translations, description_translation do |translation_fields| %>
               <%= button_tag 'type' => 'button', class: 'btn btn-text collapsed tanslation-description-toggle', 'data-toggle': 'collapse', 'data-target': "#browse_category_description_#{search.id}", 'aria-expanded': 'false', 'aria-controls': "#browse_category_description_#{search.id}" do %>
@@ -52,7 +52,7 @@
           </div>
           <div class="col-xs-1">
             <% if description_translation.value.present? %>
-              <span class='glyphicon glyphicon-ok'></span>
+              <span data-translation-present="true" class='glyphicon glyphicon-ok'></span>
             <% end %>
           </div>
         </div>

--- a/app/views/spotlight/translations/_general.html.erb
+++ b/app/views/spotlight/translations/_general.html.erb
@@ -12,7 +12,7 @@
       <%= f.fields_for :translations, translation do |translation_fields| %>
         <%= translation_fields.hidden_field :key %>
         <%= translation_fields.hidden_field :locale %>
-        <div class='form-group translation-form translation-basic-settings-title'>
+        <div data-translation-progress-item='true' class='form-group translation-form translation-basic-settings-title'>
           <%= translation_fields.label :value, t('spotlight.exhibits.translations.general.basic_settings.title'), class: 'control-label col-xs-12 col-sm-2' %>
           <div class='col-xs-11 col-sm-9 panel panel-body panel-translation'>
             <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
@@ -22,7 +22,7 @@
           </div>
           <div class='col-xs-1'>
             <% if translation.value.present? %>
-              <span class='glyphicon glyphicon-ok'></span>
+              <span data-translation-present="true" class='glyphicon glyphicon-ok'></span>
             <% end %>
           </div>
         </div>
@@ -31,7 +31,7 @@
       <%= f.fields_for :translations, translation do |translation_fields| %>
         <%= translation_fields.hidden_field :key %>
         <%= translation_fields.hidden_field :locale %>
-        <div class='form-group translation-form translation-basic-settings-subtitle'>
+        <div data-translation-progress-item='true' class='form-group translation-form translation-basic-settings-subtitle'>
           <%= translation_fields.label :value, t('spotlight.exhibits.translations.general.basic_settings.subtitle'), class: 'control-label col-xs-12 col-sm-2' %>
           <div class='col-xs-11 col-sm-9 panel panel-body panel-translation'>
             <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
@@ -41,7 +41,7 @@
           </div>
           <div class='col-xs-1'>
             <% if translation.value.present? %>
-              <span class='glyphicon glyphicon-ok'></span>
+              <span data-translation-present="true" class='glyphicon glyphicon-ok'></span>
             <% end %>
           </div>
         </div>
@@ -50,7 +50,7 @@
       <%= f.fields_for :translations, translation do |translation_fields| %>
         <%= translation_fields.hidden_field :key %>
         <%= translation_fields.hidden_field :locale %>
-        <div class='form-group translation-form translation-basic-settings-description'>
+        <div data-translation-progress-item='true' class='form-group translation-form translation-basic-settings-description'>
           <%= translation_fields.label :value, t('spotlight.exhibits.translations.general.basic_settings.description'), class: 'control-label col-xs-12 col-sm-2' %>
           <div class='col-xs-11 col-sm-9 panel panel-body panel-translation'>
             <%= translation_fields.text_area_without_bootstrap :value, class: 'form-control' %>
@@ -60,7 +60,7 @@
           </div>
           <div class='col-xs-1'>
             <% if translation.value.present? %>
-              <span class='glyphicon glyphicon-ok'></span>
+              <span data-translation-present="true" class='glyphicon glyphicon-ok'></span>
             <% end %>
           </div>
         </div>
@@ -75,7 +75,7 @@
       <%= f.fields_for :translations, translation do |translation_fields| %>
         <%= translation_fields.hidden_field :key %>
         <%= translation_fields.hidden_field :locale %>
-        <div class='form-group translation-form translation-main-menu-home'>
+        <div data-translation-progress-item='true' class='form-group translation-form translation-main-menu-home'>
           <%= translation_fields.label :value, t('spotlight.exhibits.translations.general.basic_settings.home'), class: 'control-label col-xs-12 col-sm-2' %>
           <div class='col-xs-11 col-sm-9 panel panel-body panel-translation'>
             <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
@@ -85,7 +85,7 @@
           </div>
           <div class='col-xs-1'>
             <% if translation.value.present? %>
-              <span class='glyphicon glyphicon-ok'></span>
+              <span data-translation-present="true" class='glyphicon glyphicon-ok'></span>
             <% end %>
           </div>
         </div>
@@ -94,7 +94,7 @@
       <%= f.fields_for :translations, translation do |translation_fields| %>
         <%= translation_fields.hidden_field :key %>
         <%= translation_fields.hidden_field :locale %>
-        <div class='form-group translation-form translation-main-menu-browse'>
+        <div data-translation-progress-item='true' class='form-group translation-form translation-main-menu-browse'>
           <%= translation_fields.label :value, t('spotlight.exhibits.translations.main_menu.browse'), class: 'control-label col-xs-12 col-sm-2' %>
           <div class='col-xs-11 col-sm-9 panel panel-body panel-translation'>
             <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
@@ -104,7 +104,7 @@
           </div>
           <div class='col-xs-1'>
             <% if translation.value.present? %>
-              <span class='glyphicon glyphicon-ok'></span>
+              <span data-translation-present="true" class='glyphicon glyphicon-ok'></span>
             <% end %>
           </div>
         </div>
@@ -113,7 +113,7 @@
       <%= f.fields_for :translations, translation do |translation_fields| %>
         <%= translation_fields.hidden_field :key %>
         <%= translation_fields.hidden_field :locale %>
-        <div class='form-group translation-form translation-main-menu-curated-features'>
+        <div data-translation-progress-item='true' class='form-group translation-form translation-main-menu-curated-features'>
           <%= translation_fields.label :value, t('spotlight.exhibits.translations.main_menu.curated_features'), class: 'control-label col-xs-12 col-sm-2' %>
           <div class='col-xs-11 col-sm-9 panel panel-body panel-translation'>
             <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
@@ -123,7 +123,7 @@
           </div>
           <div class='col-xs-1'>
             <% if translation.value.present? %>
-              <span class='glyphicon glyphicon-ok'></span>
+              <span data-translation-present="true" class='glyphicon glyphicon-ok'></span>
             <% end %>
           </div>
         </div>
@@ -132,7 +132,7 @@
       <%= f.fields_for :translations, translation do |translation_fields| %>
         <%= translation_fields.hidden_field :key %>
         <%= translation_fields.hidden_field :locale %>
-        <div class='form-group translation-form translation-main-menu-about'>
+        <div data-translation-progress-item='true' class='form-group translation-form translation-main-menu-about'>
           <%= translation_fields.label :value, t('spotlight.exhibits.translations.main_menu.about'), class: 'control-label col-xs-12 col-sm-2' %>
           <div class='col-xs-11 col-sm-9 panel panel-body panel-translation'>
             <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
@@ -142,7 +142,7 @@
           </div>
           <div class='col-xs-1'>
             <% if translation.value.present? %>
-              <span class='glyphicon glyphicon-ok'></span>
+              <span data-translation-present="true" class='glyphicon glyphicon-ok'></span>
             <% end %>
           </div>
         </div>

--- a/app/views/spotlight/translations/_search_fields.html.erb
+++ b/app/views/spotlight/translations/_search_fields.html.erb
@@ -13,7 +13,7 @@
         <%= f.fields_for :translations, translation do |translation_fields| %>
           <%= translation_fields.hidden_field :key %>
           <%= translation_fields.hidden_field :locale %>
-          <div class='form-group translation-form'>
+          <div data-translation-progress-item='true' class='form-group translation-form'>
             <%= translation_fields.label :value, t("spotlight.search.fields.search.#{key}", locale: I18n.default_locale), class: 'control-label col-xs-12 col-sm-2' %>
             <div class='col-xs-11 col-sm-9 panel panel-body panel-translation'>
               <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
@@ -23,7 +23,7 @@
             </div>
             <div class='col-xs-1'>
               <% if translation.value.present? %>
-                <span class='glyphicon glyphicon-ok'></span>
+                <span data-translation-present="true" class='glyphicon glyphicon-ok'></span>
               <% end %>
             </div>
           </div>
@@ -41,7 +41,7 @@
         <%= f.fields_for :translations, translation do |translation_fields| %>
           <%= translation_fields.hidden_field :key %>
           <%= translation_fields.hidden_field :locale %>
-          <div class='form-group translation-form'>
+          <div data-translation-progress-item='true' class='form-group translation-form'>
             <%= translation_fields.label :value, t("spotlight.search.fields.facet.#{key}", locale: I18n.default_locale), class: 'control-label col-xs-12 col-sm-2' %>
             <div class='col-xs-11 col-sm-9 panel panel-body panel-translation'>
               <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
@@ -51,7 +51,7 @@
             </div>
             <div class='col-xs-1'>
               <% if translation.value.present? %>
-                <span class='glyphicon glyphicon-ok'></span>
+                <span data-translation-present="true" class='glyphicon glyphicon-ok'></span>
               <% end %>
             </div>
           </div>
@@ -69,7 +69,7 @@
         <%= f.fields_for :translations, translation do |translation_fields| %>
           <%= translation_fields.hidden_field :key %>
           <%= translation_fields.hidden_field :locale %>
-          <div class='form-group translation-form'>
+          <div data-translation-progress-item='true' class='form-group translation-form'>
             <%= translation_fields.label :value, t("spotlight.search.fields.sort.#{key}", locale: I18n.default_locale), class: 'control-label col-xs-12 col-sm-2' %>
             <div class='col-xs-11 col-sm-9 panel panel-body panel-translation'>
               <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
@@ -79,7 +79,7 @@
             </div>
             <div class='col-xs-1'>
               <% if translation.value.present? %>
-                <span class='glyphicon glyphicon-ok'></span>
+                <span data-translation-present="true" class='glyphicon glyphicon-ok'></span>
               <% end %>
             </div>
           </div>

--- a/app/views/spotlight/translations/edit.html.erb
+++ b/app/views/spotlight/translations/edit.html.erb
@@ -18,18 +18,18 @@
   <div role="tabpanel">
     <ul class='nav nav-tabs' role="tablist">
       <li role="presentation" class="active">
-        <a href='#general' aria-controls="general" role="tab" data-toggle="tab">
-          <%= t('spotlight.exhibits.translations.general.label') %>
+        <a href='#general' aria-controls="general" role="tab" data-toggle="tab" data-behavior="translation-progress">
+          <%= t('spotlight.exhibits.translations.general.label') %> <span class="badge"></span>
         </a>
       </li>
       <li>
-        <a href="#search_fields" aria-controls="search_fields" role="tab" data-toggle="tab">
-          <%= t('spotlight.exhibits.translations.search_fields.label') %>
+        <a href="#search_fields" aria-controls="search_fields" role="tab" data-toggle="tab" data-behavior="translation-progress">
+          <%= t('spotlight.exhibits.translations.search_fields.label') %> <span class="badge"></span>
         </a>
       </li>
       <li>
-        <a href="#browse" aria-controls="browse" role="tab" data-toggle="tab">
-          <%= t('spotlight.exhibits.translations.browse_categories.label') %>
+        <a href="#browse" aria-controls="browse" role="tab" data-toggle="tab" data-behavior="translation-progress">
+          <%= t('spotlight.exhibits.translations.browse_categories.label') %> <span class="badge"></span>
         </a>
       </li>
     </ul>

--- a/spec/features/exhibits/translation_editing_spec.rb
+++ b/spec/features/exhibits/translation_editing_spec.rb
@@ -183,4 +183,16 @@ describe 'Translation editing', type: :feature do
       I18n.locale = I18n.default_locale
     end
   end
+
+  describe 'translation progress counter', js: true do
+    before do
+      FactoryBot.create(:translation, exhibit: exhibit, locale: 'fr', key: "#{exhibit.slug}.title", value: 'Titre')
+    end
+    it 'counts existing and total available translations' do
+      visit spotlight.edit_exhibit_translations_path(exhibit, language: 'fr')
+      expect(page).to have_link('General 1/7')
+      expect(page).to have_link('Search field labels 0/16')
+      expect(page).to have_link('Browse categories 0/2')
+    end
+  end
 end


### PR DESCRIPTION
Closes #1935 

This PR adds progress counters to each tab of the Translations page. Note: this counter is not dynamic. Counts are updated when a form is saved.

<img width="838" alt="translation_progress_counter" src="https://user-images.githubusercontent.com/5402927/37857278-0b36acba-2eb7-11e8-92b8-3c4fa7a75fd0.png">
