### PR TITLE
Fixed typo in method name for CarrierwaveFileResolver

### DIFF
--- a/app/services/spotlight/carrierwave_file_resolver.rb
+++ b/app/services/spotlight/carrierwave_file_resolver.rb
@@ -2,7 +2,7 @@ module Spotlight
   # Used by RIIIF to find files uploaded by carrierwave
   class CarrierwaveFileResolver < Riiif::AbstractFileSystemResolver
     # Override initialzer to avoid deprecation about not providing base path
-    def initializer
+    def initialize
       # nop
     end
 


### PR DESCRIPTION
This avoids a deprecation warning thrown in the super class