### PR TITLE
Languages/Translations styling updates

### DIFF
--- a/app/assets/stylesheets/spotlight/_translations.scss
+++ b/app/assets/stylesheets/spotlight/_translations.scss
@@ -2,6 +2,18 @@
   .glyphicon-ok {
     color: $translation-available-color;
   }
+
+  .browse-category-title {
+    margin-bottom: $padding-base-vertical;
+
+    label {
+      font-weight: normal;
+    }
+  }
+
+  .browse-category-description {
+    margin-bottom: $padding-large-vertical * 2;
+  }
 }
 
 .translation-subheading {
@@ -44,4 +56,15 @@
 
 .default-page-outdated {
   font-weight: 700;
+}
+
+.browse-translations-header {
+  border-bottom: 1px solid $navbar-default-border;
+  color: $gray-light;
+  display: block;
+  font-size: $font-size-h4;
+  font-weight: bold;
+  margin-bottom: $padding-large-vertical * 2;
+  margin-top: $padding-large-vertical;
+  padding-bottom: 3px;
 }

--- a/app/assets/stylesheets/spotlight/_translations.scss
+++ b/app/assets/stylesheets/spotlight/_translations.scss
@@ -58,6 +58,10 @@
   font-weight: 700;
 }
 
+.new-translated-page {
+  font-style: italic;
+}
+
 .browse-translations-header {
   border-bottom: 1px solid $navbar-default-border;
   color: $gray-light;

--- a/app/views/spotlight/exhibits/_languages.html.erb
+++ b/app/views/spotlight/exhibits/_languages.html.erb
@@ -1,7 +1,7 @@
 <div role="tabpanel" class="tab-pane <%= 'active' if @tab == 'language' %>" id="language">
   <p class="instructions"><%= t :'spotlight.exhibits.languages.selection_instructions' %></p>
 
-  <%= bootstrap_form_for [current_exhibit, Spotlight::Language.new], layout: :horizontal do |f| %>
+  <%= bootstrap_form_for [current_exhibit, Spotlight::Language.new], layout: :horizontal, label_col: "col-sm-3", control_col: "col-sm-9" do |f| %>
     <div class='col-md-6'>
       <%= f.select('locale', add_exhibit_language_dropdown_options, prompt: t('.selection_prompt')) %>
       <%= hidden_field_tag :tab, 'language' %>

--- a/app/views/spotlight/translations/_browse_categories.html.erb
+++ b/app/views/spotlight/translations/_browse_categories.html.erb
@@ -5,14 +5,14 @@
     <%= hidden_field_tag :tab, 'browse' %>
     <div class="row">
       <div class="col-xs-4 text-right">
-        <strong>
+        <span class="browse-translations-header">
           <%= t :'spotlight.exhibits.translations.browse_categories.default_language_column_label' %>
-        </strong>
+        </span>
       </div>
       <div class="col-xs-7">
-        <strong>
+        <span class="browse-translations-header">
           <%= t :'spotlight.exhibits.translations.browse_categories.translation_column_label', language: t("locales.#{@language}")  %>
-        </strong>
+        </span>
       </div>
     </div>
 
@@ -21,7 +21,7 @@
       <%= f.fields_for :translations, title_translation do |translation_fields| %>
         <%= translation_fields.hidden_field :key %>
         <%= translation_fields.hidden_field :locale %>
-        <div data-translation-progress-item="true" class="form-group">
+        <div data-translation-progress-item="true" class="form-group browse-category-title">
           <%= translation_fields.label :value, search[:title], class: 'control-label col-xs-4' %>
           <div class="col-xs-7">
             <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
@@ -35,7 +35,7 @@
       <% end %>
 
       <% description_translation = Translation.find_or_initialize_by(exhibit: current_exhibit, key: "#{search.slug}.long_description", locale: @language) %>
-      <div data-translation-progress-item="true" class="form-group">
+      <div data-translation-progress-item="true" class="form-group browse-category-description">
         <div class="col-xs-7 col-xs-offset-4">
           <%= f.fields_for :translations, description_translation do |translation_fields| %>
             <%= button_tag 'type' => 'button', class: 'btn btn-text collapsed tanslation-description-toggle', 'data-toggle': 'collapse', 'data-target': "#browse_category_description_#{search.id}", 'aria-expanded': 'false', 'aria-controls': "#browse_category_description_#{search.id}" do %>

--- a/app/views/spotlight/translations/_page.html.erb
+++ b/app/views/spotlight/translations/_page.html.erb
@@ -21,8 +21,10 @@
         <% end %>
       </p>
     <% else %>
-      <%= t('spotlight.exhibits.translations.pages.no_translated_page') %>
-      <%= link_to(t('spotlight.exhibits.translations.pages.new'), polymorphic_path([:clone, current_exhibit, page], language: @language)) %>
+      <span class="new-translated-page">
+        <%= t('spotlight.exhibits.translations.pages.no_translated_page') %>
+        <%= link_to(t('spotlight.exhibits.translations.pages.new'), polymorphic_path([:clone, current_exhibit, page], language: @language)) %>
+      <span>
     <% end %>
   </td>
   <td class="text-center">

--- a/app/views/spotlight/translations/_pages.html.erb
+++ b/app/views/spotlight/translations/_pages.html.erb
@@ -1,5 +1,5 @@
 <div role="tabpanel" class="tab-pane <%= 'active' if @tab == 'pages' %>" id="pages">
-  <p class="help-block"><%= t('spotlight.exhibits.translations.pages.help_html') %></p>
+  <p class="instructions"><%= t('spotlight.exhibits.translations.pages.help_html') %></p>
 
   <%= bootstrap_form_for @exhibit, url: polymorphic_path([:update_all, @exhibit, :pages]), layout: :horizontal, control_col: 'col-sm-10', html: {:'data-form-observer' => true} do |f| %>
     <div class="translation-home-page-settings">


### PR DESCRIPTION
This PR updates several pages related to the recent translations feature to improve styling and layout of the pages.

### General > Languages page
The Languages label can be overlapped by the select menu:

<img width="370" alt="languages-before" src="https://user-images.githubusercontent.com/101482/39449524-2b6eff6c-4c7d-11e8-9d35-0c908dd0f21d.png">

#### After
<img width="370" alt="languages-after" src="https://user-images.githubusercontent.com/101482/39449535-325555a6-4c7d-11e8-8fdb-b671a7eea501.png">

### Translations > Browse Categories
Improve styling to make column headers more clear, adjust spacing so related elements feel more grouped.

#### Before
<img width="439" alt="browse-before" src="https://user-images.githubusercontent.com/101482/39449606-5eb236b4-4c7d-11e8-8699-a85287461bec.png">

#### After
<img width="439" alt="browse-after" src="https://user-images.githubusercontent.com/101482/39449616-636e7eb0-4c7d-11e8-9e26-c2a90baf458a.png">

### Translations > Pages
Update intro text to use appropriate class (currently shows text with muted styling) and italicize the text for the translated page column in the table when no translated page currently exists.

#### Before
<img width="451" alt="pages-before" src="https://user-images.githubusercontent.com/101482/39449686-9f1e7ece-4c7d-11e8-9a42-5129f1d85c07.png">

#### After
<img width="459" alt="pages-after" src="https://user-images.githubusercontent.com/101482/39449690-a4399da8-4c7d-11e8-8fee-bfa8f2a36bbb.png">
