### PR TITLE
Add Description to the list of translatable fields for an exhibit.

### DIFF
--- a/app/models/spotlight/exhibit.rb
+++ b/app/models/spotlight/exhibit.rb
@@ -8,7 +8,7 @@ module Spotlight
     include Spotlight::ExhibitDocuments
     include Spotlight::Translatables
 
-    translates :title, :subtitle
+    translates :title, :subtitle, :description
 
     has_paper_trail
 

--- a/spec/models/spotlight/exhibit_spec.rb
+++ b/spec/models/spotlight/exhibit_spec.rb
@@ -318,10 +318,11 @@ describe Spotlight::Exhibit, type: :model do
     is_expected.to be_versioned
   end
   describe 'translatable fields' do
-    let(:persisted_exhibit) { FactoryBot.create(:exhibit, title: 'Sample', subtitle: 'SubSample') }
+    let(:persisted_exhibit) { FactoryBot.create(:exhibit, title: 'Sample', subtitle: 'SubSample', description: 'Description') }
     before do
       FactoryBot.create(:translation, locale: 'fr', exhibit: persisted_exhibit, key: "#{persisted_exhibit.slug}.title", value: 'Titre français')
       FactoryBot.create(:translation, locale: 'fr', exhibit: persisted_exhibit, key: "#{persisted_exhibit.slug}.subtitle", value: 'Sous-titre français')
+      FactoryBot.create(:translation, locale: 'fr', exhibit: persisted_exhibit, key: "#{persisted_exhibit.slug}.description", value: 'Description français')
     end
     after do
       I18n.locale = 'en'
@@ -337,6 +338,13 @@ describe Spotlight::Exhibit, type: :model do
       I18n.locale = 'fr'
       persisted_exhibit.reload
       expect(persisted_exhibit.subtitle).to eq 'Sous-titre français'
+    end
+
+    it 'has a translatable description' do
+      expect(persisted_exhibit.description).to eq 'Description'
+      I18n.locale = 'fr'
+      persisted_exhibit.reload
+      expect(persisted_exhibit.description).to eq 'Description français'
     end
   end
 end


### PR DESCRIPTION
(looks like we missed this the first time around)