### PR TITLE
Add the page type to the friendly-id scope so that pages of different…

### DIFF
--- a/app/models/spotlight/about_page.rb
+++ b/app/models/spotlight/about_page.rb
@@ -5,7 +5,7 @@ module Spotlight
   # About pages
   class AboutPage < Spotlight::Page
     extend FriendlyId
-    friendly_id :title, use: %i[slugged scoped finders history], scope: %i[exhibit locale] do |config|
+    friendly_id :title, use: %i[slugged scoped finders history], scope: %i[exhibit locale type] do |config|
       config.reserved_words&.concat(%w[update_all contacts])
     end
   end

--- a/app/models/spotlight/feature_page.rb
+++ b/app/models/spotlight/feature_page.rb
@@ -5,7 +5,7 @@ module Spotlight
   # Feature pages
   class FeaturePage < Spotlight::Page
     extend FriendlyId
-    friendly_id :title, use: %i[slugged scoped finders history], scope: %i[exhibit locale] do |config|
+    friendly_id :title, use: %i[slugged scoped finders history], scope: %i[exhibit locale type] do |config|
       config.reserved_words&.concat(%w[update_all])
     end
 

--- a/app/models/spotlight/home_page.rb
+++ b/app/models/spotlight/home_page.rb
@@ -5,7 +5,7 @@ module Spotlight
   # Exhibit home page
   class HomePage < Spotlight::Page
     extend FriendlyId
-    friendly_id :title, use: %i[slugged scoped finders history], scope: %i[exhibit locale] do |config|
+    friendly_id :title, use: %i[slugged scoped finders history], scope: %i[exhibit locale type] do |config|
       config.reserved_words&.concat(%w[update_all])
     end
 

--- a/app/models/spotlight/page.rb
+++ b/app/models/spotlight/page.rb
@@ -9,7 +9,7 @@ module Spotlight
     extend FriendlyId
     # Note: This configuration also needs to be duplicated on the
     # STI models ({Spotlight::AboutPage}, {Spotlight::FeaturePage}, {Spotlight::HomePage})
-    friendly_id :title, use: %i[slugged scoped finders history], scope: %i[exhibit locale], treat_reserved_as_conflict: true do |config|
+    friendly_id :title, use: %i[slugged scoped finders history], scope: %i[exhibit locale type], treat_reserved_as_conflict: true do |config|
       config.reserved_words&.concat(%w[update_all contacts])
     end
 

--- a/lib/migration/add_page_type_to_friendly_id_scope.rb
+++ b/lib/migration/add_page_type_to_friendly_id_scope.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Migration
+  ##
+  # Different types of pages are accessed through their
+  # own controllers so they can have the same slug. We've
+  # added the page type to the scope, and this updates existing
+  # page slugs to include page type for consistency
+  class AddPageTypeToFriendlyIdScope
+    def self.run
+      new.migrate_slugs
+    end
+
+    def migrate_slugs
+      slugs.find_each do |slug|
+        next if /type:\w+/ =~ slug.scope
+
+        slug.scope = new_scope(slug)
+        slug.save
+      end
+    end
+
+    def new_scope(slug)
+      (slug.scope.split(',') << new_scope_part(slug)).sort.join(',')
+    end
+
+    def new_scope_part(slug)
+      "type:#{slug.sluggable.type}"
+    end
+
+    def slugs
+      FriendlyId::Slug.where(sluggable_type: 'Spotlight::Page')
+    end
+  end
+end

--- a/lib/tasks/spotlight_tasks.rake
+++ b/lib/tasks/spotlight_tasks.rake
@@ -89,6 +89,12 @@ namespace :spotlight do
     Migration::PageLanguage.run
   end
 
+  desc 'Migrate page\'s FriendlyId::Slug to a scoped page type'
+  task migrate_pages_slug_type: :environment do
+    require 'migration/add_page_type_to_friendly_id_scope'
+    Migration::AddPageTypeToFriendlyIdScope.run
+  end
+
   def prompt_to_create_user
     Spotlight::Engine.user_class.find_or_create_by!(email: prompt_for_email) do |u|
       puts 'User not found. Enter a password to create the user.'

--- a/spec/lib/migration/add_page_type_to_friendly_id_scope_spec.rb
+++ b/spec/lib/migration/add_page_type_to_friendly_id_scope_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'migration/add_page_type_to_friendly_id_scope'
+
+RSpec.describe Migration::AddPageTypeToFriendlyIdScope do
+  subject { described_class }
+
+  describe '#run' do
+    let(:exhibit) { FactoryBot.create(:exhibit) }
+    let(:page) { FactoryBot.create(:feature_page, exhibit: exhibit) }
+    let(:slug) { FriendlyId::Slug.find(page.id) }
+
+    before do
+      # Remove type from the scope
+      slug.scope = slug.scope.sub(',type:Spotlight::FeaturePage', '')
+      slug.save
+      slug.reload
+    end
+
+    it 'sets the scope to the default locale' do
+      expect(slug.scope).not_to include(',type:')
+      subject.run
+      slug.reload
+      expect(slug.scope).to end_with(',type:Spotlight::FeaturePage')
+    end
+
+    it 'sorts the scope parts per friendly_id expectation' do
+      # reverse the slug
+      slug.scope = slug.scope.split(',').reverse.join(',')
+      expect(slug.scope).to match(/locale:.*,exhibit_id:.*/)
+      slug.save
+      subject.run
+      slug.reload
+      expect(slug.scope).to match(/exhibit_id:.*,locale:.*,type:.*/)
+    end
+  end
+end

--- a/spec/lib/migration/page_language_spec.rb
+++ b/spec/lib/migration/page_language_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Migration::PageLanguage do
       expect(slug.scope).not_to include(',locale:en')
       subject.run
       slug.reload
-      expect(slug.scope).to eq "exhibit_id:#{page.exhibit.id},locale:en"
+      expect(slug.scope).to include ',locale:en'
     end
   end
 end

--- a/spec/models/spotlight/page_spec.rb
+++ b/spec/models/spotlight/page_spec.rb
@@ -132,6 +132,16 @@ describe Spotlight::Page, type: :model do
         expect(page.slug).to eq 'xyz'
       end
     end
+
+    context 'different types of pages with the same slug' do
+      it 'are allowed' do
+        FactoryBot.create(:feature_page, exhibit: exhibit, title: 'MyCustomPage')
+
+        expect do
+          FactoryBot.create(:about_page, exhibit: exhibit, title: 'MyCustomPage')
+        end.not_to raise_error
+      end
+    end
   end
 
   describe 'thumbnail_image_url' do


### PR DESCRIPTION
… types can have the same name/slug.