### PR TITLE
Add an easily extendable PageConfigurations object to replace the…

### DIFF
--- a/app/helpers/spotlight/pages_helper.rb
+++ b/app/helpers/spotlight/pages_helper.rb
@@ -58,5 +58,9 @@ module Spotlight
     def render_contact_email_address(address)
       mail_to address, address
     end
+
+    def configurations_for_current_page
+      Spotlight::PageConfigurations.new(context: self, page: @page).as_json
+    end
   end
 end

--- a/app/models/spotlight/page_configurations.rb
+++ b/app/models/spotlight/page_configurations.rb
@@ -1,0 +1,93 @@
+module Spotlight
+  ##
+  # PageConfigurations is a simple class to gather and return all
+  # configurations needed for the various SirTrevor widgets.
+  # A downstream application (or gem) can inject its own data through the Spotlight's engine config like so
+  # Spotlight::Engine.config.page_configurations = {
+  #   'my-key': 'my_val'
+  # }
+  # You can also pass anything that responds to #call (eg. a lambda or custom ruby class)
+  # as the value and it will be evaluted within the PageConfiguration context
+  # (which has access to the view context).
+  # Spotlight::Engine.config.page_configurations = {
+  #   'exhibit-path': ->(context) { context.spotlight.exhibit_path(context.current_exhibit) }
+  # }
+  class PageConfigurations
+    delegate :available_view_fields,
+             :blacklight_config,
+             :current_exhibit,
+             :document_show_link_field,
+             :index_fields,
+             :index_field_label,
+             :spotlight,
+             :t,
+             :view_label,
+             to: :context
+
+    attr_reader :context, :page
+    def initialize(context:, page:)
+      @context = context
+      @page = page
+    end
+
+    def as_json(*)
+      {
+        'blacklight-configuration-index-fields': available_index_fields,
+        'blacklight-configuration-search-views': available_view_configs,
+        'attachment-endpoint': attachment_endpoint,
+        'autocomplete-exhibit-catalog-path': exhibit_autocomplete_endpoint,
+        'autocomplete-exhibit-pages-path': page_autocomplete_endpoint,
+        'autocomplete-exhibit-searches-path': search_autocomplete_endpoint,
+        'preview-url': page_preview_url
+      }.merge(downstream_parameters)
+    end
+
+    private
+
+    def available_index_fields
+      fields = blacklight_config.index_fields.map { |k, _v| { key: k, label: index_field_label(nil, k) } }
+      fields.unshift(key: document_show_link_field, label: t(:'spotlight.pages.form.title_placeholder')) unless index_fields.include? document_show_link_field
+
+      fields
+    end
+
+    def available_view_configs
+      available_view_fields.map { |k, _| { key: k, label: view_label(k) } }
+    end
+
+    def attachment_endpoint
+      spotlight.exhibit_attachments_path(current_exhibit)
+    end
+
+    def exhibit_autocomplete_endpoint
+      spotlight.autocomplete_exhibit_catalog_path(current_exhibit, q: '%QUERY', format: 'json')
+    end
+
+    def page_autocomplete_endpoint
+      spotlight.exhibit_pages_path(current_exhibit, format: 'json')
+    end
+
+    def search_autocomplete_endpoint
+      spotlight.exhibit_searches_path(current_exhibit, format: 'json')
+    end
+
+    def page_preview_url
+      return unless page.persisted?
+      spotlight.exhibit_preview_block_path(current_exhibit, page)
+    end
+
+    def downstream_parameters
+      configured_params.each_with_object({}) do |(key, value), hsh|
+        hsh[key] = if value.respond_to?(:call)
+                     value.call(self)
+                   else
+                     value
+                   end
+      end
+    end
+
+    def configured_params
+      Spotlight::Engine.config.page_configurations || {}
+    end
+  end
+end

--- a/app/views/spotlight/pages/_form.html.erb
+++ b/app/views/spotlight/pages/_form.html.erb
@@ -2,18 +2,7 @@
   # TODO: the "if @page.persisted?" business below could possibly be done w/ some clever polymorphic routing.
   # Leaving as-is for now since technically you can't get to the new page form anyway.
 %>
-<%= bootstrap_form_for([spotlight, @page.exhibit, @page], role: 'form', html: {
-              data: {
-                :'form-observer' => true,
-                :'blacklight-configuration-index-fields' => available_index_fields,
-                :'blacklight-configuration-search-views' => available_view_fields.map { |k,v| { key: k, label: view_label(k) }},
-                :'attachment-endpoint' => spotlight.exhibit_attachments_path(@page.exhibit),
-                :'autocomplete-exhibit-catalog-path'=> spotlight.autocomplete_exhibit_catalog_path(@page.exhibit, q: "%QUERY", format: "json"),
-                :'autocomplete-exhibit-pages-path' => spotlight.exhibit_pages_path(@page.exhibit, format: "json"),
-                :'autocomplete-exhibit-searches-path' => spotlight.exhibit_searches_path(@page.exhibit, format: "json"),
-                :'preview-url' => (spotlight.exhibit_preview_block_url(@page.exhibit, @page) if @page.persisted?)
-              }
-            }) do |f| %>
+<%= bootstrap_form_for([spotlight, @page.exhibit, @page], role: 'form', html: { data: configurations_for_current_page.merge('form-observer': true)}) do |f| %>
   <%= render @page.lock if @page.lock and not @page.lock.stale? and not @page.lock.current_session? %>
   <% if @page.errors.any? %>
     <div id="error_explanation">

--- a/lib/generators/spotlight/templates/config/initializers/spotlight_initializer.rb
+++ b/lib/generators/spotlight/templates/config/initializers/spotlight_initializer.rb
@@ -72,3 +72,8 @@
 #   FeaturedPages SolrDocuments SolrDocumentsCarousel SolrDocumentsEmbed
 #   SolrDocumentsFeatures SolrDocumentsGrid SearchResults
 # )
+#
+# Page configurations made available to widgets
+# Spotlight::Engine.config.page_configurations = {
+#   'my-local-config': ->(context) { context.my_custom_data_path(context.current_exhibit) }
+# }

--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -161,6 +161,10 @@ module Spotlight
     config.featured_image_square_size = [400, 400]
     config.contact_square_size = [70, 70]
 
+    # Additional page configurations to be made available to page editing widgets
+    # See Spotlight::PageConfigurations
+    config.page_configurations = {}
+
     # To present curators with analytics reports on the exhibit dashboard, you need to configure
     # an Analytics provider. Google Analytics support is provided out-of-the-box.
     config.analytics_provider = nil

--- a/spec/models/spotlight/page_configurations_spec.rb
+++ b/spec/models/spotlight/page_configurations_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+describe Spotlight::PageConfigurations, type: :model do
+  let(:view_context) do
+    double(
+      'ViewContext',
+      available_view_fields: [],
+      current_exhibit: exhibit,
+      blacklight_config: exhibit.blacklight_config,
+      document_show_link_field: 'document_show_link_field',
+      index_field_label: 'index_field_label',
+      index_fields: [],
+      spotlight: spotlight,
+      t: 'translated-content'
+    )
+  end
+
+  let(:exhibit) { FactoryBot.create(:exhibit) }
+  let(:page) { FactoryBot.create(:feature_page, exhibit: exhibit) }
+  subject(:page_config) { described_class.new(context: view_context, page: page) }
+
+  describe '#as_json' do
+    it 'is a json-able object (hash)' do
+      expect(page_config.as_json).to be_a Hash
+    end
+  end
+
+  describe 'downstream configured_params' do
+    it 'merges the supplied hash into the configs' do
+      expect(page_config).to receive_messages(configured_params: { 'hello': 'goodbye' })
+
+      expect(page_config.as_json).to include('hello': 'goodbye')
+    end
+
+    it 'sends the #call method to the value if it can respond (e.g. a lamda)' do
+      expect(view_context).to receive_messages(my_custom_plugin_path: 'my_custom_plugin/data.json')
+      expect(page_config).to receive_messages(
+        configured_params: { 'my-custom-plugin-path': ->(config) { config.context.my_custom_plugin_path } }
+      )
+
+      expect(page_config.as_json).to include('my-custom-plugin-path': 'my_custom_plugin/data.json')
+    end
+  end
+end

--- a/spec/views/spotlight/pages/_form.html.erb_spec.rb
+++ b/spec/views/spotlight/pages/_form.html.erb_spec.rb
@@ -6,9 +6,7 @@ describe 'spotlight/pages/edit', type: :view do
   end
   before do
     assign(:page, page)
-    allow(view).to receive_messages(blacklight_config: blacklight_config,
-                                    available_index_fields: [],
-                                    available_view_fields: [],
+    allow(view).to receive_messages(configurations_for_current_page: {},
                                     featured_images_path: '/foo')
   end
 

--- a/spec/views/spotlight/pages/edit.html.erb_spec.rb
+++ b/spec/views/spotlight/pages/edit.html.erb_spec.rb
@@ -3,9 +3,8 @@ describe 'spotlight/pages/edit', type: :view do
   let(:page) { stub_model(Spotlight::FeaturePage, exhibit: exhibit) }
   before do
     assign(:page, page)
-    allow(view).to receive_messages(featured_images_path: '/foo',
-                                    available_index_fields: [],
-                                    available_view_fields: [])
+    allow(view).to receive_messages(configurations_for_current_page: {},
+                                    featured_images_path: '/foo')
   end
 
   it 'renders the edit page form' do

--- a/spec/views/spotlight/pages/new.html.erb_spec.rb
+++ b/spec/views/spotlight/pages/new.html.erb_spec.rb
@@ -2,9 +2,8 @@ describe 'spotlight/pages/new', type: :view do
   let(:exhibit) { stub_model(Spotlight::Exhibit) }
   before do
     assign(:page, stub_model(Spotlight::FeaturePage, exhibit: exhibit).as_new_record)
-    allow(view).to receive_messages(featured_images_path: '/foo',
-                                    available_index_fields: [],
-                                    available_view_fields: [])
+    allow(view).to receive_messages(configurations_for_current_page: {},
+                                    featured_images_path: '/foo')
   end
 
   it 'renders new page form' do


### PR DESCRIPTION
… current hard-coded data hash.

This is intended to allow apps or plugins providing SirTrevor widgets to inject their own configurations into the page.