### PR TITLE
modifies the about page link_to syntax in sidebar to use consistent f…

### DIFF
--- a/app/controllers/spotlight/about_pages_controller.rb
+++ b/app/controllers/spotlight/about_pages_controller.rb
@@ -46,7 +46,7 @@ module Spotlight
       if action_name == 'edit'
         add_breadcrumb t(:'spotlight.pages.index.about_pages.header'), exhibit_about_pages_path(@exhibit)
       else
-        add_breadcrumb(@exhibit.main_navigations.about.label_or_default, [@exhibit, @exhibit.main_about_page])
+        add_breadcrumb(@exhibit.main_navigations.about.label_or_default, [spotlight, @exhibit, @exhibit.main_about_page])
       end
     end
 

--- a/app/controllers/spotlight/feature_pages_controller.rb
+++ b/app/controllers/spotlight/feature_pages_controller.rb
@@ -28,8 +28,8 @@ module Spotlight
         add_breadcrumb t(:'spotlight.curation.sidebar.feature_pages'), exhibit_feature_pages_path(@exhibit)
       end
 
-      add_breadcrumb @page.parent_page.title, [@page.exhibit, @page.parent_page] unless @page.top_level_page?
-      add_breadcrumb @page.title, action_name == 'edit' ? [:edit, @page.exhibit, @page] : [@page.exhibit, @page]
+      add_breadcrumb @page.parent_page.title, [spotlight, @page.exhibit, @page.parent_page] unless @page.top_level_page?
+      add_breadcrumb @page.title, action_name == 'edit' ? [:edit, @page.exhibit, @page] : [spotlight, @page.exhibit, @page]
     end
 
     def attach_index_breadcrumbs

--- a/app/controllers/spotlight/pages_controller.rb
+++ b/app/controllers/spotlight/pages_controller.rb
@@ -56,7 +56,7 @@ module Spotlight
       @page.last_edited_by = @page.created_by = current_user
 
       if @page.save
-        redirect_to [@page.exhibit, page_collection_name], notice: t(:'helpers.submit.page.created', model: @page.class.model_name.human.downcase)
+        redirect_to [spotlight, @page.exhibit, page_collection_name], notice: t(:'helpers.submit.page.created', model: @page.class.model_name.human.downcase)
       else
         render action: 'new'
       end
@@ -67,7 +67,7 @@ module Spotlight
       @page.lock.delete if @page.lock
 
       if @page.update(page_params.merge(last_edited_by: current_user))
-        redirect_to [@page.exhibit, @page], flash: { html_safe: true }, notice: undo_notice(:updated)
+        redirect_to [spotlight, @page.exhibit, @page], flash: { html_safe: true }, notice: undo_notice(:updated)
       else
         render action: 'edit'
       end
@@ -77,7 +77,7 @@ module Spotlight
     def destroy
       @page.destroy
 
-      redirect_to [@page.exhibit, page_collection_name], flash: { html_safe: true }, notice: undo_notice(:destroyed)
+      redirect_to [spotlight, @page.exhibit, page_collection_name], flash: { html_safe: true }, notice: undo_notice(:destroyed)
     end
 
     def update_all

--- a/app/views/spotlight/about_pages/_sidebar.html.erb
+++ b/app/views/spotlight/about_pages/_sidebar.html.erb
@@ -3,8 +3,8 @@
   <h4 class="nav-heading"><%= current_exhibit.main_navigations.about.label_or_default %></h4>
   <ul class="nav sidenav">
     <% current_exhibit.about_pages.for_locale.published.each do |page| %>
-      <li class="<%= 'active' if current_page? [page.exhibit, page] %>">
-        <%= link_to page.title, [page.exhibit, page] %>
+      <li class="<%= 'active' if current_page? [spotlight, current_exhibit, page] %>">
+        <%= link_to page.title, [spotlight, current_exhibit, page] %>
       </li>
     <% end %>
   </ul>

--- a/app/views/spotlight/sir_trevor/blocks/_featured_pages_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_featured_pages_block.html.erb
@@ -2,7 +2,7 @@
   <div class="spotlight-flexbox browse-categories categories-<%= featured_pages_block.pages.length %>" data-sidebar='<%= @page.display_sidebar? %>'>
     <% featured_pages_block.pages.each_with_index do |page, index| %>
       <div class="box category-<%= (index + 1) %>">
-        <%= link_to [page.exhibit, page] do %>
+        <%= link_to [spotlight, current_exhibit, page] do %>
           <div class="browse-category" style='background-image: linear-gradient(rgba(0, 0, 0, 0.0), rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.5)) <%= ", url(\"#{page.thumbnail_image_url}\")" if page.thumbnail_image_url %>'>
             <div class="category-caption">
               <p class="category-title">

--- a/spec/controllers/spotlight/about_pages_controller_spec.rb
+++ b/spec/controllers/spotlight/about_pages_controller_spec.rb
@@ -36,7 +36,7 @@ describe Spotlight::AboutPagesController, type: :controller, versioning: true do
       describe 'on the main about page' do
         it 'is successful' do
           expect(controller).to receive(:add_breadcrumb).with('Home', exhibit_root_path(exhibit))
-          expect(controller).to receive(:add_breadcrumb).with('About', [exhibit, page])
+          expect(controller).to receive(:add_breadcrumb).with('About', [a_kind_of(ActionDispatch::Routing::RoutesProxy), exhibit, page])
           get :show, params: { id: page, exhibit_id: exhibit }
           expect(assigns(:page)).to eq page
           expect(assigns(:exhibit)).to eq exhibit
@@ -45,7 +45,7 @@ describe Spotlight::AboutPagesController, type: :controller, versioning: true do
       describe 'on a different about page' do
         it 'is successful' do
           expect(controller).to receive(:add_breadcrumb).with('Home', exhibit_root_path(exhibit))
-          expect(controller).to receive(:add_breadcrumb).with('About', [exhibit, page])
+          expect(controller).to receive(:add_breadcrumb).with('About', [a_kind_of(ActionDispatch::Routing::RoutesProxy), exhibit, page])
           expect(controller).to receive(:add_breadcrumb).with(page2.title, [exhibit, page2])
           get :show, params: { id: page2, exhibit_id: exhibit }
           expect(assigns(:page)).to eq page2

--- a/spec/controllers/spotlight/feature_pages_controller_spec.rb
+++ b/spec/controllers/spotlight/feature_pages_controller_spec.rb
@@ -40,7 +40,7 @@ describe Spotlight::FeaturePagesController, type: :controller, versioning: true 
         let(:page) { FactoryBot.create(:feature_page, exhibit: exhibit) }
         it 'assigns the requested page as @page' do
           expect(controller).to receive(:add_breadcrumb).with('Home', exhibit_root_path(exhibit))
-          expect(controller).to receive(:add_breadcrumb).with(page.title, [exhibit, page])
+          expect(controller).to receive(:add_breadcrumb).with(page.title, [a_kind_of(ActionDispatch::Routing::RoutesProxy), exhibit, page])
           get :show, params: { exhibit_id: page.exhibit.id, id: page }
           expect(assigns(:page)).to eq(page)
         end
@@ -49,8 +49,10 @@ describe Spotlight::FeaturePagesController, type: :controller, versioning: true 
         let(:page) { FactoryBot.create(:feature_subpage, exhibit: exhibit) }
         it 'assigns the requested page as @page' do
           expect(controller).to receive(:add_breadcrumb).with('Home', exhibit_root_path(exhibit))
-          expect(controller).to receive(:add_breadcrumb).with(page.parent_page.title, [exhibit, page.parent_page])
-          expect(controller).to receive(:add_breadcrumb).with(page.title, [exhibit, page])
+          expect(controller).to receive(:add_breadcrumb).with(
+            page.parent_page.title, [a_kind_of(ActionDispatch::Routing::RoutesProxy), exhibit, page.parent_page]
+          )
+          expect(controller).to receive(:add_breadcrumb).with(page.title, [a_kind_of(ActionDispatch::Routing::RoutesProxy), exhibit, page])
           get :show, params: { exhibit_id: page.exhibit, id: page }
           expect(assigns(:page)).to eq(page)
         end
@@ -95,7 +97,9 @@ describe Spotlight::FeaturePagesController, type: :controller, versioning: true 
       it 'assigns the requested page as @page' do
         expect(controller).to receive(:add_breadcrumb).with('Home', exhibit_root_path(exhibit))
         expect(controller).to receive(:add_breadcrumb).with('Feature pages', exhibit_feature_pages_path(exhibit))
-        expect(controller).to receive(:add_breadcrumb).with(page.parent_page.title, [exhibit, page.parent_page])
+        expect(controller).to receive(:add_breadcrumb).with(
+          page.parent_page.title, [a_kind_of(ActionDispatch::Routing::RoutesProxy), exhibit, page.parent_page]
+        )
         expect(controller).to receive(:add_breadcrumb).with(page.title, [:edit, exhibit, page])
         get :edit, params: { exhibit_id: page.exhibit.id, id: page.id }
         expect(assigns(:page)).to eq page

--- a/spec/views/spotlight/about_pages/_sidebar.html.erb_spec.rb
+++ b/spec/views/spotlight/about_pages/_sidebar.html.erb_spec.rb
@@ -8,6 +8,7 @@ describe 'spotlight/about_pages/_sidebar.html.erb', type: :view do
   before do
     allow(view).to receive_messages(current_exhibit: exhibit)
     allow(view).to receive_messages(exhibit_about_page_path: '/about/9')
+    assign(:exhibit, page1.exhibit)
   end
 
   it 'renders a list of pages' do
@@ -15,6 +16,8 @@ describe 'spotlight/about_pages/_sidebar.html.erb', type: :view do
     # Checking that they are sorted accoding to weight
     expect(rendered).to have_selector '#sidebar ul.sidenav li:nth-child(1) a', text: 'Three'
     expect(rendered).to have_selector '#sidebar ul.sidenav li:nth-child(2) a', text: 'One'
+    expect(rendered).to have_link 'Three', href: "/spotlight/#{exhibit.slug}/about/three"
+    expect(rendered).to have_link 'One', href: "/spotlight/#{exhibit.slug}/about/one"
     expect(rendered).not_to have_link 'Two'
   end
 end


### PR DESCRIPTION
…eature page link

Without this, and when using path based locale scopes, about page links
will link to the default page language.

Fixes #2057 