### PR TITLE
Revert "Translate 'Home' breadcrumb for Browse, Features pages, and About pages"

### DIFF
--- a/app/controllers/spotlight/browse_controller.rb
+++ b/app/controllers/spotlight/browse_controller.rb
@@ -56,7 +56,7 @@ module Spotlight
     end
 
     def attach_breadcrumbs
-      add_breadcrumb t(:'spotlight.curation.nav.home', title: @exhibit.title), @exhibit
+      add_breadcrumb t(:'spotlight.exhibits.breadcrumb', title: @exhibit.title), @exhibit
       add_breadcrumb(@exhibit.main_navigations.browse.label_or_default, exhibit_browse_index_path(@exhibit))
     end
 

--- a/app/controllers/spotlight/pages_controller.rb
+++ b/app/controllers/spotlight/pages_controller.rb
@@ -130,12 +130,8 @@ module Spotlight
     def attach_breadcrumbs
       if view_context.current_page? '/'
         add_breadcrumb t(:'spotlight.curation.nav.home', title: current_exhibit.title), main_app.root_path
-      elsif @page
-        # Use curator-accessible i18n key for user-facing breadcrumb
-        add_breadcrumb t(:'spotlight.curation.nav.home', title: current_exhibit.title), spotlight.exhibit_root_path(current_exhibit)
       else
-        # Use admin interface language for dashboard breadcrumb
-        add_breadcrumb t(:'spotlight.exhibits.breadcrumb', title: current_exhibit.title), spotlight.exhibit_root_path(current_exhibit)
+        add_breadcrumb t(:'spotlight.curation.nav.home', title: current_exhibit.title), spotlight.exhibit_root_path(current_exhibit)
       end
     end
 

--- a/app/controllers/spotlight/pages_controller.rb
+++ b/app/controllers/spotlight/pages_controller.rb
@@ -129,9 +129,9 @@ module Spotlight
 
     def attach_breadcrumbs
       if view_context.current_page? '/'
-        add_breadcrumb t(:'spotlight.curation.nav.home', title: current_exhibit.title), main_app.root_path
+        add_breadcrumb t(:'spotlight.exhibits.breadcrumb', title: current_exhibit.title), main_app.root_path
       else
-        add_breadcrumb t(:'spotlight.curation.nav.home', title: current_exhibit.title), spotlight.exhibit_root_path(current_exhibit)
+        add_breadcrumb t(:'spotlight.exhibits.breadcrumb', title: current_exhibit.title), spotlight.exhibit_root_path(current_exhibit)
       end
     end
 

--- a/spec/features/exhibits/translation_editing_spec.rb
+++ b/spec/features/exhibits/translation_editing_spec.rb
@@ -38,7 +38,7 @@ describe 'Translation editing', type: :feature do
       end
     end
     describe 'main menu' do
-      it 'successfully adds translations to exhibit navbar' do
+      it 'successfully adds translations' do
         within '.translation-edit-form #general' do
           expect(page).to have_css '.help-block', text: 'Home'
           fill_in 'Home', with: 'Maison'
@@ -64,28 +64,6 @@ describe 'Translation editing', type: :feature do
         expect(exhibit.main_navigations.browse.label).to eq 'parcourir ceci!'
         expect(I18n.t(:'spotlight.curation.nav.home')).to eq 'Maison'
         I18n.locale = I18n.default_locale
-      end
-    end
-    describe 'breadcrumbs' do
-      describe 'browse categories' do
-        before do
-          exhibit.searches.first.update(published: true)
-          within '.translation-edit-form #general' do
-            fill_in 'Home', with: 'Maison'
-            fill_in 'Browse', with: 'parcourir ceci!'
-            click_button 'Save changes'
-          end
-        end
-
-        it 'adds translations to user-facing breadcrumbs' do
-          visit spotlight.exhibit_browse_index_path(exhibit, locale: 'fr')
-          expect(page).to have_breadcrumbs 'Maison', 'parcourir ceci!'
-        end
-
-        it 'does not translate admin breadcrumbs' do
-          visit spotlight.exhibit_searches_path(exhibit, locale: 'fr')
-          expect(page).to have_breadcrumbs 'Home', 'Curation', 'Browse'
-        end
       end
     end
   end

--- a/spec/features/exhibits/translation_editing_spec.rb
+++ b/spec/features/exhibits/translation_editing_spec.rb
@@ -38,7 +38,7 @@ describe 'Translation editing', type: :feature do
       end
     end
     describe 'main menu' do
-      it 'adds translations to exhibit navbar' do
+      it 'successfully adds translations to exhibit navbar' do
         within '.translation-edit-form #general' do
           expect(page).to have_css '.help-block', text: 'Home'
           fill_in 'Home', with: 'Maison'
@@ -65,31 +65,7 @@ describe 'Translation editing', type: :feature do
         expect(I18n.t(:'spotlight.curation.nav.home')).to eq 'Maison'
         I18n.locale = I18n.default_locale
       end
-
-      before { exhibit.searches.first.update(published: true) }
-      it 'adds translations to user-facing breadcrumbs' do
-        within '.translation-edit-form #general' do
-          fill_in 'Home', with: 'Maison'
-          fill_in 'Browse', with: 'parcourir ceci!'
-          click_button 'Save changes'
-        end
-        expect(page).to have_css '.flash_messages', text: 'The exhibit was successfully updated.'
-        visit spotlight.exhibit_browse_index_path(exhibit, locale: 'fr')
-        expect(page).to have_breadcrumbs 'Maison', 'parcourir ceci!'
-      end
-
-      it 'does not translate admin breadcrumbs' do
-        within '.translation-edit-form #general' do
-          fill_in 'Home', with: 'Maison'
-          fill_in 'Browse', with: 'parcourir ceci!'
-          click_button 'Save changes'
-        end
-        expect(page).to have_css '.flash_messages', text: 'The exhibit was successfully updated.'
-        visit spotlight.exhibit_searches_path(exhibit, locale: 'fr')
-        expect(page).to have_breadcrumbs 'Home', 'Curation', 'Browse'
-      end
     end
-
     describe 'breadcrumbs' do
       describe 'browse categories' do
         before do
@@ -109,27 +85,6 @@ describe 'Translation editing', type: :feature do
         it 'does not translate admin breadcrumbs' do
           visit spotlight.exhibit_searches_path(exhibit, locale: 'fr')
           expect(page).to have_breadcrumbs 'Home', 'Curation', 'Browse'
-        end
-      end
-
-      describe 'pages' do
-        let!(:about_page1) { FactoryBot.create(:about_page, title: 'First Page', exhibit: exhibit) }
-
-        before do
-          within '.translation-edit-form #general' do
-            fill_in 'Home', with: 'Maison'
-            fill_in 'About', with: 'Sur'
-            click_button 'Save changes'
-          end
-        end
-        it 'adds breadcrumbs to pages' do
-          visit spotlight.exhibit_about_page_path(about_page1.exhibit, about_page1, locale: 'fr')
-          expect(page).to have_breadcrumbs 'Maison', 'Sur'
-        end
-
-        it 'does not translate admin breadcrumbs' do
-          visit spotlight.exhibit_about_pages_path(exhibit, locale: 'fr')
-          expect(page).to have_breadcrumbs 'Home', 'Curation', 'About'
         end
       end
     end


### PR DESCRIPTION
Reverts projectblacklight/spotlight#1955

Testing to see if this fixes our build.