### PR TITLE
This commit adds support for harvesting IIIF w/out HEAD requests

### DIFF
--- a/app/models/spotlight/resources/iiif_harvester.rb
+++ b/app/models/spotlight/resources/iiif_harvester.rb
@@ -23,6 +23,7 @@ module Spotlight
       def url_is_iiif?(url)
         valid_content_types = ['application/json', 'application/ld+json']
         req = Faraday.head(url)
+        req = Faraday.get(url) if req.status == 405
         return unless req.success?
         valid_content_types.any? do |valid_type|
           req.headers['content-type'].include?(valid_type)

--- a/spec/models/spotlight/resources/iiif_harvester_spec.rb
+++ b/spec/models/spotlight/resources/iiif_harvester_spec.rb
@@ -18,6 +18,18 @@ describe Spotlight::Resources::IiifHarvester do
         expect(subject.errors[:url]).to eq ['Invalid IIIF URL']
       end
     end
+    context 'when not responding to a HEAD request' do
+      before do
+        stub_request(:head, 'http://example.com').to_return(status: 405, headers: { 'Content-Type' => 'text/html' })
+        stub_request(:get, 'http://example.com').to_return(status: 200, headers: { 'Content-Type' => ' application/ld+json' })
+      end
+      let(:url) { 'http://example.com' }
+
+      it 'no errors when the URL responds to the GET request' do
+        expect(subject).to be_valid
+        expect(subject.errors).not_to be_present
+      end
+    end
   end
 
   describe '#documents_to_index' do


### PR DESCRIPTION
IIIF Presentation resources are not required to support a HEAD
request. This change will use a 405 response from a resource
to try a GET request.