### PR TITLE
Disabling turbolinks when clicking on the Edit link for page objects.

### DIFF
--- a/app/views/spotlight/dashboards/_page.html.erb
+++ b/app/views/spotlight/dashboards/_page.html.erb
@@ -4,10 +4,10 @@
     <div class="page-links">
       <% if page.is_a?(Spotlight::HomePage) %>
           <%= link_to action_default_value(page, :view), current_exhibit, :class => 'btn btn-link' %> &middot;
-          <%= exhibit_edit_link page, edit_exhibit_home_page_path(page.exhibit), :class => 'btn btn-link' %>
+          <%= exhibit_edit_link page, edit_exhibit_home_page_path(page.exhibit), :class => 'btn btn-link', data: { turbolinks: false } %>
       <% else %>
         <%= exhibit_view_link page, :class => 'btn btn-link' %> &middot;
-        <%= exhibit_edit_link page, :class => 'btn btn-link' %>
+        <%= exhibit_edit_link page, :class => 'btn btn-link', data: { turbolinks: false } %>
       <% end %>
     </div>
   </td>

--- a/app/views/spotlight/feature_pages/_header.html.erb
+++ b/app/views/spotlight/feature_pages/_header.html.erb
@@ -14,7 +14,7 @@
           </div>
           <div class="col-sm-4 page-links">
             <%= exhibit_view_link page, exhibit_root_path(page.exhibit), class: 'btn btn-link' %> &middot;
-            <%= exhibit_edit_link page, edit_exhibit_home_page_path(page.exhibit), class: 'btn btn-link' %>
+            <%= exhibit_edit_link page, edit_exhibit_home_page_path(page.exhibit), class: 'btn btn-link', data: { turbolinks: false } %>
           </div>
         </div>
       </div>

--- a/app/views/spotlight/home_pages/_edit_page_link.html.erb
+++ b/app/views/spotlight/home_pages/_edit_page_link.html.erb
@@ -1,1 +1,1 @@
-<%= exhibit_edit_link @page, edit_exhibit_home_page_path(@page.exhibit), class: 'edit-button pull-right btn btn-primary' %>
+<%= exhibit_edit_link @page, edit_exhibit_home_page_path(@page.exhibit), class: 'edit-button pull-right btn btn-primary', data: { turbolinks: false } %>

--- a/app/views/spotlight/pages/_edit_page_link.html.erb
+++ b/app/views/spotlight/pages/_edit_page_link.html.erb
@@ -1,1 +1,1 @@
-<%= exhibit_edit_link @page, class: 'edit-button pull-right btn btn-primary' %>
+<%= exhibit_edit_link @page, class: 'edit-button pull-right btn btn-primary', data: { turbolinks: false } %>

--- a/app/views/spotlight/pages/_page.html.erb
+++ b/app/views/spotlight/pages/_page.html.erb
@@ -18,7 +18,7 @@
 
         <div class="page-links col-sm-4">
           <%= exhibit_view_link page, :class => 'btn btn-link' %> &middot;
-          <%= exhibit_edit_link page, :class => 'btn btn-link' %> &middot;
+          <%= exhibit_edit_link page, :class => 'btn btn-link', data: { turbolinks: false } %> &middot;
           <%= exhibit_delete_link page, :class => 'btn btn-link' %>
         </div>
         <%- if page.feature_page? -%>


### PR DESCRIPTION
Something w/ Turbolinks appears to interfere with the SirTrevor widget framework and causes edits to not be persisted.

This explicitly fixes #1326 but the hope is that it might improve or resolve #1206