### PR TITLE
add page migration task to new locales

### DIFF
--- a/lib/migration/page_language.rb
+++ b/lib/migration/page_language.rb
@@ -1,0 +1,27 @@
+module Migration
+  ##
+  # This migration sets the Spotlight::Page locale to the I18n.default_locale.
+  # Needed for migrating Exhibits to internationalization work.
+  class PageLanguage
+    def self.run
+      new.run
+    end
+
+    def initialize; end
+
+    def run
+      migrate_pages
+    end
+
+    private
+
+    def migrate_pages
+      FriendlyId::Slug.where(sluggable_type: 'Spotlight::Page').find_each do |slug|
+        unless /locale:\w+/ =~ slug.scope
+          slug.scope += ",locale:#{I18n.default_locale}"
+          slug.save
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/spotlight_tasks.rake
+++ b/lib/tasks/spotlight_tasks.rake
@@ -69,6 +69,12 @@ namespace :spotlight do
     end
   end
 
+  desc 'Migrate page\'s FriendlyId::Slug to a scoped language'
+  task migrate_pages_language: :environment do
+    require 'migration/page_language'
+    Migration::PageLanguage.run
+  end
+
   def prompt_to_create_user
     Spotlight::Engine.user_class.find_or_create_by!(email: prompt_for_email) do |u|
       puts 'User not found. Enter a password to create the user.'

--- a/spec/lib/migration/page_language_spec.rb
+++ b/spec/lib/migration/page_language_spec.rb
@@ -1,0 +1,21 @@
+require 'migration/page_language'
+
+RSpec.describe Migration::PageLanguage do
+  describe '#migrate_pages' do
+    let(:exhibit) { FactoryBot.create(:exhibit) }
+    let(:page) { FactoryBot.create(:feature_page, exhibit: exhibit) }
+    let(:slug) { FriendlyId::Slug.find(page.id) }
+    before do
+      # Remove the locale scope (anticipating pre translation state of scope)
+      slug.scope = slug.scope.sub(',locale:en', '')
+      slug.save
+      slug.reload
+    end
+    it 'sets the scope to the default locale' do
+      expect(slug.scope).not_to include(',locale:en')
+      subject.run
+      slug.reload
+      expect(slug.scope).to eq "exhibit_id:#{page.exhibit.id},locale:en"
+    end
+  end
+end


### PR DESCRIPTION
Fixes #2003 

A few questions here...

 - [x] Should this be for all exhibits? .. yep
 - [x] ~~Should we limit this to a certain type of page? (e.g `where(locale: nil)` ) or something similar?~~ ... yep.. and its really just setting the `FriendId::Slug`