### PR TITLE
Fix async form observer

### DIFF
--- a/app/assets/javascripts/spotlight/form_observer.js
+++ b/app/assets/javascripts/spotlight/form_observer.js
@@ -1,64 +1,86 @@
 Spotlight.onLoad(function() {
-  serializeObservedForms(observedForms());
-});
-// All the observed forms
-function observedForms(){
-  return $('[data-form-observer]');
-}
-// Serialize all observed forms on the page
-function serializeObservedForms(forms){
-  forms.each(function(){
-    serializeFormStatus($(this));
-    unbindObservedFormSubmit();
-  });
-}
-// Unbind observing form on submit (which we have to do because of turbolinks)
-function unbindObservedFormSubmit(){
-  observedForms().each(function(){
-    $(this).on("submit", function(){
-      $(this).data("being-submitted", true);
-    });
-  });
-}
-// Store form serialization in data attribute
-function serializeFormStatus(form){
-  form.data("serialized-form", formSerialization(form));
-}
-// Do custom serialization of the sir-trevor form data
-function formSerialization(form){
-  var content_editable = [];
-  var i=0;
-  $("[contenteditable='true']", form).each(function(){
-    content_editable.push("&contenteditable_" + i + "=" + $(this).text());
-  });
-  return form.serialize() + content_editable.join();
-}
-// Get the stored serialized form status
-function serializedFormStatus(form){
-  return form.data("serialized-form");
-}
-// Check all observed forms on page for status change
-function observedFormsStatusHasChanged(){
-  var unsaved_changes = false;
-  observedForms().each(function(){
-    if ( !$(this).data("being-submitted") ) {
-      if (serializedFormStatus($(this)) != formSerialization($(this))) {
-        unsaved_changes = true;
+  // Instantiate the singleton SerializedForm plugin
+  var serializedForm = $.SerializedForm();
+  $(window).on('beforeunload page:before-change turbolinks:before-visit', function(event) {
+    // Don't handle the same event twice #turbolinks
+    if (event.handled !== true) {
+      if ( serializedForm.observedFormsStatusHasChanged() ) {
+        event.handled = true;
+        var message = "You have unsaved changes. Are you sure you want to leave this page?";
+        // There are variations in how Webkit browsers may handle this:
+        // https://developer.mozilla.org/en-US/docs/Web/Events/beforeunload
+        if ( event.type == "beforeunload" ) {
+          return message;
+        }else{
+          
+          return confirm(message)
+        }
       }
     }
   });
-  return unsaved_changes;
-}
-// Compare stored and current form serializations
-// to determine if the form has changed before
-// unload and before any turbolinks change event
-$(window).on('beforeunload page:before-change turbolinks:before-cache', function(event) {
-  if ( observedFormsStatusHasChanged() ) {
-    var message = "You have unsaved changes. Are you sure you want to leave this page?";
-    if ( event.type == "beforeunload" ) {
-      return message;
-    }else{
-      return confirm(message)
-    }
-  }
 });
+
+(function($, undefined) {
+  'use strict';
+
+  /*
+  * SerializedForm is built as a singleton jQuery plugin. It needs to be able to
+  * handle instantiation from multiple sources, and use the [data-form-observer]
+  * as global state object.
+  */
+  $.SerializedForm = function () {
+    var $serializedForm;
+    var plugin = this;
+
+    // Store form serialization in data attribute
+    function serializeFormStatus () {
+      $serializedForm.data('serialized-form', formSerialization($serializedForm));
+    }
+
+    // Do custom serialization of the sir-trevor form data. This needs to be a
+    // passed in argument for comparison later on.
+    function formSerialization (form) {
+      var content_editable = [];
+      var i = 0;
+      $("[contenteditable='true']", form).each(function(){
+        content_editable.push('&contenteditable_' + i + '=' + $(this).text());
+      });
+      return form.serialize() + content_editable.join();
+    }
+
+    // Unbind observing form on submit (which we have to do because of turbolinks)
+    function unbindObservedFormSubmit () {
+      $serializedForm.on('submit', function () {
+        $(this).data('being-submitted', true);
+      });
+    }
+
+    // Get the stored serialized form status
+    function serializedFormStatus () {
+      return $serializedForm.data('serialized-form');
+    }
+
+    // Check all observed forms on page for status change
+    plugin.observedFormsStatusHasChanged = function () {
+      var unsaved_changes = false;
+      $('[data-form-observer]').each(function (){
+        if ( !$(this).data("being-submitted") ) {
+          if (serializedFormStatus() != formSerialization($(this))) {
+            unsaved_changes = true;
+          }
+        }
+      });
+      return unsaved_changes;
+    }
+
+    function init () {
+      $serializedForm = $('[data-form-observer]');
+      serializeFormStatus();
+      unbindObservedFormSubmit();
+    }
+
+    init();
+
+    return plugin;
+  };
+})(jQuery);

--- a/app/assets/javascripts/spotlight/pages.js.erb
+++ b/app/assets/javascripts/spotlight/pages.js.erb
@@ -26,7 +26,7 @@ Spotlight.onLoad(function(){
       blockTypes: instance.data('blockTypes'),
       defaultType:["Text"],
       onEditorRender: function() {
-        serializeObservedForms(observedForms());
+        $.SerializedForm();
       },
       blockTypeLimits: {
         "SearchResults": 1

--- a/spec/features/javascript/feature_page_admin_spec.rb
+++ b/spec/features/javascript/feature_page_admin_spec.rb
@@ -55,12 +55,8 @@ feature 'Feature Pages Adminstration', js: true do
   it 'stays in curation mode if a user has unsaved data' do
     visit spotlight.edit_exhibit_feature_page_path(page1.exhibit, page1)
 
-    # Hack to bypass alert about unsaved changes
-    page.evaluate_script('function observedFormsStatusHasChanged() { return false; }')
-
     fill_in('Title', with: 'Some Fancy Title')
-
-    page.accept_confirm do
+    page.dismiss_confirm do
       click_link 'Cancel'
     end
     expect(page).not_to have_selector 'a', text: 'Edit'
@@ -68,9 +64,6 @@ feature 'Feature Pages Adminstration', js: true do
 
   it 'stays in curation mode if a user has unsaved contenteditable data' do
     visit spotlight.edit_exhibit_feature_page_path(page1.exhibit, page1)
-
-    # Hack to bypass alert about unsaved changes
-    page.evaluate_script('function observedFormsStatusHasChanged() { return false; }')
 
     add_widget 'solr_documents'
     content_editable = find('.st-text-block')
@@ -86,9 +79,6 @@ feature 'Feature Pages Adminstration', js: true do
     visit spotlight.exhibit_dashboard_path(exhibit)
 
     click_link 'Feature pages'
-
-    # Hack to bypass alert about unsaved changes
-    page.evaluate_script('function observedFormsStatusHasChanged() { return false; }')
 
     within("[data-id='#{page1.id}']") do
       within('h3') do


### PR DESCRIPTION
Refactor form-observer to be useful when serving javascript as async

This refactor does a few things:
 - Removes the form observer methods from the global state
 - creates this as a singleton jQuery type plugin/module
 - Documents some strange edge cases / handles same event instantiation

Unforuntately this is not compatible to running our tests in an async
way. But manual smoke testing has confirmed this working.

To test, set:
https://github.com/projectblacklight/spotlight/blob/master/app/views/layouts/spotlight/spotlight.html.erb#L24

```diff
- <%= javascript_include_tag "application" %>
+ <%= javascript_include_tag "application", async: true %>
```
You will also need to set:

```diff
# .internal_test_app/config/environments/development.rb
- config.assets.debug = true
+ config.assets.debug = false
```
