### PR TITLE
db: change taggable_id to integer

### DIFF
--- a/db/migrate/20180822233601_change_type_of_taggings_taggable.rb
+++ b/db/migrate/20180822233601_change_type_of_taggings_taggable.rb
@@ -1,0 +1,8 @@
+class ChangeTypeOfTaggingsTaggable < ActiveRecord::Migration[5.1]
+  def change
+    change_column :taggings,
+                  :taggable_id,
+                  :integer,
+                  using: 'taggable_id::integer'
+  end
+end


### PR DESCRIPTION
Fixes GH-1433.
Closes GH-1827.

Tests are failing locally with:
```
== 20180814221815 ChangePaperTrailVersionsObjectColumnToMediumText: migrating =
-- adapter_name()
   -> 0.0000s
-- change_column(:versions, :object, :text, {:limit=>1073741823})
rake aborted!
StandardError: An error has occurred, this and all later migrations canceled:

Could not find table 'versions'
/Users/alex/clones/spotlight/.internal_test_app/db/migrate/20180814221815_change_paper_trail_versions_object_column_to_medium_text.rb:9:in `change'
/Users/alex/.rbenv/versions/2.4.4/bin/bundle:23:in `load'
/Users/alex/.rbenv/versions/2.4.4/bin/bundle:23:in `<main>'
