### PR TITLE
Add a helper for getting a IIIF manifest URL

### DIFF
--- a/app/helpers/spotlight/application_helper.rb
+++ b/app/helpers/spotlight/application_helper.rb
@@ -146,6 +146,12 @@ module Spotlight
       current_exhibit.theme if current_exhibit && current_exhibit.theme.present? && Spotlight::Engine.config.exhibit_themes.include?(current_exhibit.theme)
     end
 
+    # @param manifest_service [ManifestService] a ManifestService containing a SolrDocument that has a IIIF manifest
+    # @return [String] the URL to the IIIF manifest
+    def iiif_manifest(manifest_service:)
+      manifest_service.url
+    end
+
     private
 
     def main_app_url_helper?(method)

--- a/app/services/spotlight/manifest_service.rb
+++ b/app/services/spotlight/manifest_service.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Spotlight
+  # Service that is initilized with a SolrDocument from an item in spotlight and
+  # returns the IIIF manifest URL
+  class ManifestService
+    attr_reader :document
+
+    # @param document [SolrDocument] a SolrDocument from an item in Spotlight with a IIIF manifest
+    def initialize(document:)
+      @document = document
+    end
+
+    # @return [String] the URL to a IIIF manifest
+    def url
+      document.response.dig(:response, :docs, 0, :iiif_manifest_url_ssi)
+    end
+  end
+end

--- a/spec/helpers/spotlight/application_helper_spec.rb
+++ b/spec/helpers/spotlight/application_helper_spec.rb
@@ -186,4 +186,16 @@ describe Spotlight::ApplicationHelper, type: :helper do
       expect(helper.block_document_index_view_type(block_with_bad_or_missing_data)).to eq :a
     end
   end
+
+  describe '#iiif_manifest' do
+    let(:document) { SolrDocument.new }
+    let(:manifest_url) { 'https://example.com/manifest' }
+    let(:response) { { docs: [iiif_manifest_url_ssi: manifest_url] } }
+    let(:manifest_service) { Spotlight::ManifestService.new(document: document) }
+
+    it 'returns the iiif_manifest for a document' do
+      allow(manifest_service).to receive(:url).and_return(manifest_url)
+      expect(helper.iiif_manifest(manifest_service: manifest_service)).to eq(manifest_url)
+    end
+  end
 end

--- a/spec/services/spotlight/manifest_service_spec.rb
+++ b/spec/services/spotlight/manifest_service_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Spotlight::ManifestService do
+  let(:document) { SolrDocument.new }
+  let(:manifest_service) { described_class.new(document: document) }
+  let(:iiif_manifest_url) { '/manifest' }
+
+  describe '#url' do
+    it 'returns the correct url for the given document' do
+      allow(document).to receive(:response).and_return(
+        response: { docs: [iiif_manifest_url_ssi: iiif_manifest_url] }
+      )
+      expect(manifest_service.url).to eq(iiif_manifest_url)
+    end
+  end
+end


### PR DESCRIPTION
This commit adds a service and helper for retrieving the IIIF manifest
from a SolrDocument. Currently trying to access this URL
for an item on a view is kind of awkward:

```
document['response']['response']['docs'][0]['iiif_manifest_url_ssi']
```

With this service and helper, you can access it in views by doing:

```
iiif_manifest(manifest_service: Spotlight::ManifestService.new(document: document))
```

The functionality of the service could be expanded to additional
checking and other useful things in the future.