### PR TITLE
Add the current locale to the cache key for searches/browse categories.

### DIFF
--- a/app/views/spotlight/browse/_search.html.erb
+++ b/app/views/spotlight/browse/_search.html.erb
@@ -1,4 +1,4 @@
-<%= cache [@exhibit, search] do %>
+<%= cache [@exhibit, search, I18n.locale] do %>
   <div class="col-sm-4 col-xs-12 category">
     <%= link_to spotlight.exhibit_browse_path(@exhibit, search) do %>
       <div class="image-overlay">


### PR DESCRIPTION
I believe this is causing browse category titles to be cached and not changed when switching locales on the browse category landing page.