### PR TITLE
Use documents returned from #get_previous_and_next_documents_for_sear…

### DIFF
--- a/app/controllers/spotlight/catalog_controller.rb
+++ b/app/controllers/spotlight/catalog_controller.rb
@@ -156,13 +156,13 @@ module Spotlight
 
     def setup_next_and_previous_documents_from_browse_category
       index = search_session['counter'].to_i - 1
-      response, _docs = get_previous_and_next_documents_for_search index, current_browse_category.query_params.with_indifferent_access
+      response, documents = get_previous_and_next_documents_for_search index, current_browse_category.query_params.with_indifferent_access
 
       return unless response
 
       search_session['total'] = response.total
-      @previous_document = response.documents.first
-      @next_document = response.documents.last
+      @previous_document = documents.first
+      @next_document = documents.last
     end
 
     def _prefixes

--- a/app/controllers/spotlight/concerns/application_controller.rb
+++ b/app/controllers/spotlight/concerns/application_controller.rb
@@ -62,7 +62,7 @@ module Spotlight
       def document_index_view_type
         view_param = params[:view]
         view_param ||= session[:preferred_view]
-        if view_param && document_index_views.keys.include?(view_param.to_sym)
+        if view_param && document_index_views.key?(view_param.to_sym)
           view_param.to_sym
         else
           default_document_index_view_type


### PR DESCRIPTION
…ch instead of directly from response.

The documents array returned from #get_previous_and_next_documents_for_search handles the nil first/last documents appropriately for previous/next pagination.

https://github.com/projectblacklight/blacklight/blob/v6.15.0/app/controllers/concerns/blacklight/search_helper.rb#L98-L100

Fixes sul-dlss/exhibits#450

## Before
<img width="527" alt="before" src="https://user-images.githubusercontent.com/96776/39718363-eb88b244-51ea-11e8-986d-8ce21131c66b.png">

## After
<img width="631" alt="after" src="https://user-images.githubusercontent.com/96776/39718364-eba23304-51ea-11e8-9a71-2d1b3fdc28c0.png">
