### PR TITLE
[WIP] Make titles and text independent in relevant SirTrevor blocks.

### DIFF
--- a/app/assets/javascripts/spotlight/blocks/oembed_block.js
+++ b/app/assets/javascripts/spotlight/blocks/oembed_block.js
@@ -2,7 +2,7 @@
   Sir Trevor ItemText Block.
   This block takes an ID,
   fetches the record from solr,
-  displays the image, title, 
+  displays the image, title,
   and any provided text
   and displays them.
 */
@@ -15,12 +15,11 @@ SirTrevor.Blocks.Oembed =  (function(){
     id_key:"url",
 
     type: "oembed",
-    
+
     title: function() { return i18n.t('blocks:oembed:title'); },
     description: function() { return i18n.t('blocks:oembed:description'); },
 
     icon_name: "oembed",
-    show_heading: false,
 
     template: [
     '<div class="form oembed-text-admin clearfix">',

--- a/app/assets/javascripts/spotlight/sir-trevor/locales.js
+++ b/app/assets/javascripts/spotlight/sir-trevor/locales.js
@@ -23,13 +23,13 @@ SirTrevor.Locales.en.blocks = $.extend(SirTrevor.Locales.en.blocks, {
 
   oembed: {
     title: "Embed + Text",
-    description: "This widget embeds an oEmbed-supported web resource and a text block to the left or right of it. Examples of oEmbed-supported resources include those from YouTube, Twitter, Flickr, and SlideShare.",
+    description: "This widget embeds an oEmbed-supported web resource. Examples of oEmbed-supported resources include those from YouTube, Twitter, Flickr, and SlideShare. Optionally, you can add a heading to be displayed above the resource and/or text to be displayed adjacent to the resource.",
     url: "URL",
   },
 
   uploaded_items: {
     title: "Uploaded Item Row",
-    description: "This widget displays uploaded items in a horizontal row. Optionally, you can add a heading and/or text to be displayed adjacent to the items.",
+    description: "This widget displays uploaded items in a horizontal row. Optionally, you can add a heading to be displayed above the items and/or text to be displayed adjacent to the items.",
     caption: 'Caption'
   },
 
@@ -57,7 +57,7 @@ SirTrevor.Locales.en.blocks = $.extend(SirTrevor.Locales.en.blocks, {
 
   solr_documents: {
     title: "Item Row",
-    description: "This widget displays exhibit items in a horizontal row. Optionally, you can add a heading and/or text to be displayed adjacent to the items.",
+    description: "This widget displays exhibit items in a horizontal row. Optionally, you can add a heading to be displayed above the items and/or text to be displayed adjacent to the items.",
     caption: {
       placeholder: "Select...",
       primary: "Primary caption",
@@ -82,7 +82,7 @@ SirTrevor.Locales.en.blocks = $.extend(SirTrevor.Locales.en.blocks, {
 
   solr_documents_embed: {
     title: "Item Embed",
-    description: "This widget embeds exhibit items on a page. Optionally, you can add a heading and/or text to be displayed adjacent to the items.",
+    description: "This widget embeds an exhibit item in a viewer on a page. Optionally, you can add a heading to be displayed above the viewer and/or text to be displayed adjacent to the viewer."
   },
 
   solr_documents_features: {
@@ -92,7 +92,7 @@ SirTrevor.Locales.en.blocks = $.extend(SirTrevor.Locales.en.blocks, {
 
   solr_documents_grid: {
     title: "Item Grid",
-    description: "This widget displays exhibit items in a multi-row grid. Optionally, you can add a heading and/or text to be displayed adjacent to the items."
+    description: "This widget displays exhibit items in a multi-row grid. Optionally, you can add a heading to be displayed above the items and/or text to be displayed adjacent to the items."
   },
 
   textable: {

--- a/app/views/spotlight/sir_trevor/blocks/_oembed_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_oembed_block.html.erb
@@ -1,13 +1,13 @@
 <div class="content-block item-text row">
+  <% if oembed_block.title.present? %>
+    <h3 class="col-md-12"><%= oembed_block.title %></h3>
+  <% end %>
   <div class="<%= 'col-md-6' if oembed_block.text? %> col-xs-12 oembed-block pull-<%= oembed_block.content_align %>">
     <%= render_oembed_tag oembed_block.url %>
   </div>
 
   <% if oembed_block.text? %>
     <div class="text-col col-md-6">
-      <% unless oembed_block.title.blank? %>
-        <h3><%= oembed_block.title %></h3>
-      <% end %>
       <%= sir_trevor_markdown oembed_block.text %>
     </div>
   <% end %>

--- a/app/views/spotlight/sir_trevor/blocks/_solr_documents_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_solr_documents_block.html.erb
@@ -1,6 +1,10 @@
 <% solr_documents_block.with_solr_helper(self) %>
 
 <div class="content-block items-block row">
+  <% if solr_documents_block.title.present? %>
+    <h3 class="col-md-12"><%= solr_documents_block.title %></h3>
+  <% end %>
+
   <% if solr_documents_block.documents? %>
 
     <div class="items-col spotlight-flexbox pull-<%= solr_documents_block.content_align %> <%= solr_documents_block.text? ? "col-md-6" : "col-md-12" %> ">
@@ -36,9 +40,6 @@
 
   <% if solr_documents_block.text? %>
     <div class="text-col col-md-6">
-      <% unless solr_documents_block.title.blank? %>
-        <h3><%= solr_documents_block.title %></h3>
-      <% end %>
       <%= sir_trevor_markdown solr_documents_block.text %>
     </div>
   <% end %>

--- a/app/views/spotlight/sir_trevor/blocks/_solr_documents_embed_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_solr_documents_embed_block.html.erb
@@ -1,6 +1,9 @@
 <% solr_documents_embed_block.with_solr_helper(self) %>
 
 <div class="content-block items-block row">
+  <% if solr_documents_embed_block.title.present? %>
+    <h3 class="col-md-12"><%= solr_documents_embed_block.title %></h3>
+  <% end %>
 
   <% if solr_documents_embed_block.documents? %>
 
@@ -15,9 +18,6 @@
 
   <% if solr_documents_embed_block.text? %>
     <div class="text-col col-md-6">
-      <% unless solr_documents_embed_block.title.blank? %>
-        <h3><%= solr_documents_embed_block.title %></h3>
-      <% end %>
       <%= sir_trevor_markdown solr_documents_embed_block.text %>
     </div>
   <% end %>

--- a/app/views/spotlight/sir_trevor/blocks/_solr_documents_grid_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_solr_documents_grid_block.html.erb
@@ -1,5 +1,8 @@
 <% solr_documents_grid_block.with_solr_helper(self) %>
 <div class="content-block item-grid-block row">
+  <% if solr_documents_grid_block.title.present? %>
+    <h3 class="col-md-12"><%= solr_documents_grid_block.title %></h3>
+  <% end %>
   <div class="items-col <%= solr_documents_grid_block.text? ? 'col-md-9' : 'col-md-12' %> pull-<%= solr_documents_grid_block.content_align %>">
     <% if solr_documents_grid_block.documents? %>
         <% solr_documents_grid_block.each_document.each_with_index do |(block_options, document), index| %>
@@ -19,9 +22,6 @@
 
   <% if solr_documents_grid_block.text? %>
     <div class="text-col col-md-3">
-      <% unless solr_documents_grid_block.title.blank? %>
-        <h3><%= solr_documents_grid_block.title %></h3>
-      <% end %>
       <%= sir_trevor_markdown solr_documents_grid_block.text %>
     </div>
   <% end %>

--- a/app/views/spotlight/sir_trevor/blocks/_uploaded_items_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_uploaded_items_block.html.erb
@@ -1,4 +1,6 @@
 <div class="content-block item-text row">
+  <%= content_tag(:h3, uploaded_items_block.title, class: 'col-md-12') if uploaded_items_block.title.present? %>
+
   <div class="items-col spotlight-flexbox <%= 'col-md-6' if uploaded_items_block.text? %> col-xs-12 uploaded-items-block pull-<%= uploaded_items_block.content_align %>">
     <% if uploaded_items_block.files.present? %>
       <% uploaded_items_block.files.each do |file| %>
@@ -20,7 +22,6 @@
 
   <% if uploaded_items_block.text? %>
     <div class="text-col col-md-6">
-      <%= content_tag(:h3, uploaded_items_block.title) if uploaded_items_block.title.present? %>
       <%= sir_trevor_markdown uploaded_items_block.text %>
     </div>
   <% end %>


### PR DESCRIPTION
This commit also enables the Heading field for the oEmbed + Text block.

See https://github.com/sul-dlss/exhibits/issues/1208#issuecomment-401400129 for rationale

@ggeisler this affects a few more blocks than originally specified.  I think I have done the correct thing wrt the help text in the various blocks, but let me know if anything should be changed.

* Embed + Text (previously did not have a Heading field so I added one)
* Uploaded Item Row
* Item Row
* Item Embed (the original widget that was reported)
* Item Grid

## Before
<img width="907" alt="old-widget-layout" src="https://user-images.githubusercontent.com/96776/42184459-7593873a-7dfa-11e8-8207-ff458c4c729d.png">

## After
<img width="972" alt="new-widget-layout" src="https://user-images.githubusercontent.com/96776/42184460-75b1d2a8-7dfa-11e8-9538-2f2d80361ce2.png">
