### PR TITLE
Redirect to the same Config > Translations tab after submitting form

### DIFF
--- a/app/controllers/spotlight/translations_controller.rb
+++ b/app/controllers/spotlight/translations_controller.rb
@@ -2,7 +2,7 @@ module Spotlight
   ##
   # Base CRUD controller for translations
   class TranslationsController < Spotlight::ApplicationController
-    before_action :authenticate_user!, :set_language
+    before_action :authenticate_user!, :set_language, :set_tab
     load_and_authorize_resource :exhibit, class: Spotlight::Exhibit
 
     def edit; end
@@ -11,7 +11,7 @@ module Spotlight
       if current_exhibit.update(exhibit_params)
         I18n.reload! # reload since we're memoizing
         notice = t(:'helpers.submit.spotlight_default.updated', model: current_exhibit.class.model_name.human.downcase)
-        redirect_to edit_exhibit_translations_path(current_exhibit, params: { language: @language }), notice: notice
+        redirect_to edit_exhibit_translations_path(current_exhibit, language: @language, tab: @tab), notice: notice
       else
         render 'edit'
       end
@@ -25,6 +25,10 @@ module Spotlight
 
     def set_language
       @language = params[:language] || current_exhibit.available_locales.first
+    end
+
+    def set_tab
+      @tab = params[:tab] || nil
     end
   end
 end

--- a/app/views/spotlight/translations/_browse_categories.html.erb
+++ b/app/views/spotlight/translations/_browse_categories.html.erb
@@ -1,7 +1,8 @@
-<div role="tabpanel" class="tab-pane" id="browse">
+<div role="tabpanel" class="tab-pane <%= 'active' if @tab == 'browse' %>" id="browse">
   <%= bootstrap_form_for current_exhibit, url: spotlight.exhibit_translations_path(current_exhibit), layout: :horizontal do |f| %>
-    <% # Add a hidden field for the language so the redirect knows how to come back here %>
+    <% # Add hidden fields for the language and tab so the redirect knows how to come back here %>
     <%= hidden_field_tag :language, @language %>
+    <%= hidden_field_tag :tab, 'browse' %>
     <div class="row">
       <div class="col-xs-4 text-right">
         <strong>

--- a/app/views/spotlight/translations/_general.html.erb
+++ b/app/views/spotlight/translations/_general.html.erb
@@ -1,4 +1,4 @@
-<div role="tabpanel" class="tab-pane active" id="general">
+<div role="tabpanel" class="tab-pane <%= 'active' if @tab.blank? %>" id="general">
   <%= bootstrap_form_for current_exhibit, url: spotlight.exhibit_translations_path(current_exhibit), layout: :horizontal do |f| %>
     <% # Add a hidden field for the language so the redirect knows how to come back here %>
     <%= hidden_field_tag :language, @language %>

--- a/app/views/spotlight/translations/_search_fields.html.erb
+++ b/app/views/spotlight/translations/_search_fields.html.erb
@@ -1,7 +1,8 @@
-<div role="tabpanel" class="tab-pane" id="search_fields">
+<div role="tabpanel" class="tab-pane <%= 'active' if @tab == 'search_fields' %>" id="search_fields">
   <%= bootstrap_form_for current_exhibit, url: spotlight.exhibit_translations_path(current_exhibit), layout: :horizontal do |f| %>
-    <% # Add a hidden field for the language so the redirect knows how to come back here %>
+    <% # Add hidden fields for the language and tab so the redirect knows how to come back here %>
     <%= hidden_field_tag :language, @language %>
+    <%= hidden_field_tag :tab, 'search_fields' %>
 
     <div class='translation-field-based-search-fields'>
       <h2 class='translation-subheading'>

--- a/app/views/spotlight/translations/edit.html.erb
+++ b/app/views/spotlight/translations/edit.html.erb
@@ -17,17 +17,17 @@
 
   <div role="tabpanel">
     <ul class='nav nav-tabs' role="tablist">
-      <li role="presentation" class="active">
+      <li role="presentation" class="<%= 'active' if @tab.blank? %>">
         <a href='#general' aria-controls="general" role="tab" data-toggle="tab" data-behavior="translation-progress">
           <%= t('spotlight.exhibits.translations.general.label') %> <span class="badge"></span>
         </a>
       </li>
-      <li>
+      <li class="<%= 'active' if @tab == 'search_fields' %>">
         <a href="#search_fields" aria-controls="search_fields" role="tab" data-toggle="tab" data-behavior="translation-progress">
           <%= t('spotlight.exhibits.translations.search_fields.label') %> <span class="badge"></span>
         </a>
       </li>
-      <li>
+      <li class="<%= 'active' if @tab == 'browse' %>">
         <a href="#browse" aria-controls="browse" role="tab" data-toggle="tab" data-behavior="translation-progress">
           <%= t('spotlight.exhibits.translations.browse_categories.label') %> <span class="badge"></span>
         </a>

--- a/spec/features/exhibits/translation_editing_spec.rb
+++ b/spec/features/exhibits/translation_editing_spec.rb
@@ -71,6 +71,17 @@ describe 'Translation editing', type: :feature do
   describe 'Search field labels' do
     before { visit spotlight.edit_exhibit_translations_path(exhibit, language: 'fr') }
 
+    it 'redirects to the same form tab' do
+      click_link 'Search field labels'
+      within('#search_fields', visible: true) do
+        fill_in 'Everything', with: 'Tout'
+        click_button 'Save changes'
+      end
+
+      expect(page).to have_css '.nav-pills li.active', text: 'French'
+      expect(page).to have_css '.nav-tabs li.active', text: 'Search field labels'
+    end
+
     describe 'field-based search fields' do
       it 'has a text input for each enabled search field' do
         within '#search_fields .translation-field-based-search-fields' do
@@ -156,6 +167,17 @@ describe 'Translation editing', type: :feature do
 
         expect(page).to have_css('.help-block', text: 'All items in this exhibit.')
       end
+    end
+
+    it 'redirects to the same form tab' do
+      click_link 'Browse categories'
+      within('#browse', visible: true) do
+        fill_in 'All Exhibit Items', with: "Tous les objets d'exposition"
+        click_button 'Save changes'
+      end
+
+      expect(page).to have_css '.nav-pills li.active', text: 'French'
+      expect(page).to have_css '.nav-tabs li.active', text: 'Browse categories'
     end
 
     it 'persists changes', js: true do


### PR DESCRIPTION
Closes #1958 

This PR enhances redirect behavior for the Config > Translations form. After a user submits a translation form (e.g. "Search fields"), they will be sent back to the same tab.

**Note:** This only implements redirects for General, Search fields, and Browse categories. This behavior will need to be added to Metadata fields (#1959) and Pages (#1919) once available. 

## Demo
![translations-tab-redirects](https://user-images.githubusercontent.com/5402927/37858906-eeede444-2ec8-11e8-8eb9-72b1457d4fed.gif)

