### PR TITLE
add SQL validation for translation uniqueness

### DIFF
--- a/db/migrate/20180403130857_translation_uniqueness.rb
+++ b/db/migrate/20180403130857_translation_uniqueness.rb
@@ -1,0 +1,5 @@
+class TranslationUniqueness < ActiveRecord::Migration[5.0]
+  def change
+    add_index(:translations, [:exhibit_id, :key, :locale], unique: true)
+  end
+end

--- a/spec/models/translation_spec.rb
+++ b/spec/models/translation_spec.rb
@@ -1,0 +1,11 @@
+describe Translation, type: :model do
+  let(:exhibit) { FactoryBot.create(:exhibit) }
+  describe 'is unique by key, locale, and exhibit' do
+    it 'fails validation' do
+      Translation.create(exhibit_id: exhibit.id, key: 'abc', locale: 'fr', value: 'yo')
+      expect do
+        Translation.create(exhibit_id: exhibit.id, key: 'abc', locale: 'fr', value: 'lo')
+      end.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1933 

I'm not adding an ActiveRecord validation here also as it would require us to monkey patch i18n_active-record. I think the SQL validation gets us what we want.