### PR TITLE
Display language instructions only when languages are present.

### DIFF
--- a/app/views/spotlight/exhibits/_languages.html.erb
+++ b/app/views/spotlight/exhibits/_languages.html.erb
@@ -10,9 +10,10 @@
   <% end %>
 
   <h3><%= t :'spotlight.exhibits.languages.current_header' %></h3>
-  <p class="instructions"><%= t :'spotlight.exhibits.languages.current_instructions' %></p>
 
   <% if current_exhibit.languages.any? && current_exhibit.languages.last.persisted? %>
+    <p class="instructions"><%= t :'spotlight.exhibits.languages.current_instructions' %></p>
+
     <%= bootstrap_form_for current_exhibit, layout: :horizontal do |f| %>
       <div class="row">
         <div class="col-md-8">


### PR DESCRIPTION
Fixes #2037 

## Before
<img width="923" alt="before" src="https://user-images.githubusercontent.com/96776/39377639-c17de2ea-4a0a-11e8-835b-db969b2d0110.png">

## After
<img width="908" alt="after" src="https://user-images.githubusercontent.com/96776/39377638-c1649ace-4a0a-11e8-93bd-5b8994ab2ec4.png">

