### PR TITLE
Drop support for rails 5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Read more about what Spotlight is, our motivations for creating it, and how to i
 ## Requirements
 
 1. Ruby (2.2.0 or greater)
-2. Rails (5.0 or greater)
+2. Rails (5.1 or greater)
 3. Java (7 or greater) *for Solr*
 4. ImageMagick (http://www.imagemagick.org/script/index.php) due to [carrierwave](https://github.com/carrierwaveuploader/carrierwave#adding-versions)
 

--- a/blacklight-spotlight.gemspec
+++ b/blacklight-spotlight.gemspec
@@ -19,7 +19,7 @@ these collections.)
 
   s.required_ruby_version = '~> 2.2'
 
-  s.add_dependency 'rails', '~> 5.0'
+  s.add_dependency 'rails', '~> 5.1'
   s.add_dependency 'blacklight', '~> 6.3'
   s.add_dependency 'autoprefixer-rails'
   s.add_dependency 'cancancan'

--- a/blacklight-spotlight.gemspec
+++ b/blacklight-spotlight.gemspec
@@ -68,7 +68,6 @@ these collections.)
   s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'factory_bot', '~> 4.5'
   s.add_development_dependency 'engine_cart', '~> 2.0'
-  s.add_development_dependency 'database_cleaner', '~> 1.3'
   s.add_development_dependency 'solr_wrapper'
   s.add_development_dependency 'simplecov', '~> 0.12'
   s.add_development_dependency 'coveralls'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,5 @@
 ENV['RAILS_ENV'] ||= 'test'
 require 'factory_bot'
-require 'database_cleaner'
 require 'devise'
 require 'engine_cart'
 EngineCart.load_application!
@@ -60,24 +59,13 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
 
-  config.use_transactional_fixtures = false
+  config.use_transactional_fixtures = true
   config.before :all do
     WebMock.disable_net_connect!(allow_localhost: true)
   end
   config.before :each do
-    DatabaseCleaner.strategy = if Capybara.current_driver == :rack_test
-                                 :transaction
-                               else
-                                 :truncation
-                               end
-    DatabaseCleaner.start
-
     # The first user is automatically granted admin privileges; we don't want that behavior for many of our tests
     Spotlight::Engine.user_class.create email: 'initial+admin@example.com', password: 'password', password_confirmation: 'password'
-  end
-
-  config.after do
-    DatabaseCleaner.clean
   end
 
   if defined? Devise::Test::ControllerHelpers


### PR DESCRIPTION
Also removes `database_cleaner` in favor of transaction fixtures.

_Checking to see if this helps our build performance at all._

_This should get rolled out with Spotlight 2_