### PR TITLE
Add a description translation field for all browse categories.

### DIFF
--- a/app/views/spotlight/translations/_browse_categories.html.erb
+++ b/app/views/spotlight/translations/_browse_categories.html.erb
@@ -34,29 +34,27 @@
       <% end %>
 
       <% description_translation = Translation.find_or_initialize_by(exhibit: current_exhibit, key: "#{search.slug}.long_description", locale: @language) %>
-      <% if search[:long_description] || description_translation.persisted? %>
-        <div data-translation-progress-item="true" class="form-group">
-          <div class="col-xs-7 col-xs-offset-4">
-            <%= f.fields_for :translations, description_translation do |translation_fields| %>
-              <%= button_tag 'type' => 'button', class: 'btn btn-text collapsed tanslation-description-toggle', 'data-toggle': 'collapse', 'data-target': "#browse_category_description_#{search.id}", 'aria-expanded': 'false', 'aria-controls': "#browse_category_description_#{search.id}" do %>
-                <%= translation_fields.label :value, t(:'spotlight.exhibits.translations.browse_categories.description_label') %>
-                <span class="caret"></span>
-              <% end %>
-              <%= translation_fields.hidden_field :key %>
-              <%= translation_fields.hidden_field :locale %>
-              <div id="browse_category_description_<%= search.id %>" class="panel panel-body collapse panel-translation">
-                <%= translation_fields.text_area_without_bootstrap :value, class: 'form-control' %>
-                <p class="help-block"><%= search[:long_description] %></p>
-              </div>
+      <div data-translation-progress-item="true" class="form-group">
+        <div class="col-xs-7 col-xs-offset-4">
+          <%= f.fields_for :translations, description_translation do |translation_fields| %>
+            <%= button_tag 'type' => 'button', class: 'btn btn-text collapsed tanslation-description-toggle', 'data-toggle': 'collapse', 'data-target': "#browse_category_description_#{search.id}", 'aria-expanded': 'false', 'aria-controls': "#browse_category_description_#{search.id}" do %>
+              <%= translation_fields.label :value, t(:'spotlight.exhibits.translations.browse_categories.description_label') %>
+              <span class="caret"></span>
             <% end %>
-          </div>
-          <div class="col-xs-1">
-            <% if description_translation.value.present? %>
-              <span data-translation-present="true" class='glyphicon glyphicon-ok'></span>
-            <% end %>
-          </div>
+            <%= translation_fields.hidden_field :key %>
+            <%= translation_fields.hidden_field :locale %>
+            <div id="browse_category_description_<%= search.id %>" class="panel panel-body collapse panel-translation">
+              <%= translation_fields.text_area_without_bootstrap :value, class: 'form-control' %>
+              <p class="help-block"><%= search[:long_description] %></p>
+            </div>
+          <% end %>
         </div>
-      <% end %>
+        <div class="col-xs-1">
+          <% if description_translation.value.present? %>
+            <span data-translation-present="true" class='glyphicon glyphicon-ok'></span>
+          <% end %>
+        </div>
+      </div>
     <% end %>
 
     <div class="form-actions">

--- a/spec/features/exhibits/translation_editing_spec.rb
+++ b/spec/features/exhibits/translation_editing_spec.rb
@@ -142,18 +142,13 @@ describe 'Translation editing', type: :feature do
       visit spotlight.edit_exhibit_translations_path(exhibit, language: 'fr')
     end
 
-    it 'has a title for every browse category' do
+    it 'has a title and description for every browse category' do
       within '#browse' do
         expect(page).to have_css('input[type="text"]', count: 2)
+        expect(page).to have_css('textarea', count: 2)
+
         expect(page).to have_field 'All Exhibit Items'
         expect(page).to have_field 'Browse Category 1'
-      end
-    end
-
-    it 'only renders a description field if search has one' do
-      within '#browse #browse_category_description_1' do
-        expect(page).to have_css('textarea', count: 1)
-
         expect(page).to have_css('.help-block', text: 'All items in this exhibit.')
       end
     end
@@ -164,7 +159,7 @@ describe 'Translation editing', type: :feature do
       within('#browse', visible: true) do
         fill_in 'All Exhibit Items', with: "Tous les objets d'exposition"
 
-        click_button 'Description'
+        first('.tanslation-description-toggle').click
 
         textarea = page.find('textarea')
         textarea.set('Tous les articles de cette exposition.')


### PR DESCRIPTION
Closes #1963 

<img width="907" alt="browse-cat-descriptions" src="https://user-images.githubusercontent.com/96776/38263000-a49d09de-3723-11e8-9eaf-9e2eda906203.png">
