### PR TITLE
add more specific selector to fix chromeheadless error

### DIFF
--- a/spec/features/slideshow_spec.rb
+++ b/spec/features/slideshow_spec.rb
@@ -7,13 +7,12 @@ describe 'Slideshow', type: :feature, js: true do
     exhibit.blacklight_configuration.update(document_index_view_types: %w(list gallery slideshow))
   end
   it 'has slideshow' do
-    pending('does not work with chrome headless')
     visit spotlight.search_exhibit_catalog_path(exhibit, f: { genre_ssim: ['map'] })
     expect(page).to have_content 'You searched for:'
     within '.view-type' do
       click_link 'Slideshow'
     end
-    find('.grid [data-slide-to="1"]').click
+    find('.grid [data-slide-to="1"] img').click
     expect(page).to have_selector '#slideshow', visible: true
   end
 end


### PR DESCRIPTION
This should reduce our testing suite runtime ~10sec