### PR TITLE
Encapsulate the Spotlight config

### DIFF
--- a/app/components/spotlight/analytics/dashboard_component.rb
+++ b/app/components/spotlight/analytics/dashboard_component.rb
@@ -22,11 +22,11 @@ module Spotlight
       end
 
       def min_date
-        Spotlight::Engine.config.ga_date_range['start_date'] || Date.new(2015, 8, 14) # This is the minimum date supported by GA
+        Spotlight::Engine.config.spotlight.ga_date_range['start_date'] || Date.new(2015, 8, 14) # This is the minimum date supported by GA
       end
 
       def max_date
-        Spotlight::Engine.config.ga_date_range['end_date'] || Time.zone.today
+        Spotlight::Engine.config.spotlight.ga_date_range['end_date'] || Time.zone.today
       end
 
       def note

--- a/app/components/spotlight/select_image_component.rb
+++ b/app/components/spotlight/select_image_component.rb
@@ -14,7 +14,7 @@ module Spotlight
     end
 
     def initial_crop_selection
-      Spotlight::Engine.config.thumbnail_initial_crop_selection
+      Spotlight::Engine.config.spotlight.thumbnail_initial_crop_selection
     end
 
     def help_text

--- a/app/components/spotlight/tag_list_form_component.html.erb
+++ b/app/components/spotlight/tag_list_form_component.html.erb
@@ -1,9 +1,9 @@
-<% if Spotlight::Engine.config.site_tags %>
+<% if Spotlight::Engine.config.spotlight.site_tags %>
   <div class="form-group mb-3 row">
   <label class="col-form-label col-md-2" for="tag_list">Tag list</label>
   <div class="col-md-10">
     <div class="overflow-scroll rounded border px-3 py-2 h-25" style="overflow: scroll; height: 25vh!important;">
-      <% Spotlight::Engine.config.site_tags.each do |tag| %>
+      <% Spotlight::Engine.config.spotlight.site_tags.each do |tag| %>
         <%= form.check_box :tag_list, { multiple: true, label: tag }, tag , nil %>
       <% end %>
     </div>

--- a/app/controllers/concerns/spotlight/base.rb
+++ b/app/controllers/concerns/spotlight/base.rb
@@ -15,7 +15,7 @@ module Spotlight
     end
 
     def controller_tracking_method
-      Spotlight::Engine.config.controller_tracking_method
+      Spotlight::Engine.config.spotlight.controller_tracking_method
     end
 
     # This overwrites Blacklight::Configurable#blacklight_config
@@ -35,12 +35,12 @@ module Spotlight
         id: doc.id,
         title: CGI.unescapeHTML(view_context.document_presenter(doc).heading.to_str),
         thumbnail: doc.first(blacklight_config.index.thumbnail_field),
-        full_image_url: doc.first(Spotlight::Engine.config.full_image_field),
+        full_image_url: doc.first(Spotlight::Engine.config.spotlight.full_image_field),
         description: doc.id,
         url: polymorphic_path([current_exhibit, doc]),
         private: doc.private?(current_exhibit),
         global_id: doc.to_global_id.to_s,
-        iiif_manifest: doc[Spotlight::Engine.config.iiif_manifest_field]
+        iiif_manifest: doc[Spotlight::Engine.config.spotlight.iiif_manifest_field]
       }
     end
     # rubocop:enable Metrics/AbcSize

--- a/app/controllers/spotlight/browse_controller.rb
+++ b/app/controllers/spotlight/browse_controller.rb
@@ -118,7 +118,7 @@ module Spotlight
     end
 
     def default_browse_index_view_type
-      Spotlight::Engine.config.default_browse_index_view_type
+      Spotlight::Engine.config.spotlight.default_browse_index_view_type
     end
 
     def render_save_this_search?

--- a/app/controllers/spotlight/catalog_controller.rb
+++ b/app/controllers/spotlight/catalog_controller.rb
@@ -66,7 +66,7 @@ module Spotlight
     # results when a partial match is passed in the "q" parameter.
     def autocomplete
       @response = search_service.search_results do |builder|
-        builder.with(builder.blacklight_params.merge(search_field: Spotlight::Engine.config.autocomplete_search_field, public: true, rows: 100))
+        builder.with(builder.blacklight_params.merge(search_field: Spotlight::Engine.config.spotlight.autocomplete_search_field, public: true, rows: 100))
       end
 
       respond_to do |format|

--- a/app/controllers/spotlight/contact_forms_controller.rb
+++ b/app/controllers/spotlight/contact_forms_controller.rb
@@ -33,7 +33,7 @@ module Spotlight
     def contact_form_params
       return {} if params[:action] == 'new'
 
-      params.require(:contact_form).permit(:name, :email, Spotlight::Engine.config.spambot_honeypot_email_field, :message, :current_url)
+      params.require(:contact_form).permit(:name, :email, Spotlight::Engine.config.spotlight.spambot_honeypot_email_field, :message, :current_url)
     end
   end
 end

--- a/app/controllers/spotlight/dashboards_controller.rb
+++ b/app/controllers/spotlight/dashboards_controller.rb
@@ -24,7 +24,7 @@ module Spotlight
 
       @pages = @exhibit.pages.recent.limit(5)
       @solr_documents = load_recent_solr_documents 5
-      @recent_reindexing = @exhibit.job_trackers.where.not(job_class: Spotlight::Engine.config.hidden_job_classes).recent
+      @recent_reindexing = @exhibit.job_trackers.where.not(job_class: Spotlight::Engine.config.spotlight.hidden_job_classes).recent
 
       attach_dashboard_breadcrumbs
     end

--- a/app/controllers/spotlight/featured_images_controller.rb
+++ b/app/controllers/spotlight/featured_images_controller.rb
@@ -22,7 +22,7 @@ module Spotlight
     end
 
     def tilesource
-      Spotlight::Engine.config.iiif_service.info_url(@featured_image, request.host)
+      Spotlight::Engine.config.spotlight.iiif_service.info_url(@featured_image, request.host)
     end
 
     # The create action can be called from a number of different forms, so

--- a/app/controllers/spotlight/searches_controller.rb
+++ b/app/controllers/spotlight/searches_controller.rb
@@ -47,7 +47,7 @@ module Spotlight
     end
 
     def autocomplete
-      search_params = autocomplete_params.merge(search_field: Spotlight::Engine.config.autocomplete_search_field)
+      search_params = autocomplete_params.merge(search_field: Spotlight::Engine.config.spotlight.autocomplete_search_field)
       response = search_service.search_results do |builder|
         builder.with(search_params)
       end

--- a/app/controllers/spotlight/solr_controller.rb
+++ b/app/controllers/spotlight/solr_controller.rb
@@ -63,7 +63,7 @@ module Spotlight
     end
 
     def validate_writable_index!
-      return if Spotlight::Engine.config.writable_index
+      return if Spotlight::Engine.config.spotlight.writable_index
 
       render plain: 'Spotlight is unable to write to solr', status: :conflict
     end

--- a/app/helpers/spotlight/main_app_helpers.rb
+++ b/app/helpers/spotlight/main_app_helpers.rb
@@ -18,7 +18,7 @@ module Spotlight
     end
 
     def show_contact_form?
-      current_exhibit && (Spotlight::Engine.config.default_contact_email || current_exhibit.contact_emails.confirmed.any?)
+      current_exhibit && (Spotlight::Engine.config.spotlight.default_contact_email || current_exhibit.contact_emails.confirmed.any?)
     end
 
     def link_back_to_catalog(opts = { label: nil })

--- a/app/helpers/spotlight/roles_helper.rb
+++ b/app/helpers/spotlight/roles_helper.rb
@@ -7,7 +7,7 @@ module Spotlight
     ##
     # Format the available roles for a select_tag
     def roles_for_select
-      Spotlight::Engine.config.exhibit_roles.index_by do |key|
+      Spotlight::Engine.config.spotlight.exhibit_roles.index_by do |key|
         t("spotlight.role.#{key}")
       end
     end

--- a/app/jobs/concerns/spotlight/gather_documents.rb
+++ b/app/jobs/concerns/spotlight/gather_documents.rb
@@ -17,7 +17,7 @@ module Spotlight
         cursor_mark = next_cursor_mark
         response = exhibit.blacklight_config.repository.search(
           solr_params.merge(
-            'rows' => Spotlight::Engine.config.bulk_actions_batch_size,
+            'rows' => Spotlight::Engine.config.spotlight.bulk_actions_batch_size,
             'cursorMark' => cursor_mark,
             'sort' => "#{exhibit.blacklight_config.document_model.unique_key} asc"
           )

--- a/app/jobs/spotlight/cleanup_job_trackers_job.rb
+++ b/app/jobs/spotlight/cleanup_job_trackers_job.rb
@@ -7,7 +7,7 @@ module Spotlight
   ###
   class CleanupJobTrackersJob < Spotlight::ApplicationJob
     def perform
-      Spotlight::JobTracker.where(status: 'completed', updated_at: Time.zone.at(0)...Spotlight::Engine.config.reindex_progress_window.minutes.ago).delete_all
+      Spotlight::JobTracker.where(status: 'completed', updated_at: Time.zone.at(0)...Spotlight::Engine.config.spotlight.reindex_progress_window.minutes.ago).delete_all
     end
   end
 end

--- a/app/jobs/spotlight/process_bulk_updates_csv_job.rb
+++ b/app/jobs/spotlight/process_bulk_updates_csv_job.rb
@@ -77,7 +77,7 @@ module Spotlight
     end
 
     def config
-      Spotlight::Engine.config.bulk_updates
+      Spotlight::Engine.config.spotlight.bulk_updates
     end
   end
 end

--- a/app/jobs/spotlight/reindex_exhibit_job.rb
+++ b/app/jobs/spotlight/reindex_exhibit_job.rb
@@ -10,7 +10,10 @@ module Spotlight
 
     include Spotlight::LimitConcurrency
 
-    def perform(exhibit, batch_size: Spotlight::Engine.config.reindexing_batch_size, batch_count: Spotlight::Engine.config.reindexing_batch_count, **)
+    def perform(exhibit,
+                batch_size: Spotlight::Engine.config.spotlight.reindexing_batch_size,
+                batch_count: Spotlight::Engine.config.spotlight.reindexing_batch_count,
+                **)
       count = exhibit.resources.count
 
       # Use the provided batch size, or calculate a reasonable default

--- a/app/jobs/spotlight/reindex_job.rb
+++ b/app/jobs/spotlight/reindex_job.rb
@@ -81,7 +81,7 @@ module Spotlight
     def job_data
       return unless job_tracker
 
-      @job_data ||= { Spotlight::Engine.config.job_tracker_id_field => job_tracker.top_level_job_tracker.job_id }
+      @job_data ||= { Spotlight::Engine.config.spotlight.job_tracker_id_field => job_tracker.top_level_job_tracker.job_id }
     end
 
     def resource_list(exhibit_or_resources, start: nil, finish: nil)

--- a/app/models/concerns/spotlight/exhibit_analytics.rb
+++ b/app/models/concerns/spotlight/exhibit_analytics.rb
@@ -17,7 +17,7 @@ module Spotlight
     end
 
     def analytics_provider
-      @analytics_provider ||= Spotlight::Engine.config.analytics_provider.new
+      @analytics_provider ||= Spotlight::Engine.config.spotlight.analytics_provider.new
     end
   end
 end

--- a/app/models/concerns/spotlight/exhibit_defaults.rb
+++ b/app/models/concerns/spotlight/exhibit_defaults.rb
@@ -17,7 +17,7 @@ module Spotlight
     protected
 
     def initialize_filter
-      return unless Spotlight::Engine.config.filter_resources_by_exhibit
+      return unless Spotlight::Engine.config.spotlight.filter_resources_by_exhibit
 
       filters.create field: default_filter_field, value: default_filter_value
     end
@@ -44,7 +44,7 @@ module Spotlight
     end
 
     def default_filter_field
-      "#{Spotlight::Engine.config.solr_fields.prefix}spotlight_exhibit_slug_#{slug}#{Spotlight::Engine.config.solr_fields.boolean_suffix}"
+      "#{Spotlight::Engine.config.spotlight.solr_fields.prefix}spotlight_exhibit_slug_#{slug}#{Spotlight::Engine.config.spotlight.solr_fields.boolean_suffix}"
     end
 
     # Return a string to work around any ActiveRecord type-casting
@@ -55,7 +55,7 @@ module Spotlight
     private
 
     def default_main_navigations
-      Spotlight::Engine.config.exhibit_main_navigation.dup
+      Spotlight::Engine.config.spotlight.exhibit_main_navigation.dup
     end
   end
 end

--- a/app/models/concerns/spotlight/solr_document.rb
+++ b/app/models/concerns/spotlight/solr_document.rb
@@ -33,23 +33,23 @@ module Spotlight
       end
 
       def exhibit_slug_field
-        "#{Spotlight::Engine.config.solr_fields.prefix}spotlight_exhibit_slugs#{Spotlight::Engine.config.solr_fields.string_suffix}"
+        "#{Spotlight::Engine.config.spotlight.solr_fields.prefix}spotlight_exhibit_slugs#{Spotlight::Engine.config.spotlight.solr_fields.string_suffix}"
       end
 
       def solr_field_for_tagger(tagger)
-        :"#{solr_field_prefix(tagger)}tags#{Spotlight::Engine.config.solr_fields.string_suffix}"
+        :"#{solr_field_prefix(tagger)}tags#{Spotlight::Engine.config.spotlight.solr_fields.string_suffix}"
       end
 
       def visibility_field(exhibit)
-        :"#{solr_field_prefix(exhibit)}public#{Spotlight::Engine.config.solr_fields.boolean_suffix}"
+        :"#{solr_field_prefix(exhibit)}public#{Spotlight::Engine.config.spotlight.solr_fields.boolean_suffix}"
       end
 
       def resource_type_field
-        :"#{Spotlight::Engine.config.solr_fields.prefix}spotlight_resource_type#{Spotlight::Engine.config.solr_fields.string_suffix}"
+        :"#{Spotlight::Engine.config.spotlight.solr_fields.prefix}spotlight_resource_type#{Spotlight::Engine.config.spotlight.solr_fields.string_suffix}"
       end
 
       def solr_field_prefix(exhibit)
-        "#{Spotlight::Engine.config.solr_fields.prefix}#{exhibit.class.model_name.param_key}_#{exhibit.to_param}_"
+        "#{Spotlight::Engine.config.spotlight.solr_fields.prefix}#{exhibit.class.model_name.param_key}_#{exhibit.to_param}_"
       end
     end
 

--- a/app/models/concerns/spotlight/solr_document/atomic_updates.rb
+++ b/app/models/concerns/spotlight/solr_document/atomic_updates.rb
@@ -14,7 +14,7 @@ module Spotlight
       end
 
       def write?
-        Spotlight::Engine.config.writable_index
+        Spotlight::Engine.config.spotlight.writable_index
       end
 
       private

--- a/app/models/concerns/spotlight/solr_document/uploaded_resource.rb
+++ b/app/models/concerns/spotlight/solr_document/uploaded_resource.rb
@@ -12,7 +12,7 @@ module Spotlight
       end
 
       def uploaded_resource
-        @uploaded_resource ||= GlobalID::Locator.locate first(Spotlight::Engine.config.resource_global_id_field)
+        @uploaded_resource ||= GlobalID::Locator.locate first(Spotlight::Engine.config.spotlight.resource_global_id_field)
       rescue StandardError => e
         Rails.logger.info("Unable to locate uploaded resource: #{e}")
         nil

--- a/app/models/concerns/spotlight/user.rb
+++ b/app/models/concerns/spotlight/user.rb
@@ -36,7 +36,7 @@ module Spotlight
     end
 
     def add_default_roles
-      return unless Spotlight::Engine.config.assign_default_roles_to_first_user
+      return unless Spotlight::Engine.config.spotlight.assign_default_roles_to_first_user
 
       roles.build role: 'admin', resource: Spotlight::Site.instance unless self.class.any?
     end

--- a/app/models/sir_trevor_rails/block.rb
+++ b/app/models/sir_trevor_rails/block.rb
@@ -28,7 +28,7 @@ module SirTrevorRails
     # Sets a list of custom block types to speed up lookup at runtime.
     def self.custom_block_types
       # You can define your custom block types directly here or in your engine config.
-      Spotlight::Engine.config.sir_trevor_widgets
+      Spotlight::Engine.config.spotlight.sir_trevor_widgets
     end
 
     def self.custom_block_type_alt_text_settings

--- a/app/models/spotlight/analytics/ga.rb
+++ b/app/models/spotlight/analytics/ga.rb
@@ -8,12 +8,12 @@ module Spotlight
     # Google Analytics data provider for the Exhibit dashboard
     class Ga
       def enabled?
-        Spotlight::Engine.config.ga_json_key_path && client
+        Spotlight::Engine.config.spotlight.ga_json_key_path && client
       end
 
       def client
         Google::Analytics::Data.analytics_data do |config|
-          config.credentials = Spotlight::Engine.config.ga_json_key_path
+          config.credentials = Spotlight::Engine.config.spotlight.ga_json_key_path
         end
       rescue StandardError => e
         Rails.logger.error(e)
@@ -48,7 +48,7 @@ module Spotlight
                                     metrics: [{ name: 'eventCount' }, { name: 'sessions' },
                                               { name: 'screenPageViewsPerSession' }, { name: 'engagementRate' }],
                                     order_bys: [{ metric: { metric_name: 'eventCount' },
-                                                  desc: true }] }).merge(Spotlight::Engine.config.ga_search_analytics_options)
+                                                  desc: true }] }).merge(Spotlight::Engine.config.spotlight.ga_search_analytics_options)
       end
 
       def page_params(path, dates)
@@ -57,7 +57,7 @@ module Spotlight
                                     order_bys: [{ metric: { metric_name: 'screenPageViews' }, desc: true }],
                                     metrics: [{ name: 'totalUsers' }, { name: 'activeUsers' },
                                               { name: 'screenPageViews' }]
-                                  }).merge(Spotlight::Engine.config.ga_page_analytics_options)
+                                  }).merge(Spotlight::Engine.config.spotlight.ga_page_analytics_options)
       end
 
       def report(params)
@@ -120,7 +120,7 @@ module Spotlight
       private
 
       def ga_property_id
-        Spotlight::Engine.config.ga_property_id
+        Spotlight::Engine.config.spotlight.ga_property_id
       end
     end
   end

--- a/app/models/spotlight/background_job_progress.rb
+++ b/app/models/spotlight/background_job_progress.rb
@@ -42,7 +42,7 @@ module Spotlight
       return false unless most_relevant_job_tracker.persisted?
       return true if most_relevant_job_tracker.in_progress?
 
-      finished? && most_relevant_job_tracker.updated_at >= Spotlight::Engine.config.reindex_progress_window.ago
+      finished? && most_relevant_job_tracker.updated_at >= Spotlight::Engine.config.spotlight.reindex_progress_window.ago
     end
 
     def started_at

--- a/app/models/spotlight/blacklight_configuration.rb
+++ b/app/models/spotlight/blacklight_configuration.rb
@@ -98,7 +98,7 @@ module Spotlight
         config.index.merge! index if index.present?
         config.index.respond_to[:iiif_json] = true
 
-        config.index.thumbnail_field ||= Spotlight::Engine.config.thumbnail_field
+        config.index.thumbnail_field ||= Spotlight::Engine.config.spotlight.thumbnail_field
 
         config.add_results_collection_tool 'curator_actions', if: :render_curator_actions?
 
@@ -363,11 +363,12 @@ module Spotlight
     end
 
     def add_autocomplete_field(config)
-      return unless Spotlight::Engine.config.autocomplete_search_field && !config.search_fields[Spotlight::Engine.config.autocomplete_search_field]
+      autocomplete_search_field = Spotlight::Engine.config.spotlight.autocomplete_search_field
+      return unless autocomplete_search_field && !config.search_fields[autocomplete_search_field]
 
-      config.add_search_field(Spotlight::Engine.config.autocomplete_search_field) do |field|
+      config.add_search_field(autocomplete_search_field) do |field|
         field.include_in_simple_select = false
-        field.solr_parameters = Spotlight::Engine.config.default_autocomplete_params.deep_dup
+        field.solr_parameters = Spotlight::Engine.config.spotlight.default_autocomplete_params.deep_dup
         field.solr_parameters[:fl] ||= default_autocomplete_field_list(config)
       end
     end
@@ -376,8 +377,8 @@ module Spotlight
       [
         config.document_model.unique_key,
         config.view_config(:show).title_field,
-        config.index.thumbnail_field || Spotlight::Engine.config.thumbnail_field,
-        Spotlight::Engine.config.iiif_manifest_field
+        config.index.thumbnail_field || Spotlight::Engine.config.spotlight.thumbnail_field,
+        Spotlight::Engine.config.spotlight.iiif_manifest_field
       ].flatten.join(' ')
     end
 

--- a/app/models/spotlight/contact_form.rb
+++ b/app/models/spotlight/contact_form.rb
@@ -6,7 +6,7 @@ module Spotlight
   class ContactForm
     include ActiveModel::Model
 
-    attr_accessor :current_exhibit, :name, :email, Spotlight::Engine.config.spambot_honeypot_email_field, :message, :current_url, :request
+    attr_accessor :current_exhibit, :name, :email, Spotlight::Engine.config.spotlight.spambot_honeypot_email_field, :message, :current_url, :request
 
     validates :email, format: { with: /\A([\w.%+-]+)@([\w-]+\.)+(\w{2,})\z/i }
 
@@ -15,7 +15,7 @@ module Spotlight
     # browser wouldn't, allowing us to differentiate and reject likely spam messages.
     # the field must be present, since we expect real users to just submit the form as-is w/o
     # hacking what fields are present.
-    validates Spotlight::Engine.config.spambot_honeypot_email_field, length: { is: 0 }
+    validates Spotlight::Engine.config.spotlight.spambot_honeypot_email_field, length: { is: 0 }
 
     def headers
       {
@@ -32,7 +32,7 @@ module Spotlight
     end
 
     def to
-      Spotlight::Engine.config.default_contact_email || contact_emails.first.to_s
+      Spotlight::Engine.config.spotlight.default_contact_email || contact_emails.first.to_s
     end
 
     def contact_emails

--- a/app/models/spotlight/contact_image.rb
+++ b/app/models/spotlight/contact_image.rb
@@ -7,7 +7,7 @@ module Spotlight
     private
 
     def image_size
-      Spotlight::Engine.config.contact_square_size
+      Spotlight::Engine.config.spotlight.contact_square_size
     end
   end
 end

--- a/app/models/spotlight/custom_field.rb
+++ b/app/models/spotlight/custom_field.rb
@@ -15,7 +15,7 @@ module Spotlight
 
     friendly_id :slug_candidates, use: %i[slugged scoped finders], scope: :exhibit
 
-    scope :facetable, -> { where(field_type: Spotlight::Engine.config.custom_field_types.select { |_k, v| v[:facetable] }.keys) }
+    scope :facetable, -> { where(field_type: Spotlight::Engine.config.spotlight.custom_field_types.select { |_k, v| v[:facetable] }.keys) }
     scope :writeable, -> { where(readonly_field: false) }
 
     before_create do

--- a/app/models/spotlight/exhibit.rb
+++ b/app/models/spotlight/exhibit.rb
@@ -29,7 +29,7 @@ module Spotlight
 
     validates :title, presence: true, if: -> { I18n.locale == I18n.default_locale }
     validates :slug, uniqueness: { message: I18n.t('spotlight.exhibits.new_exhibit_form.errors.slug_taken') }
-    validates :theme, inclusion: { in: Spotlight::Engine.config.exhibit_themes }, allow_blank: true
+    validates :theme, inclusion: { in: Spotlight::Engine.config.spotlight.exhibit_themes }, allow_blank: true
 
     after_validation :move_friendly_id_error_to_slug
 
@@ -67,7 +67,7 @@ module Spotlight
     has_many :roles, as: :resource, dependent: :delete_all
     has_many :searches, dependent: :destroy, extend: FriendlyId::FinderMethods
     has_many :solr_document_sidecars, dependent: :delete_all
-    has_many :users, through: :roles, class_name: Spotlight::Engine.config.user_class
+    has_many :users, through: :roles, class_name: Spotlight::Engine.config.spotlight.user_class
 
     has_many :pages, dependent: :destroy
     has_many :filters, dependent: :delete_all
@@ -98,7 +98,7 @@ module Spotlight
 
     def themes
       @themes ||= begin
-        return Spotlight::Engine.config.exhibit_themes unless self.class.themes_selector
+        return Spotlight::Engine.config.spotlight.exhibit_themes unless self.class.themes_selector
 
         self.class.themes_selector.call(self)
       end
@@ -126,7 +126,7 @@ module Spotlight
     end
 
     def uploaded_resource_fields
-      Spotlight::Engine.config.upload_fields
+      Spotlight::Engine.config.spotlight.upload_fields
     end
 
     def searchable?

--- a/app/models/spotlight/exhibit_thumbnail.rb
+++ b/app/models/spotlight/exhibit_thumbnail.rb
@@ -8,7 +8,7 @@ module Spotlight
     private
 
     def image_size
-      Spotlight::Engine.config.featured_image_square_size
+      Spotlight::Engine.config.spotlight.featured_image_square_size
     end
   end
 end

--- a/app/models/spotlight/featured_image.rb
+++ b/app/models/spotlight/featured_image.rb
@@ -62,7 +62,7 @@ module Spotlight
       if self[:iiif_tilesource]
         self[:iiif_tilesource]
       elsif file_present?
-        Spotlight::Engine.config.iiif_service.info_url(self)
+        Spotlight::Engine.config.spotlight.iiif_service.info_url(self)
       end
     end
 
@@ -75,7 +75,7 @@ module Spotlight
     private
 
     def image_size
-      Spotlight::Engine.config.featured_image_thumb_size
+      Spotlight::Engine.config.spotlight.featured_image_thumb_size
     end
 
     def iiif_service_base

--- a/app/models/spotlight/filter.rb
+++ b/app/models/spotlight/filter.rb
@@ -18,7 +18,7 @@ module Spotlight
     def cast_value
       return value unless field
 
-      if field.ends_with? Spotlight::Engine.config.solr_fields.boolean_suffix
+      if field.ends_with? Spotlight::Engine.config.spotlight.solr_fields.boolean_suffix
         value_to_boolean(value)
       else
         value

--- a/app/models/spotlight/job_tracker.rb
+++ b/app/models/spotlight/job_tracker.rb
@@ -9,7 +9,7 @@ module Spotlight
 
     belongs_to :on, polymorphic: true
     belongs_to :resource, polymorphic: true
-    belongs_to :user, optional: true, class_name: Spotlight::Engine.config.user_class
+    belongs_to :user, optional: true, class_name: Spotlight::Engine.config.spotlight.user_class
     has_many :events, as: :resource, dependent: :delete_all
     has_many :job_trackers, as: :on, dependent: Rails.version > '6.1' ? :destroy_async : :destroy
     has_many :subevents, through: :job_trackers, source: :events

--- a/app/models/spotlight/language.rb
+++ b/app/models/spotlight/language.rb
@@ -16,7 +16,7 @@ module Spotlight
     end
 
     def to_native
-      Spotlight::Engine.config.i18n_locales[locale.to_sym] || ''
+      Spotlight::Engine.config.spotlight.i18n_locales[locale.to_sym] || ''
     end
 
     def self.default_instance

--- a/app/models/spotlight/masthead.rb
+++ b/app/models/spotlight/masthead.rb
@@ -11,7 +11,7 @@ module Spotlight
     private
 
     def image_size
-      Spotlight::Engine.config.featured_image_masthead_size
+      Spotlight::Engine.config.spotlight.featured_image_masthead_size
     end
   end
 end

--- a/app/models/spotlight/page.rb
+++ b/app/models/spotlight/page.rb
@@ -4,7 +4,7 @@ module Spotlight
   ##
   # Base page class. See {Spotlight::AboutPage}, {Spotlight::FeaturePage}, {Spotlight::HomePage}
   class Page < ActiveRecord::Base
-    MAX_PAGES = Spotlight::Engine.config.max_pages
+    MAX_PAGES = Spotlight::Engine.config.spotlight.max_pages
 
     extend FriendlyId
 
@@ -15,8 +15,8 @@ module Spotlight
     end
 
     belongs_to :exhibit, touch: true
-    belongs_to :created_by, class_name: Spotlight::Engine.config.user_class, optional: true
-    belongs_to :last_edited_by, class_name: Spotlight::Engine.config.user_class, optional: true
+    belongs_to :created_by, class_name: Spotlight::Engine.config.spotlight.user_class, optional: true
+    belongs_to :last_edited_by, class_name: Spotlight::Engine.config.spotlight.user_class, optional: true
 
     belongs_to :thumbnail, class_name: 'Spotlight::FeaturedImage', dependent: :destroy, optional: true
     belongs_to :default_locale_page, class_name: 'Spotlight::Page', optional: true, inverse_of: :translated_pages
@@ -69,7 +69,7 @@ module Spotlight
     end
 
     def content_type
-      self[:content_type] || Spotlight::Engine.config.default_page_content_type
+      self[:content_type] || Spotlight::Engine.config.spotlight.default_page_content_type
     end
 
     def content=(content)

--- a/app/models/spotlight/page_configurations.rb
+++ b/app/models/spotlight/page_configurations.rb
@@ -5,13 +5,13 @@ module Spotlight
   # PageConfigurations is a simple class to gather and return all
   # configurations needed for the various SirTrevor widgets.
   # A downstream application (or gem) can inject its own data through the Spotlight's engine config like so
-  # Spotlight::Engine.config.page_configurations = {
+  # Spotlight::Engine.config.spotlight.page_configurations = {
   #   'my-key': 'my_val'
   # }
   # You can also pass anything that responds to #call (eg. a lambda or custom ruby class)
   # as the value and it will be evaluted within the PageConfiguration context
   # (which has access to the view context).
-  # Spotlight::Engine.config.page_configurations = {
+  # Spotlight::Engine.config.spotlight.page_configurations = {
   #   'exhibit-path': ->(context) { context.spotlight.exhibit_path(context.current_exhibit) }
   # }
   class PageConfigurations
@@ -98,7 +98,7 @@ module Spotlight
     end
 
     def configured_params
-      Spotlight::Engine.config.page_configurations || {}
+      Spotlight::Engine.config.spotlight.page_configurations || {}
     end
   end
 end

--- a/app/models/spotlight/page_content.rb
+++ b/app/models/spotlight/page_content.rb
@@ -12,7 +12,7 @@ module Spotlight
     end
 
     def self.default_page_content_class
-      Spotlight::PageContent.const_get(Spotlight::Engine.config.default_page_content_type)
+      Spotlight::PageContent.const_get(Spotlight::Engine.config.spotlight.default_page_content_type)
     end
   end
 end

--- a/app/models/spotlight/resources/iiif_manifest.rb
+++ b/app/models/spotlight/resources/iiif_manifest.rb
@@ -51,11 +51,11 @@ module Spotlight
       end
 
       def collection_id_field
-        Spotlight::Engine.config.iiif_collection_id_field
+        Spotlight::Engine.config.spotlight.iiif_collection_id_field
       end
 
       def add_manifest_url
-        solr_hash[Spotlight::Engine.config.iiif_manifest_field] = url
+        solr_hash[Spotlight::Engine.config.spotlight.iiif_manifest_field] = url
       end
 
       def add_thumbnail_url
@@ -150,7 +150,7 @@ module Spotlight
       end
 
       def full_image_field
-        Spotlight::Engine.config.full_image_field
+        Spotlight::Engine.config.spotlight.full_image_field
       end
 
       def tile_source_field
@@ -158,7 +158,7 @@ module Spotlight
       end
 
       def title_fields
-        Spotlight::Engine.config.iiif_title_fields || blacklight_config.index&.title_field
+        Spotlight::Engine.config.spotlight.iiif_title_fields || blacklight_config.index&.title_field
       end
 
       def sidecar
@@ -170,7 +170,7 @@ module Spotlight
       end
 
       def metadata_class
-        Spotlight::Engine.config.iiif_metadata_class.call
+        Spotlight::Engine.config.spotlight.iiif_metadata_class.call
       end
     end
   end

--- a/app/models/spotlight/resources/iiif_manifest_metadata.rb
+++ b/app/models/spotlight/resources/iiif_manifest_metadata.rb
@@ -8,7 +8,7 @@ module Spotlight
     #  This is intended to be overriden by an
     #  application if a different metadata
     #  strucure is used by the consumer
-    #  override with Spotlight::Engine.config.iiif_metadata_class
+    #  override with Spotlight::Engine.config.spotlight.iiif_metadata_class
     class IiifManifestMetadata
       def initialize(manifest)
         @manifest = manifest
@@ -154,7 +154,7 @@ module Spotlight
       end
 
       def default_json_ld_language
-        Spotlight::Engine.config.default_json_ld_language
+        Spotlight::Engine.config.spotlight.default_json_ld_language
       end
     end
   end

--- a/app/models/spotlight/resources/upload.rb
+++ b/app/models/spotlight/resources/upload.rb
@@ -14,7 +14,7 @@ module Spotlight
         @fields ||= {}
         @fields[exhibit] ||= begin
           index_title_field = exhibit.blacklight_config.index.title_field
-          title_field = Spotlight::Engine.config.upload_title_field ||
+          title_field = Spotlight::Engine.config.spotlight.upload_title_field ||
                         Spotlight::UploadFieldConfig.new(
                           field_name: index_title_field,
                           label: I18n.t(:"spotlight.search.fields.#{index_title_field}")
@@ -43,13 +43,15 @@ module Spotlight
       def to_solr
         return {} unless upload&.file_present?
 
-        dimensions = Spotlight::Engine.config.iiif_service.info(upload.id)
+        spotlight_config = Spotlight::Engine.config.spotlight
+        iiif_service = spotlight_config.iiif_service
+        dimensions = iiif_service.info(upload.id)
 
         {
           spotlight_full_image_width_ssm: dimensions.width,
           spotlight_full_image_height_ssm: dimensions.height,
-          Spotlight::Engine.config.thumbnail_field => Spotlight::Engine.config.iiif_service.thumbnail_url(upload),
-          Spotlight::Engine.config.iiif_manifest_field => Spotlight::Engine.config.iiif_service.manifest_url(exhibit, self)
+          spotlight_config.thumbnail_field => iiif_service.thumbnail_url(upload),
+          spotlight_config.iiif_manifest_field => iiif_service.manifest_url(exhibit, self)
         }
       end
 

--- a/app/models/spotlight/role.rb
+++ b/app/models/spotlight/role.rb
@@ -5,9 +5,9 @@ module Spotlight
   # Exhibit authorization roles
   class Role < ActiveRecord::Base
     belongs_to :resource, polymorphic: true, optional: true
-    belongs_to :user, class_name: Spotlight::Engine.config.user_class, autosave: true, optional: false
+    belongs_to :user, class_name: Spotlight::Engine.config.spotlight.user_class, autosave: true, optional: false
 
-    validates :role, inclusion: { in: Spotlight::Engine.config.exhibit_roles }
+    validates :role, inclusion: { in: Spotlight::Engine.config.spotlight.exhibit_roles }
     validate :user_must_be_unique, if: :user
 
     def user_key

--- a/app/presenters/spotlight/iiif_manifest_presenter.rb
+++ b/app/presenters/spotlight/iiif_manifest_presenter.rb
@@ -51,7 +51,7 @@ module Spotlight
 
     # a description of the manifest
     def description
-      resource.first(Spotlight::Engine.config.upload_description_field)
+      resource.first(Spotlight::Engine.config.spotlight.upload_description_field)
     end
 
     # IIIFManifest will call #to_s on each leaf node to get its respective label (not called out in README).
@@ -79,7 +79,7 @@ module Spotlight
 
     def iiif_url
       # yes this is hacky, and we are appropriately ashamed.
-      Spotlight::Engine.config.iiif_service.info_url(uploaded_resource.upload)
+      Spotlight::Engine.config.spotlight.iiif_service.info_url(uploaded_resource.upload)
                        .sub(%r{/info\.json\Z}, '')
     end
   end

--- a/app/services/spotlight/bulk_updates_csv_template_service.rb
+++ b/app/services/spotlight/bulk_updates_csv_template_service.rb
@@ -59,7 +59,7 @@ module Spotlight
     end
 
     def bulk_updates_config
-      Spotlight::Engine.config.bulk_updates
+      Spotlight::Engine.config.spotlight.bulk_updates
     end
 
     # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
@@ -76,7 +76,7 @@ module Spotlight
         response = exhibit.blacklight_config.repository.search(
           solr_params.merge(
             'q' => '*',
-            'rows' => Spotlight::Engine.config.bulk_actions_batch_size,
+            'rows' => Spotlight::Engine.config.spotlight.bulk_actions_batch_size,
             'cursorMark' => cursor_mark,
             'sort' => "#{exhibit.blacklight_config.document_model.unique_key} asc"
           )

--- a/app/services/spotlight/etl/solr_loader.rb
+++ b/app/services/spotlight/etl/solr_loader.rb
@@ -8,7 +8,7 @@ module Spotlight
 
       delegate :size, to: :queue
 
-      def initialize(batch_size: Spotlight::Engine.config.solr_batch_size, solr_connection: nil)
+      def initialize(batch_size: Spotlight::Engine.config.spotlight.solr_batch_size, solr_connection: nil)
         @queue = Queue.new
         @batch_size = batch_size
         @blacklight_solr = solr_connection
@@ -85,7 +85,7 @@ module Spotlight
       end
 
       def write?
-        Spotlight::Engine.config.writable_index
+        Spotlight::Engine.config.spotlight.writable_index
       end
 
       def logger

--- a/app/services/spotlight/etl/transforms.rb
+++ b/app/services/spotlight/etl/transforms.rb
@@ -50,7 +50,7 @@ module Spotlight
         document_model = pipeline.context.document_model
 
         data.reverse_merge(
-          Spotlight::Engine.config.resource_global_id_field => (resource.to_global_id.to_s if resource.persisted?),
+          Spotlight::Engine.config.spotlight.resource_global_id_field => (resource.to_global_id.to_s if resource.persisted?),
           document_model.resource_type_field => resource.class.to_s.tableize
         )
       end

--- a/app/services/spotlight/exhibit_import_export_service.rb
+++ b/app/services/spotlight/exhibit_import_export_service.rb
@@ -17,7 +17,7 @@ module Spotlight
 
     attr_reader :exhibit, :include
 
-    def initialize(exhibit, include: Spotlight::Engine.config.exports)
+    def initialize(exhibit, include: Spotlight::Engine.config.spotlight.exports)
       @exhibit = exhibit
       @include = include
     end

--- a/app/uploaders/spotlight/attachment_uploader.rb
+++ b/app/uploaders/spotlight/attachment_uploader.rb
@@ -4,7 +4,7 @@ module Spotlight
   ##
   # Sir-trevor image widget uploads
   class AttachmentUploader < CarrierWave::Uploader::Base
-    storage Spotlight::Engine.config.uploader_storage
+    storage Spotlight::Engine.config.spotlight.uploader_storage
 
     # Override the directory where uploaded files will be stored.
     # This is a sensible default for uploaders that are meant to be mounted:

--- a/app/uploaders/spotlight/bulk_updates_uploader.rb
+++ b/app/uploaders/spotlight/bulk_updates_uploader.rb
@@ -3,6 +3,6 @@
 module Spotlight
   # :nodoc:
   class BulkUpdatesUploader < CarrierWave::Uploader::Base
-    storage Spotlight::Engine.config.uploader_storage
+    storage Spotlight::Engine.config.spotlight.uploader_storage
   end
 end

--- a/app/uploaders/spotlight/featured_image_uploader.rb
+++ b/app/uploaders/spotlight/featured_image_uploader.rb
@@ -4,10 +4,10 @@ module Spotlight
   ##
   # Page, browse category, and exhibit featured image thumbnails
   class FeaturedImageUploader < CarrierWave::Uploader::Base
-    storage Spotlight::Engine.config.uploader_storage
+    storage Spotlight::Engine.config.spotlight.uploader_storage
 
     def extension_allowlist
-      Spotlight::Engine.config.allowed_upload_extensions
+      Spotlight::Engine.config.spotlight.allowed_upload_extensions
     end
 
     def store_dir

--- a/app/values/custom_field_name.rb
+++ b/app/values/custom_field_name.rb
@@ -29,11 +29,11 @@ class CustomFieldName
   end
 
   def field_suffix
-    (field_type && Spotlight::Engine.config.custom_field_types[field_type.to_sym][:suffix]) ||
+    (field_type && Spotlight::Engine.config.spotlight.custom_field_types[field_type.to_sym][:suffix]) ||
       default_field_suffix
   end
 
   def default_field_suffix
-    Spotlight::Engine.config.solr_fields.text_suffix
+    Spotlight::Engine.config.spotlight.solr_fields.text_suffix
   end
 end

--- a/app/views/shared/_analytics.html.erb
+++ b/app/views/shared/_analytics.html.erb
@@ -1,14 +1,14 @@
-<% if Spotlight::Engine.config.ga_web_property_id %>
+<% if Spotlight::Engine.config.spotlight.ga_web_property_id %>
 <!-- Google tag (gtag.js) -->
-<% if Spotlight::Engine.config.ga_debug_mode %>
+<% if Spotlight::Engine.config.spotlight.ga_debug_mode %>
 <script>window.analyticsDebug = true;</script>
 <% end %>
-<script async src="https://www.googletagmanager.com/gtag/js?id=<%= Spotlight::Engine.config.ga_web_property_id %>"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=<%= Spotlight::Engine.config.spotlight.ga_web_property_id %>"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag() { dataLayer.push(arguments); }
   var opts = window.analyticsDebug ? {'debug_mode': true} : {};
   gtag("js", new Date());
-  gtag("config", "<%= Spotlight::Engine.config.ga_web_property_id %>", opts);
+  gtag("config", "<%= Spotlight::Engine.config.spotlight.ga_web_property_id %>", opts);
 </script>
 <% end %>

--- a/app/views/spotlight/appearances/edit.html.erb
+++ b/app/views/spotlight/appearances/edit.html.erb
@@ -54,14 +54,14 @@
       <div role="tabpanel" class="tab-pane <%= 'active' unless current_exhibit.themes.many? %>" id="site-masthead">
         <p class="instructions"><%= t(:'.site_masthead.help') %></p>
         <%= f.fields_for(:masthead, current_exhibit.masthead || current_exhibit.build_masthead) do |m| %>
-          <%= render '/spotlight/featured_images/form', f: m, initial_crop_selection: Spotlight::Engine.config.masthead_initial_crop_selection, crop_type: :masthead %>
+          <%= render '/spotlight/featured_images/form', f: m, initial_crop_selection: Spotlight::Engine.config.spotlight.masthead_initial_crop_selection, crop_type: :masthead %>
         <% end %>
       </div>
 
       <div role="tabpanel" class="tab-pane" id="site-thumbnail">
         <p class="instructions"><%= t(:'.site_thumbnail.help') %></p>
         <%= f.fields_for(:thumbnail, current_exhibit.thumbnail || current_exhibit.build_thumbnail) do |m| %>
-          <%= render '/spotlight/featured_images/form', f: m, initial_crop_selection: Spotlight::Engine.config.thumbnail_initial_crop_selection, crop_type: :thumbnail %>
+          <%= render '/spotlight/featured_images/form', f: m, initial_crop_selection: Spotlight::Engine.config.spotlight.thumbnail_initial_crop_selection, crop_type: :thumbnail %>
         <% end %>
       </div>
 

--- a/app/views/spotlight/catalog/_admin_header.html.erb
+++ b/app/views/spotlight/catalog/_admin_header.html.erb
@@ -7,7 +7,7 @@
       <%= link_to t('.reindex'), reindex_all_exhibit_resources_path(current_exhibit), 
           data: { method: :post, turbo_method: :post },
           class: 'btn btn-outline-primary' %>
-      <% if Spotlight::Engine.config.resource_partials.any? %>
+      <% if Spotlight::Engine.config.spotlight.resource_partials.any? %>
         <%= link_to t('.new_resource'), new_exhibit_resource_path(current_exhibit), class: 'btn btn-primary' %>
       <% end %>
     </div>

--- a/app/views/spotlight/catalog/_edit_default.html.erb
+++ b/app/views/spotlight/catalog/_edit_default.html.erb
@@ -6,7 +6,7 @@
   <% end %>
 
   <%= f.fields_for :uploaded_resource do |r| %>
-    <%= r.url_field :url, type: "file", help: t('.url-field.help', extensions: Spotlight::Engine.config.allowed_upload_extensions.join(' ')), label: "File" %>
+    <%= r.url_field :url, type: "file", help: t('.url-field.help', extensions: Spotlight::Engine.config.spotlight.allowed_upload_extensions.join(' ')), label: "File" %>
   <% end if document.uploaded_resource? %>
 
   <%= render partial: 'edit_sidecar', locals: { document: document, f: f } %>

--- a/app/views/spotlight/catalog/index.iiif_json.jbuilder
+++ b/app/views/spotlight/catalog/index.iiif_json.jbuilder
@@ -8,9 +8,9 @@ json.viewingHint 'top'
 json.description current_exhibit.description if current_exhibit.description
 json.manifests do
   json.array!(@response.documents) do |doc|
-    next unless doc.first(Spotlight::Engine.config.iiif_manifest_field)
+    next unless doc.first(Spotlight::Engine.config.spotlight.iiif_manifest_field)
 
-    json.set! :@id, doc.first(Spotlight::Engine.config.iiif_manifest_field)
+    json.set! :@id, doc.first(Spotlight::Engine.config.spotlight.iiif_manifest_field)
     json.set! :@type, 'sc:manifest'
     json.label document_presenter(doc).heading
   end

--- a/app/views/spotlight/contacts/_form.html.erb
+++ b/app/views/spotlight/contacts/_form.html.erb
@@ -19,7 +19,7 @@
         </div>
       </div>
 
-      <%= iiif_cropper_tags af, initial_crop_selection: Spotlight::Engine.config.contact_square_size %>
+      <%= iiif_cropper_tags af, initial_crop_selection: Spotlight::Engine.config.spotlight.contact_square_size %>
     <% end %>
     </div>
   <% end %>

--- a/app/views/spotlight/custom_fields/_form.html.erb
+++ b/app/views/spotlight/custom_fields/_form.html.erb
@@ -4,7 +4,7 @@
   <%= f.text_area :short_description %>
 
   <%= f.form_group :field_type, label: { text: t(:'.field_type.label') } do %>
-    <% Spotlight::Engine.config.custom_field_types.each do |key, field_type| %>
+    <% Spotlight::Engine.config.spotlight.custom_field_types.each do |key, field_type| %>
       <%= f.radio_button :field_type, key, label: t(:".field_type.#{key}") %>
     <% end %>
   <% end %>

--- a/app/views/spotlight/home_pages/_empty.html.erb
+++ b/app/views/spotlight/home_pages/_empty.html.erb
@@ -19,7 +19,7 @@
         <li>If you want help building the exhibit, use the <%= link_to "Configuration > Users", exhibit_roles_path(current_exhibit) %> page to add other user accounts.</li>
       <% end %>
 
-      <% if Spotlight::Engine.config.resource_partials.any? %>
+      <% if Spotlight::Engine.config.spotlight.resource_partials.any? %>
         <li>Add items to the exhibit. Go to the <%= link_to "Curation > Items", admin_exhibit_catalog_path(current_exhibit) %> page and select <b>Add items</b>. You can add items individually or in bulk via a CSV file.</li>
       <% end %>
 

--- a/app/views/spotlight/pages/_form.html.erb
+++ b/app/views/spotlight/pages/_form.html.erb
@@ -52,7 +52,7 @@
       <div role="tabpanel" class="tab-pane" id="page-thumbnail">
         <%= f.fields_for :thumbnail, (@page.thumbnail || @page.build_thumbnail), include_id: false do |m| %>
           <p class="instructions"><%= t(:'.thumbnail.help') %></p>
-          <%= render '/spotlight/featured_images/form', f: m, initial_crop_selection: Spotlight::Engine.config.featured_image_thumb_size, crop_type: :thumbnail %>
+          <%= render '/spotlight/featured_images/form', f: m, initial_crop_selection: Spotlight::Engine.config.spotlight.featured_image_thumb_size, crop_type: :thumbnail %>
         <% end %>
       </div>
       <% end %>

--- a/app/views/spotlight/resources/_external_resources_form.html.erb
+++ b/app/views/spotlight/resources/_external_resources_form.html.erb
@@ -1,10 +1,10 @@
-<% if Spotlight::Engine.config.external_resources_partials.empty? %>
+<% if Spotlight::Engine.config.spotlight.external_resources_partials.empty? %>
   <%= render 'missing_external_resources_partials' %>
 <% end %>
 
 <div role="tabpanel">
   <ul class="nav nav-pills" role="tablist">
-    <% Spotlight::Engine.config.external_resources_partials.each_with_index do |p, i| %>
+    <% Spotlight::Engine.config.spotlight.external_resources_partials.each_with_index do |p, i| %>
       <li role="presentation" class="nav-item">
         <%= link_to(
               t("#{p.gsub('/', '.')}.title"),
@@ -19,7 +19,7 @@
     <% end %>
   </ul>
   <div class="tab-content">
-    <% Spotlight::Engine.config.external_resources_partials.each_with_index do |p, i| %>
+    <% Spotlight::Engine.config.spotlight.external_resources_partials.each_with_index do |p, i| %>
       <%= content_tag :div, id: "external_resource_tab_#{i}", role: 'tabpanel', class: "tab-pane #{"active" if i == 0}" do %>
         <%= render p %>
       <% end %>

--- a/app/views/spotlight/resources/new.html.erb
+++ b/app/views/spotlight/resources/new.html.erb
@@ -5,7 +5,7 @@
 <%= curation_page_title %>
 <div role="tabpanel">
   <ul class="nav nav-tabs" role="tablist">
-    <% Spotlight::Engine.config.resource_partials.each_with_index do |p, i| %>
+    <% Spotlight::Engine.config.spotlight.resource_partials.each_with_index do |p, i| %>
       <% tab_name = p.split('/')[2] %>
       <li role="presentation" class="nav-item">
         <%= link_to t("#{p.gsub('/', '.')}.title"),
@@ -18,7 +18,7 @@
     <% end %>
   </ul>
   <div class="tab-content">
-    <% Spotlight::Engine.config.resource_partials.each_with_index do |p, i| %>
+    <% Spotlight::Engine.config.spotlight.resource_partials.each_with_index do |p, i| %>
       <% tab_name = p.split('/')[2] %>
       <%= content_tag :div, id: "#{tab_name}", role: 'tabpanel', class: "tab-pane #{"active" if @tab == tab_name}" do %>
         <%= render p %>

--- a/app/views/spotlight/resources/upload/_form.html.erb
+++ b/app/views/spotlight/resources/upload/_form.html.erb
@@ -1,5 +1,5 @@
 <%= bootstrap_form_for([current_exhibit, @resource.becomes(Spotlight::Resources::Upload)], layout: :horizontal, label_col: 'col-md-2', control_col: 'col-sm-6 col-md-6', html: { class: 'item-upload-form', multipart: true } ) do |f| %>
-  <%= f.url_field :url, type: "file", help: t('.url-field.help', extensions: Spotlight::Engine.config.allowed_upload_extensions.join(' ')), label: "File" %>
+  <%= f.url_field :url, type: "file", help: t('.url-field.help', extensions: Spotlight::Engine.config.spotlight.allowed_upload_extensions.join(' ')), label: "File" %>
   <%= f.fields_for :data do |d| %>
     <% Spotlight::Resources::Upload.fields(current_exhibit).each do |config| %>
       <%= d.send(config.form_field_type, config.field_name, label: uploaded_field_label(config)) %>

--- a/app/views/spotlight/searches/_form.html.erb
+++ b/app/views/spotlight/searches/_form.html.erb
@@ -66,13 +66,13 @@
         <%= f.fields_for :masthead, (@search.masthead || @search.build_masthead) do |m| %>
           <p class="instructions"><%= t(:'.masthead.help') %></p>
           <p class="instructions"><%= t(:'.masthead.help_secondary') %></p>
-          <%= render '/spotlight/featured_images/form', f: m, initial_crop_selection: Spotlight::Engine.config.masthead_initial_crop_selection, crop_type: :masthead %>
+          <%= render '/spotlight/featured_images/form', f: m, initial_crop_selection: Spotlight::Engine.config.spotlight.masthead_initial_crop_selection, crop_type: :masthead %>
         <% end %>
       </div>
       <div role="tabpanel" class="tab-pane" id="search-thumbnail">
         <%= f.fields_for :thumbnail, (@search.thumbnail || @search.build_thumbnail) do |m| %>
           <p class="instructions"><%= t(:'.thumbnail.help') %></p>
-          <%= render '/spotlight/featured_images/form', f: m, initial_crop_selection: Spotlight::Engine.config.featured_image_thumb_size, crop_type: :thumbnail %>
+          <%= render '/spotlight/featured_images/form', f: m, initial_crop_selection: Spotlight::Engine.config.spotlight.featured_image_thumb_size, crop_type: :thumbnail %>
         <% end %>
       </div>
 

--- a/app/views/spotlight/shared/_honeypot_field.html.erb
+++ b/app/views/spotlight/shared/_honeypot_field.html.erb
@@ -1,4 +1,4 @@
 <div style="display:none;visibility:hidden;">
-  <% honeypot_field_name = Spotlight::Engine.config.spambot_honeypot_email_field %>
+  <% honeypot_field_name = Spotlight::Engine.config.spotlight.spambot_honeypot_email_field %>
   <%= f.email_field honeypot_field_name, label: t(:'spotlight.shared.report_a_problem.honeypot_field_explanation') %>
 </div>

--- a/app/views/spotlight/sites/edit.html.erb
+++ b/app/views/spotlight/sites/edit.html.erb
@@ -18,7 +18,7 @@
       <div role="tabpanel" class="tab-pane" id="site-masthead">
         <p class="instructions"><%= t(:'.site_masthead.help') %></p>
         <%= f.fields_for(:masthead, @site.masthead || @site.build_masthead) do |m| %>
-          <%= render '/spotlight/featured_images/upload_form', f: m, initial_crop_selection: Spotlight::Engine.config.masthead_initial_crop_selection, crop_type: :masthead %>
+          <%= render '/spotlight/featured_images/upload_form', f: m, initial_crop_selection: Spotlight::Engine.config.spotlight.masthead_initial_crop_selection, crop_type: :masthead %>
         <% end %>
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,7 +61,7 @@ Spotlight::Engine.routes.draw do
               except: [:index],
               path: '/catalog',
               controller: 'catalog',
-              **Spotlight::Engine.config.routes.solr_documents do
+              **Spotlight::Engine.config.spotlight.routes.solr_documents do
       concerns :exportable
 
       member do

--- a/lib/generators/spotlight/scaffold_resource_generator.rb
+++ b/lib/generators/spotlight/scaffold_resource_generator.rb
@@ -49,7 +49,7 @@ module Spotlight
 
   def inject_configuration
     inject_into_file 'config/initializers/spotlight_initializer.rb' do
-      "\n  Spotlight::Engine.config.external_resources_partials += ['#{file_name}_resources/form']\n"
+      "\n  Spotlight::Engine.config.spotlight.external_resources_partials += ['#{file_name}_resources/form']\n"
     end
   end
 

--- a/lib/generators/spotlight/templates/config/initializers/spotlight_initializer.rb
+++ b/lib/generators/spotlight/templates/config/initializers/spotlight_initializer.rb
@@ -2,49 +2,49 @@
 
 # ==> User model
 # Note that your chosen model must include Spotlight::User mixin
-# Spotlight::Engine.config.user_class = '::User'
+# Spotlight::Engine.config.spotlight.user_class = '::User'
 
 # ==> Blacklight configuration
 # Spotlight uses this upstream configuration to populate settings for the curator
-# Spotlight::Engine.config.catalog_controller_class = '::CatalogController'
-# Spotlight::Engine.config.default_blacklight_config = nil
+# Spotlight::Engine.config.spotlight.catalog_controller_class = '::CatalogController'
+# Spotlight::Engine.config.spotlight.default_blacklight_config = nil
 
 # ==> Appearance configuration
-# Spotlight::Engine.config.exhibit_main_navigation = [:curated_features, :browse, :about]
-# Spotlight::Engine.config.resource_partials = [
+# Spotlight::Engine.config.spotlight.exhibit_main_navigation = [:curated_features, :browse, :about]
+# Spotlight::Engine.config.spotlight.resource_partials = [
 #   'spotlight/resources/external_resources_form',
 #   'spotlight/resources/upload/form',
 #   'spotlight/resources/csv_upload/form',
 #   'spotlight/resources/json_upload/form'
 # ]
-# Spotlight::Engine.config.external_resources_partials = []
-# Spotlight::Engine.config.default_browse_index_view_type = :gallery
-# Spotlight::Engine.config.default_contact_email = nil
+# Spotlight::Engine.config.spotlight.external_resources_partials = []
+# Spotlight::Engine.config.spotlight.default_browse_index_view_type = :gallery
+# Spotlight::Engine.config.spotlight.default_contact_email = nil
 
 # ==> IIIF configuration
-# Spotlight::Engine.config.iiif_service = Spotlight::RIIIFService
+# Spotlight::Engine.config.spotlight.iiif_service = Spotlight::RIIIFService
 
 # ==> Solr configuration
-# Spotlight::Engine.config.writable_index = true
-# Spotlight::Engine.config.solr_batch_size = 20
-# Spotlight::Engine.config.filter_resources_by_exhibit = true
-# Spotlight::Engine.config.autocomplete_search_field = 'autocomplete'
-# Spotlight::Engine.config.default_autocomplete_params = { qf: 'id^1000 full_title_tesim^100 id_ng full_title_ng' }
+# Spotlight::Engine.config.spotlight.writable_index = true
+# Spotlight::Engine.config.spotlight.solr_batch_size = 20
+# Spotlight::Engine.config.spotlight.filter_resources_by_exhibit = true
+# Spotlight::Engine.config.spotlight.autocomplete_search_field = 'autocomplete'
+# Spotlight::Engine.config.spotlight.default_autocomplete_params = { qf: 'id^1000 full_title_tesim^100 id_ng full_title_ng' }
 
 # Solr field configurations
-# Spotlight::Engine.config.solr_fields.prefix = ''.freeze
-# Spotlight::Engine.config.solr_fields.boolean_suffix = '_bsi'.freeze
-# Spotlight::Engine.config.solr_fields.string_suffix = '_ssim'.freeze
-# Spotlight::Engine.config.solr_fields.text_suffix = '_tesim'.freeze
-# Spotlight::Engine.config.resource_global_id_field = :"#{config.solr_fields.prefix}spotlight_resource_id#{config.solr_fields.string_suffix}"
-# Spotlight::Engine.config.full_image_field = :full_image_url_ssm
-# Spotlight::Engine.config.thumbnail_field = :thumbnail_url_ssm
+# Spotlight::Engine.config.spotlight.solr_fields.prefix = ''.freeze
+# Spotlight::Engine.config.spotlight.solr_fields.boolean_suffix = '_bsi'.freeze
+# Spotlight::Engine.config.spotlight.solr_fields.string_suffix = '_ssim'.freeze
+# Spotlight::Engine.config.spotlight.solr_fields.text_suffix = '_tesim'.freeze
+# Spotlight::Engine.config.spotlight.resource_global_id_field = :"#{Spotlight::Engine.config.spotlight.solr_fields.prefix}spotlight_resource_id#{Spotlight::Engine.config.spotlight.solr_fields.string_suffix}"
+# Spotlight::Engine.config.spotlight.full_image_field = :full_image_url_ssm
+# Spotlight::Engine.config.spotlight.thumbnail_field = :thumbnail_url_ssm
 
 # ==> Uploaded item configuration
-# Spotlight::Engine.config.upload_fields = [
+# Spotlight::Engine.config.spotlight.upload_fields = [
 #   Spotlight::UploadFieldConfig.new(
-#     field_name: Spotlight::Engine.config.upload_description_field,
-#     label: -> { I18n.t(:"spotlight.search.fields.#{Spotlight::Engine.config.upload_description_field}") },
+#     field_name: Spotlight::Engine.config.spotlight.upload_description_field,
+#     label: -> { I18n.t(:"spotlight.search.fields.#{Spotlight::Engine.config.spotlight.upload_description_field}") },
 #     form_field_type: :text_area
 #   ),
 #   Spotlight::UploadFieldConfig.new(
@@ -56,12 +56,12 @@
 #     label: -> { I18n.t(:'spotlight.search.fields.spotlight_upload_date_tesim') }
 #   )
 # ]
-# Spotlight::Engine.config.upload_title_field = nil # Spotlight::UploadFieldConfig.new(...)
-# Spotlight::Engine.config.uploader_storage = :file
-# Spotlight::Engine.config.allowed_upload_extensions = %w(jpg jpeg png)
+# Spotlight::Engine.config.spotlight.upload_title_field = nil # Spotlight::UploadFieldConfig.new(...)
+# Spotlight::Engine.config.spotlight.uploader_storage = :file
+# Spotlight::Engine.config.spotlight.allowed_upload_extensions = %w(jpg jpeg png)
 
-# Spotlight::Engine.config.featured_image_thumb_size = [400, 300]
-# Spotlight::Engine.config.featured_image_square_size = [400, 400]
+# Spotlight::Engine.config.spotlight.featured_image_thumb_size = [400, 300]
+# Spotlight::Engine.config.spotlight.featured_image_square_size = [400, 400]
 
 # ==> Google Analytics integration
 # After creating a property for your site on Google Analytics, you need to:
@@ -75,31 +75,31 @@
 # ga_property_id is used for fetching analytics data from google's api, ga_web_property_id is used for sending events to GA analtyics
 # ga_web_property_id will probably change in V5 to ga_measurement_id for clarity
 # Rails.application.config.to_prepare do
-#   Spotlight::Engine.config.analytics_provider = Spotlight::Analytics::Ga
-#   Spotlight::Engine.config.ga_json_key_path = nil
-#   Spotlight::Engine.config.ga_web_property_id = 'G-XXXXXXXXXX'
-#   Spotlight::Engine.config.ga_property_id = '12345678'
-#   Spotlight::Engine.config.ga_date_range = { 'start_date' => nil, 'end_date' => nil }
-#   Spotlight::Engine.config.ga_analytics_options = {}
-#   Spotlight::Engine.config.ga_page_analytics_options = Spotlight::Engine.config.ga_analytics_options.merge(limit: 5)
-#   Spotlight::Engine.config.ga_search_analytics_options = Spotlight::Engine.config.ga_analytics_options.merge(limit: 11)
-#   Spotlight::Engine.config.ga_debug_mode = false
+#   Spotlight::Engine.config.spotlight.analytics_provider = Spotlight::Analytics::Ga
+#   Spotlight::Engine.config.spotlight.ga_json_key_path = nil
+#   Spotlight::Engine.config.spotlight.ga_web_property_id = 'G-XXXXXXXXXX'
+#   Spotlight::Engine.config.spotlight.ga_property_id = '12345678'
+#   Spotlight::Engine.config.spotlight.ga_date_range = { 'start_date' => nil, 'end_date' => nil }
+#   Spotlight::Engine.config.spotlight.ga_analytics_options = {}
+#   Spotlight::Engine.config.spotlight.ga_page_analytics_options = Spotlight::Engine.config.spotlight.ga_analytics_options.merge(limit: 5)
+#   Spotlight::Engine.config.spotlight.ga_search_analytics_options = Spotlight::Engine.config.spotlight.ga_analytics_options.merge(limit: 11)
+#   Spotlight::Engine.config.spotlight.ga_debug_mode = false
 # end
 
 # ==> Customizable settings for site tags
 # When set the free text tag list field becomes multiple selection checklist
-# Spotlight::Engine.config.site_tags = []
+# Spotlight::Engine.config.spotlight.site_tags = []
 
 # ==> Sir Trevor Widget Configuration
 # These are set by default by Spotlight's configuration,
 # but you can customize them here, or in the SirTrevorRails::Block#custom_block_types method
-# Spotlight::Engine.config.sir_trevor_widgets = %w(
+# Spotlight::Engine.config.spotlight.sir_trevor_widgets = %w(
 #   Heading Text List Quote Iframe Video Oembed Rule UploadedItems Browse BrowseGroupCategories LinkToSearch
 #   FeaturedPages SolrDocuments SolrDocumentsCarousel SolrDocumentsEmbed
 #   SolrDocumentsFeatures SolrDocumentsGrid SearchResults
 # )
 #
 # Page configurations made available to widgets
-# Spotlight::Engine.config.page_configurations = {
+# Spotlight::Engine.config.spotlight.page_configurations = {
 #   'my-local-config': ->(context) { context.my_custom_data_path(context.current_exhibit) }
 # }

--- a/lib/migration/iiif.rb
+++ b/lib/migration/iiif.rb
@@ -69,7 +69,7 @@ module Migration
 
       old_file = File.new(filepath)
       image = contact.create_avatar { |i| i.image.store!(old_file) }
-      iiif_tilesource = Spotlight::Engine.config.iiif_service.info_url(image)
+      iiif_tilesource = Spotlight::Engine.config.spotlight.iiif_service.info_url(image)
       image.update(iiif_tilesource:, iiif_region: avatar_coordinates(contact))
       image
     end
@@ -83,7 +83,7 @@ module Migration
 
       old_file = File.new(filepath)
       image = upload.create_upload { |i| i.image.store!(old_file) }
-      iiif_tilesource = Spotlight::Engine.config.iiif_service.info_url(image)
+      iiif_tilesource = Spotlight::Engine.config.spotlight.iiif_service.info_url(image)
       image.update(iiif_tilesource:)
       upload.upload_id = image.id
       upload.save_and_index
@@ -91,7 +91,7 @@ module Migration
 
     def update_iiif_url(image)
       image.update(
-        iiif_tilesource: Spotlight::Engine.config.iiif_service.info_url(image),
+        iiif_tilesource: Spotlight::Engine.config.spotlight.iiif_service.info_url(image),
         iiif_region: coordinates(image)
       )
     end

--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -69,79 +69,86 @@ module Spotlight
       end
     end
 
+    # All Spotlight-specific configuration is encapsulated onto a single
+    # +spotlight+ entry in the Rails configuration namespace, rather than
+    # polluting the shared Railtie::Configuration namespace. Other railties
+    # follow the same convention.
+    spotlight_config = OpenStruct.new
+    config.spotlight = spotlight_config
+
     def self.user_class
-      Spotlight::Engine.config.user_class.constantize
+      Spotlight::Engine.config.spotlight.user_class.constantize
     end
 
     def self.catalog_controller
-      Spotlight::Engine.config.catalog_controller_class.constantize
+      Spotlight::Engine.config.spotlight.catalog_controller_class.constantize
     end
 
     def self.blacklight_config
-      Spotlight::Engine.config.default_blacklight_config || catalog_controller.blacklight_config
+      Spotlight::Engine.config.spotlight.default_blacklight_config || catalog_controller.blacklight_config
     end
 
-    config.user_class = '::User'
+    spotlight_config.user_class = '::User'
 
-    config.catalog_controller_class = '::CatalogController'
-    config.default_blacklight_config = nil
+    spotlight_config.catalog_controller_class = '::CatalogController'
+    spotlight_config.default_blacklight_config = nil
 
-    config.exhibit_main_navigation = %i[curated_features browse about]
+    spotlight_config.exhibit_main_navigation = %i[curated_features browse about]
 
-    config.resource_partials = [
+    spotlight_config.resource_partials = [
       'spotlight/resources/external_resources_form',
       'spotlight/resources/upload/form',
       'spotlight/resources/csv_upload/form',
       'spotlight/resources/json_upload/form',
       'spotlight/resources/iiif/form'
     ]
-    config.external_resources_partials = []
-    config.solr_batch_size = 20
+    spotlight_config.external_resources_partials = []
+    spotlight_config.solr_batch_size = 20
 
-    Spotlight::Engine.config.reindex_progress_window = 1.hour
+    spotlight_config.reindex_progress_window = 1.hour
 
     # Filter resources by exhibit by default
-    config.filter_resources_by_exhibit = true
+    spotlight_config.filter_resources_by_exhibit = true
 
     # Should Spotlight write to solr? If set to false, Spotlight will not initiate indexing.
-    config.writable_index = true
+    spotlight_config.writable_index = true
 
     # The allowed file extensions for uploading non-repository items.
-    config.allowed_upload_extensions = %w[jpg jpeg png]
+    spotlight_config.allowed_upload_extensions = %w[jpg jpeg png]
 
     # IIIF integration
-    config.iiif_service = Spotlight::RiiifService
+    spotlight_config.iiif_service = Spotlight::RiiifService
 
     # Suffixes for spotlight-created solr fields
-    config.solr_fields = OpenStruct.new
-    config.solr_fields.prefix = ''
-    config.solr_fields.boolean_suffix = '_bsi'
-    config.solr_fields.string_suffix = '_ssim'
-    config.solr_fields.text_suffix = '_tesim'
+    spotlight_config.solr_fields = OpenStruct.new
+    spotlight_config.solr_fields.prefix = ''
+    spotlight_config.solr_fields.boolean_suffix = '_bsi'
+    spotlight_config.solr_fields.string_suffix = '_ssim'
+    spotlight_config.solr_fields.text_suffix = '_tesim'
 
     # Suffixes for exhibit-specific solr fields
-    config.custom_field_types = {
+    spotlight_config.custom_field_types = {
       vocab: { suffix: '_ssim', facetable: true },
       text: { suffix: '_tesim' }
     }
 
-    config.resource_global_id_field = :"#{config.solr_fields.prefix}spotlight_resource_id#{config.solr_fields.string_suffix}"
-    config.job_tracker_id_field = :"#{config.solr_fields.prefix}spotlight_job_tracker_id#{config.solr_fields.string_suffix}"
+    spotlight_config.resource_global_id_field = :"#{spotlight_config.solr_fields.prefix}spotlight_resource_id#{spotlight_config.solr_fields.string_suffix}"
+    spotlight_config.job_tracker_id_field = :"#{spotlight_config.solr_fields.prefix}spotlight_job_tracker_id#{spotlight_config.solr_fields.string_suffix}"
 
     # Set to nil if you don't want to pull thumbnails from the index
-    config.full_image_field = :full_image_url_ssm
-    config.thumbnail_field = :thumbnail_url_ssm
+    spotlight_config.full_image_field = :full_image_url_ssm
+    spotlight_config.thumbnail_field = :thumbnail_url_ssm
 
-    Spotlight::Engine.config.site_tags = nil
+    spotlight_config.site_tags = nil
 
     # Defaults to the blacklight_config.index.title_field:
-    config.upload_title_field = nil # UploadFieldConfig.new(...)
-    config.upload_description_field = :spotlight_upload_description_tesim
+    spotlight_config.upload_title_field = nil # UploadFieldConfig.new(...)
+    spotlight_config.upload_description_field = :spotlight_upload_description_tesim
 
-    config.upload_fields = [
+    spotlight_config.upload_fields = [
       UploadFieldConfig.new(
-        field_name: config.upload_description_field,
-        label: -> { I18n.t(:"spotlight.search.fields.#{config.upload_description_field}") },
+        field_name: spotlight_config.upload_description_field,
+        label: -> { I18n.t(:"spotlight.search.fields.#{Spotlight::Engine.config.spotlight.upload_description_field}") },
         form_field_type: :text_area
       ),
       UploadFieldConfig.new(
@@ -154,39 +161,38 @@ module Spotlight
       )
     ]
 
-    config.iiif_manifest_field = :iiif_manifest_url_ssi
-    config.iiif_metadata_class = -> { Spotlight::Resources::IiifManifestMetadata }
-    config.iiif_collection_id_field = :collection_id_ssim
-    config.iiif_title_fields = nil
-    config.default_json_ld_language = 'en'
+    spotlight_config.iiif_manifest_field = :iiif_manifest_url_ssi
+    spotlight_config.iiif_metadata_class = -> { Spotlight::Resources::IiifManifestMetadata }
+    spotlight_config.iiif_collection_id_field = :collection_id_ssim
+    spotlight_config.iiif_title_fields = nil
+    spotlight_config.default_json_ld_language = 'en'
 
-    config.masthead_initial_crop_selection = [1200, 120]
-    config.thumbnail_initial_crop_selection = [120, 120]
+    spotlight_config.masthead_initial_crop_selection = [1200, 120]
+    spotlight_config.thumbnail_initial_crop_selection = [120, 120]
 
     # Configure the CarrierWave file storage mechanism
-    config.uploader_storage = :file
-    config.featured_image_masthead_size = [1800, 180]
-    config.featured_image_thumb_size = [400, 300]
-    config.featured_image_square_size = [400, 400]
-    config.contact_square_size = [70, 70]
+    spotlight_config.uploader_storage = :file
+    spotlight_config.featured_image_masthead_size = [1800, 180]
+    spotlight_config.featured_image_thumb_size = [400, 300]
+    spotlight_config.featured_image_square_size = [400, 400]
+    spotlight_config.contact_square_size = [70, 70]
 
     # Additional page configurations to be made available to page editing widgets
     # See Spotlight::PageConfigurations
-    config.page_configurations = {}
+    spotlight_config.page_configurations = {}
 
     # To present curators with analytics reports on the exhibit dashboard, you need to configure
     # an Analytics provider. Google Analytics support is provided out-of-the-box.
-    config.analytics_provider = nil
+    spotlight_config.analytics_provider = nil
 
     initializer 'analytics.initialize' do
       ActiveSupport::Reloader.to_prepare do
-        Spotlight::Engine.config.analytics_provider = Spotlight::Analytics::Ga
+        Spotlight::Engine.config.spotlight.analytics_provider = Spotlight::Analytics::Ga
       end
     end
 
     initializer 'components.initialize' do
       ActiveSupport::Reloader.to_prepare do
-        Spotlight::Engine.config.spotlight = OpenStruct.new
         Spotlight::Engine.config.spotlight.header_navigation_link_component = Spotlight::HeaderNavigationLinkComponent
         Spotlight::Engine.config.spotlight.title_component = Spotlight::TitleComponent
       end
@@ -200,19 +206,19 @@ module Spotlight
     # d) Set the ga_web_property_id. (located in admin -> Data collection and modification -> Web stream details and begins with G-)
     # ga_property_id is used for fetching analytics data from google's api, ga_web_property_id is used for sending events to GA analtyics
     # ga_web_property_id will probably change in V5 to ga_measurement_id for clarity
-    config.ga_json_key_path = nil
-    config.ga_web_property_id = nil
-    config.ga_property_id = nil
-    config.ga_analytics_options = {}
-    config.ga_page_analytics_options = config.ga_analytics_options.merge(limit: 5)
-    config.ga_date_range = { 'start_date' => nil, 'end_date' => nil }
-    config.ga_debug_mode = false
+    spotlight_config.ga_json_key_path = nil
+    spotlight_config.ga_web_property_id = nil
+    spotlight_config.ga_property_id = nil
+    spotlight_config.ga_analytics_options = {}
+    spotlight_config.ga_page_analytics_options = spotlight_config.ga_analytics_options.merge(limit: 5)
+    spotlight_config.ga_date_range = { 'start_date' => nil, 'end_date' => nil }
+    spotlight_config.ga_debug_mode = false
 
-    config.max_pages = 1000
+    spotlight_config.max_pages = 1000
 
     Blacklight::Engine.config.inject_blacklight_helpers = false
 
-    config.i18n_locales = {
+    spotlight_config.i18n_locales = {
       ar: 'العربية',
       de: 'Deutsch',
       en: 'English',
@@ -228,7 +234,7 @@ module Spotlight
 
     # Whitelisting the available_locales is necessary here, as any dependency we
     # add could add an available locale which could break things if unexpected.
-    config.i18n.available_locales = config.i18n_locales.keys
+    config.i18n.available_locales = spotlight_config.i18n_locales.keys
 
     # Copy of JbuilderHandler tweaked to spit out YAML for translation exports
     class TranslationYamlHandler
@@ -250,17 +256,17 @@ module Spotlight
     end
 
     # Query parameters for autocomplete requests
-    config.autocomplete_search_field = 'autocomplete'
-    config.default_autocomplete_params = { qf: 'id^1000 full_title_tesim^100 id_ng full_title_ng',
-                                           facet: false,
-                                           'facet.field' => [] }
+    spotlight_config.autocomplete_search_field = 'autocomplete'
+    spotlight_config.default_autocomplete_params = { qf: 'id^1000 full_title_tesim^100 id_ng full_title_ng',
+                                                     facet: false,
+                                                     'facet.field' => [] }
 
-    config.default_browse_index_view_type = :gallery
+    spotlight_config.default_browse_index_view_type = :gallery
 
     # default email address to send "Report a Problem" feedback to (in addition to any exhibit-specific contacts)
-    config.default_contact_email = nil
+    spotlight_config.default_contact_email = nil
 
-    config.spambot_honeypot_email_field = :email_address
+    spotlight_config.spambot_honeypot_email_field = :email_address
 
     Blacklight::Configuration.default_configuration do
       # Field containing the last modified date for a Solr document
@@ -279,24 +285,24 @@ module Spotlight
     Blacklight::OpenStructWithHashAccess.send(:extend, ActiveModel::Translation)
     # rubocop:enable Lint/SendWithMixinArgument
 
-    config.exhibit_themes = ['default']
+    spotlight_config.exhibit_themes = ['default']
 
-    config.default_page_content_type = 'SirTrevor'
+    spotlight_config.default_page_content_type = 'SirTrevor'
 
     # Added here for backwards compatability with SirTrevor 0.6
     # and apps who have customized their avaialble widgets
-    config.sir_trevor_widgets = %w[
+    spotlight_config.sir_trevor_widgets = %w[
       Heading Text List Quote Iframe Video Oembed Rule UploadedItems Browse BrowseGroupCategories LinkToSearch
       FeaturedPages SolrDocuments SolrDocumentsCarousel SolrDocumentsEmbed
       SolrDocumentsFeatures SolrDocumentsGrid SearchResults
     ]
 
-    config.routes = OpenStruct.new
-    config.routes.solr_documents = {}
+    spotlight_config.routes = OpenStruct.new
+    spotlight_config.routes.solr_documents = {}
 
-    config.controller_tracking_method = 'track_catalog_path'
+    spotlight_config.controller_tracking_method = 'track_catalog_path'
 
-    config.exports = {
+    spotlight_config.exports = {
       attachments: true,
       blacklight_configuration: true,
       config: true,
@@ -304,22 +310,22 @@ module Spotlight
       resources: true
     }
 
-    config.reindexing_batch_size = nil
-    config.reindexing_batch_count = nil
-    config.hidden_job_classes = %w[Spotlight::ReindexJob]
+    spotlight_config.reindexing_batch_size = nil
+    spotlight_config.reindexing_batch_count = nil
+    spotlight_config.hidden_job_classes = %w[Spotlight::ReindexJob]
 
-    config.bulk_actions_batch_size = 1000
+    spotlight_config.bulk_actions_batch_size = 1000
 
-    config.bulk_updates = OpenStruct.new
-    config.bulk_updates.csv_id = 'Item ID'
-    config.bulk_updates.csv_title = 'Item Title'
-    config.bulk_updates.csv_visibility = 'Visibility'
-    config.bulk_updates.csv_tags_prefix = 'Tag:'
-    config.bulk_updates.csv_tags = 'Tag: %s'
+    spotlight_config.bulk_updates = OpenStruct.new
+    spotlight_config.bulk_updates.csv_id = 'Item ID'
+    spotlight_config.bulk_updates.csv_title = 'Item Title'
+    spotlight_config.bulk_updates.csv_visibility = 'Visibility'
+    spotlight_config.bulk_updates.csv_tags_prefix = 'Tag:'
+    spotlight_config.bulk_updates.csv_tags = 'Tag: %s'
 
-    config.assign_default_roles_to_first_user = true
+    spotlight_config.assign_default_roles_to_first_user = true
 
-    config.exhibit_roles = %w[admin curator viewer]
+    spotlight_config.exhibit_roles = %w[admin curator viewer]
     # PaperTrail serializes objects to YAML, so we need to permit these classes to be deserialized
     ActiveRecord.yaml_column_permitted_classes += [ActiveSupport::HashWithIndifferentAccess,
                                                    ActiveSupport::TimeWithZone,

--- a/lib/spotlight/upload_field_config.rb
+++ b/lib/spotlight/upload_field_config.rb
@@ -4,7 +4,7 @@ module Spotlight
   ##
   # A class to model the configuration required to build the Document Upload form.
   # This configuration is also used in other places around the application (e.g. Metadata Field Config)
-  # See Spotlight::Engine.config.upload_fields for where this is consumed
+  # See Spotlight::Engine.config.spotlight.upload_fields for where this is consumed
   # We should look into changing this to a standard blacklight field config in Blacklight 7
   class UploadFieldConfig
     attr_reader :blacklight_options, :field_name, :form_field_type

--- a/lib/tasks/spotlight_tasks.rake
+++ b/lib/tasks/spotlight_tasks.rake
@@ -144,7 +144,7 @@ namespace :spotlight do
       print ' - atomic updates:'
       begin
         id = 'test123'
-        field = "test_#{Spotlight::Engine.config.solr_fields.string_suffix}"
+        field = "test_#{Spotlight::Engine.config.spotlight.solr_fields.string_suffix}"
         sample_doc = { Spotlight::Engine.blacklight_config.document_model.unique_key => id, field => { set: 'a-new-string' } }
         Blacklight.default_index.connection.add Spotlight::Engine.blacklight_config.document_model.unique_key.to_sym => id, field => 'some-string'
         Blacklight.default_index.connection.update data: [sample_doc].to_json, headers: { 'Content-Type' => 'application/json' }

--- a/spec/components/spotlight/analytics/dashboard_component_spec.rb
+++ b/spec/components/spotlight/analytics/dashboard_component_spec.rb
@@ -98,16 +98,16 @@ RSpec.describe Spotlight::Analytics::DashboardComponent, type: :component do
     end
   end
 
-  context 'Spotlight::Engine.config.ga_date_range is set' do
+  context 'Spotlight::Engine.config.spotlight.ga_date_range is set' do
     let(:start_date) { '2024-04-24' }
     let(:end_date) { '2024-07-24' }
 
     before do
-      Spotlight::Engine.config.ga_date_range = { 'start_date' => Date.new(2024, 4, 24), 'end_date' => Date.new(2024, 7, 24) }
+      Spotlight::Engine.config.spotlight.ga_date_range = { 'start_date' => Date.new(2024, 4, 24), 'end_date' => Date.new(2024, 7, 24) }
     end
 
     after do
-      Spotlight::Engine.config.ga_date_range = { 'start_date' => nil, 'end_date' => nil }
+      Spotlight::Engine.config.spotlight.ga_date_range = { 'start_date' => nil, 'end_date' => nil }
     end
 
     it 'has start and end date selectors' do

--- a/spec/controllers/spotlight/contact_forms_controller_spec.rb
+++ b/spec/controllers/spotlight/contact_forms_controller_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Spotlight::ContactFormsController, type: :controller do
   routes { Spotlight::Engine.routes }
   let(:exhibit) { FactoryBot.create(:exhibit) }
-  let(:honeypot_field_name) { Spotlight::Engine.config.spambot_honeypot_email_field }
+  let(:honeypot_field_name) { Spotlight::Engine.config.spotlight.spambot_honeypot_email_field }
 
   before do
     request.env['HTTP_REFERER'] = '/whatever'

--- a/spec/controllers/spotlight/filters_controller_spec.rb
+++ b/spec/controllers/spotlight/filters_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Spotlight::FiltersController do
     let(:exhibit) { FactoryBot.create(:exhibit) }
 
     before do
-      allow(Spotlight::Engine.config).to receive(:filter_resources_by_exhibit).and_return(false)
+      allow(Spotlight::Engine.config.spotlight).to receive(:filter_resources_by_exhibit).and_return(false)
     end
 
     context 'when not signed in' do
@@ -41,7 +41,7 @@ RSpec.describe Spotlight::FiltersController do
     let(:exhibit_filter) { exhibit.filters.first }
 
     before do
-      allow(Spotlight::Engine.config).to receive(:filter_resources_by_exhibit).and_return(true)
+      allow(Spotlight::Engine.config.spotlight).to receive(:filter_resources_by_exhibit).and_return(true)
     end
 
     context 'when not signed in' do

--- a/spec/controllers/spotlight/solr_controller_spec.rb
+++ b/spec/controllers/spotlight/solr_controller_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Spotlight::SolrController, type: :controller do
 
       context 'when the index is not writable' do
         before do
-          allow(Spotlight::Engine.config).to receive_messages(writable_index: false)
+          allow(Spotlight::Engine.config.spotlight).to receive_messages(writable_index: false)
         end
 
         it 'raises an error' do

--- a/spec/features/autocomplete_typeahead_spec.rb
+++ b/spec/features/autocomplete_typeahead_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Autocomplete typeahead', js: true, type: :feature do
       end
 
       it 'instantiates the multi-image selector when an multi-image item is chosen in the typeahead (and again on edit)' do
-        allow(Spotlight::Engine.config).to receive(:exhibit_themes).and_return(['default'])
+        allow(Spotlight::Engine.config.spotlight).to receive(:exhibit_themes).and_return(['default'])
 
         visit spotlight.edit_exhibit_appearance_path(exhibit)
 
@@ -77,7 +77,7 @@ RSpec.describe 'Autocomplete typeahead', js: true, type: :feature do
 
     context 'for items that do not include a IIIF manifest' do
       before do
-        allow(Spotlight::Engine.config).to receive(:iiif_manifest_field).and_return('not_a_real_field')
+        allow(Spotlight::Engine.config.spotlight).to receive(:iiif_manifest_field).and_return('not_a_real_field')
       end
 
       it 'provides an alert informing the user that they cannot crop from that item' do

--- a/spec/features/exhibits/administration_spec.rb
+++ b/spec/features/exhibits/administration_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe 'Exhibit Administration', type: :feature do
 
   describe 'Tag list' do
     before do
-      allow(Spotlight::Engine.config).to receive(:site_tags).and_return(site_tags)
+      allow(Spotlight::Engine.config.spotlight).to receive(:site_tags).and_return(site_tags)
     end
 
     context 'site_tags are set to a list' do

--- a/spec/features/report_a_problem_spec.rb
+++ b/spec/features/report_a_problem_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe 'Report a Problem', type: :feature do
   let!(:exhibit) { FactoryBot.create(:exhibit) }
-  let(:honeypot_field_name) { Spotlight::Engine.config.spambot_honeypot_email_field }
+  let(:honeypot_field_name) { Spotlight::Engine.config.spotlight.spambot_honeypot_email_field }
 
   it 'does not have a header link' do
     visit root_path

--- a/spec/helpers/spotlight/exhibit_theme_helper_spec.rb
+++ b/spec/helpers/spotlight/exhibit_theme_helper_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Spotlight::ExhibitThemeHelper, type: :helper do
 
     context 'for a themed exhibit' do
       before do
-        allow(Spotlight::Engine.config).to receive(:exhibit_themes).and_return(%w[default modern])
+        allow(Spotlight::Engine.config.spotlight).to receive(:exhibit_themes).and_return(%w[default modern])
         exhibit.update(theme: 'modern')
       end
 

--- a/spec/helpers/spotlight/main_app_helpers_spec.rb
+++ b/spec/helpers/spotlight/main_app_helpers_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Spotlight::MainAppHelpers, type: :helper do
 
     context 'with a default contact address' do
       before do
-        allow(Spotlight::Engine.config).to receive_messages default_contact_email: 'root@localhost'
+        allow(Spotlight::Engine.config.spotlight).to receive_messages default_contact_email: 'root@localhost'
         allow(helper).to receive_messages current_exhibit: exhibit
       end
 

--- a/spec/jobs/spotlight/add_tags_job_spec.rb
+++ b/spec/jobs/spotlight/add_tags_job_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Spotlight::AddTagsJob do
   let(:tags) { 'hello,world' }
 
   before do
-    allow(Spotlight::Engine.config).to receive_messages(bulk_actions_batch_size: 5)
+    allow(Spotlight::Engine.config.spotlight).to receive_messages(bulk_actions_batch_size: 5)
   end
 
   it 'adds tags to SolrDocumentSidecar objects' do

--- a/spec/jobs/spotlight/change_visibility_job_spec.rb
+++ b/spec/jobs/spotlight/change_visibility_job_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Spotlight::ChangeVisibilityJob do
   let(:visibility) { 'private' }
 
   before do
-    allow(Spotlight::Engine.config).to receive_messages(bulk_actions_batch_size: 5)
+    allow(Spotlight::Engine.config.spotlight).to receive_messages(bulk_actions_batch_size: 5)
   end
 
   it 'sets the items based off of the visibility' do

--- a/spec/jobs/spotlight/remove_tags_job_spec.rb
+++ b/spec/jobs/spotlight/remove_tags_job_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Spotlight::RemoveTagsJob do
   let(:tags) { %w[hello world] }
 
   before do
-    allow(Spotlight::Engine.config).to receive_messages(bulk_actions_batch_size: 5)
+    allow(Spotlight::Engine.config.spotlight).to receive_messages(bulk_actions_batch_size: 5)
   end
 
   it 'removes tags from SolrDocumentSidecar objects' do

--- a/spec/models/spotlight/access_controls_enforcement_search_builder_spec.rb
+++ b/spec/models/spotlight/access_controls_enforcement_search_builder_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Spotlight::AccessControlsEnforcementSearchBuilder do
   describe '#apply_exhibit_resources_filter' do
     context 'with filter_resources_by_exhibit' do
       before do
-        allow(Spotlight::Engine.config).to receive(:filter_resources_by_exhibit).and_return(true)
+        allow(Spotlight::Engine.config.spotlight).to receive(:filter_resources_by_exhibit).and_return(true)
       end
 
       it 'filters resources to just those created by the exhibit' do

--- a/spec/models/spotlight/analytics/ga_spec.rb
+++ b/spec/models/spotlight/analytics/ga_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Spotlight::Analytics::Ga do
 
   describe '#client' do
     it 'selects the correct profile based on the web property id' do
-      allow(Spotlight::Engine.config).to receive_messages(ga_property_id: 'bar')
+      allow(Spotlight::Engine.config.spotlight).to receive_messages(ga_property_id: 'bar')
       expect(subject.send(:ga_property_id)).to eq 'bar'
     end
   end

--- a/spec/models/spotlight/blacklight_configuration_spec.rb
+++ b/spec/models/spotlight/blacklight_configuration_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Spotlight::BlacklightConfiguration, type: :model do
   end
 
   it 'adds a default thumbnail field' do
-    expect(subject.blacklight_config.index.thumbnail_field).to eq Spotlight::Engine.config.thumbnail_field
+    expect(subject.blacklight_config.index.thumbnail_field).to eq Spotlight::Engine.config.spotlight.thumbnail_field
   end
 
   describe 'facet fields' do
@@ -590,7 +590,7 @@ RSpec.describe Spotlight::BlacklightConfiguration, type: :model do
 
     context 'with the default search field' do
       let(:search_field) do
-        subject.blacklight_config.search_fields[Spotlight::Engine.config.autocomplete_search_field]
+        subject.blacklight_config.search_fields[Spotlight::Engine.config.spotlight.autocomplete_search_field]
       end
 
       it 'is hidden from the search field selector' do
@@ -598,7 +598,7 @@ RSpec.describe Spotlight::BlacklightConfiguration, type: :model do
       end
 
       it "uses the engine's autocomplete parameters" do
-        expect(search_field.solr_parameters).to include Spotlight::Engine.config.default_autocomplete_params
+        expect(search_field.solr_parameters).to include Spotlight::Engine.config.spotlight.default_autocomplete_params
       end
 
       it 'includes the relevant fields' do

--- a/spec/models/spotlight/contact_form_spec.rb
+++ b/spec/models/spotlight/contact_form_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Spotlight::ContactForm do
   subject { described_class.new(name: 'Root', email: 'user@example.com') }
 
   let(:exhibit) { FactoryBot.build_stubbed(:exhibit) }
-  let(:honeypot_field_name) { Spotlight::Engine.config.spambot_honeypot_email_field }
+  let(:honeypot_field_name) { Spotlight::Engine.config.spotlight.spambot_honeypot_email_field }
 
   describe 'the email subject' do
     it 'has a subject' do
@@ -34,10 +34,10 @@ RSpec.describe Spotlight::ContactForm do
   end
 
   context 'with a site-wide contact email' do
-    before { allow(Spotlight::Engine.config).to receive_messages default_contact_email: 'root@localhost' }
+    before { allow(Spotlight::Engine.config.spotlight).to receive_messages default_contact_email: 'root@localhost' }
 
     it 'sends the email to the configured contact' do
-      expect(subject.headers[:to]).to eq Spotlight::Engine.config.default_contact_email
+      expect(subject.headers[:to]).to eq Spotlight::Engine.config.spotlight.default_contact_email
     end
 
     context 'with exhibit-specific contacts' do

--- a/spec/models/spotlight/custom_field_spec.rb
+++ b/spec/models/spotlight/custom_field_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe Spotlight::CustomField, type: :model do
 
     context 'with a solr field prefix configured' do
       before do
-        allow(Spotlight::Engine.config.solr_fields).to receive(:prefix).and_return 'prefix_'
+        allow(Spotlight::Engine.config.spotlight.solr_fields).to receive(:prefix).and_return 'prefix_'
       end
 
       it 'uses the solr field prefix' do

--- a/spec/models/spotlight/exhibit_spec.rb
+++ b/spec/models/spotlight/exhibit_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Spotlight::Exhibit, type: :model do
     end
 
     it "uses the engine's configuration for default navigations" do
-      expect(Spotlight::Engine.config).to receive(:exhibit_main_navigation).and_return(%i[a b])
+      expect(Spotlight::Engine.config.spotlight).to receive(:exhibit_main_navigation).and_return(%i[a b])
       expect(subject.main_navigations).to have(2).main_navigations
       expect(subject.main_navigations.map(&:nav_type).compact).to match_array %w[a b]
     end
@@ -128,7 +128,7 @@ RSpec.describe Spotlight::Exhibit, type: :model do
   describe '#themes' do
     context 'when no themes_selector proc is set' do
       it 'is the configured themes' do
-        expect(subject.themes).to eq Spotlight::Engine.config.exhibit_themes
+        expect(subject.themes).to eq Spotlight::Engine.config.spotlight.exhibit_themes
       end
     end
 
@@ -180,7 +180,7 @@ RSpec.describe Spotlight::Exhibit, type: :model do
 
     context 'when not filtering by exhibit' do
       before do
-        allow(Spotlight::Engine.config).to receive(:filter_resources_by_exhibit).and_return(false)
+        allow(Spotlight::Engine.config.spotlight).to receive(:filter_resources_by_exhibit).and_return(false)
       end
 
       it 'is blank' do
@@ -190,7 +190,7 @@ RSpec.describe Spotlight::Exhibit, type: :model do
 
     context 'when no filters have been defined' do
       before do
-        allow(Spotlight::Engine.config).to receive(:filter_resources_by_exhibit).and_return(true)
+        allow(Spotlight::Engine.config.spotlight).to receive(:filter_resources_by_exhibit).and_return(true)
       end
 
       it 'provides a solr field with the exhibit slug' do
@@ -281,7 +281,7 @@ RSpec.describe Spotlight::Exhibit, type: :model do
 
     context 'with filter_resources_by_exhibit enabled' do
       before do
-        allow(Spotlight::Engine.config).to receive(:filter_resources_by_exhibit).and_return(true)
+        allow(Spotlight::Engine.config.spotlight).to receive(:filter_resources_by_exhibit).and_return(true)
       end
 
       it 'filters the solr results using the exhibit filter' do
@@ -293,7 +293,7 @@ RSpec.describe Spotlight::Exhibit, type: :model do
 
     context 'with filter_resources_by_exhibit disabled' do
       before do
-        allow(Spotlight::Engine.config).to receive(:filter_resources_by_exhibit).and_return(false)
+        allow(Spotlight::Engine.config.spotlight).to receive(:filter_resources_by_exhibit).and_return(false)
       end
 
       it 'does not filters the solr results' do

--- a/spec/models/spotlight/resources/iiif_harvester_spec.rb
+++ b/spec/models/spotlight/resources/iiif_harvester_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Spotlight::Resources::IiifHarvester do
 
     before do
       stub_default_collection
-      allow(Spotlight::Engine.config).to receive(:writable_index).and_return(false)
+      allow(Spotlight::Engine.config.spotlight).to receive(:writable_index).and_return(false)
     end
 
     it 'indexes all the solr documents' do

--- a/spec/models/spotlight/resources/iiif_manifest_spec.rb
+++ b/spec/models/spotlight/resources/iiif_manifest_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Spotlight::Resources::IiifManifest do
       end
 
       it 'indexes to multiple fields when configured' do
-        allow(Spotlight::Engine.config).to receive(:iiif_title_fields).at_least(:once).and_return(%w[title_field1 title_field2])
+        allow(Spotlight::Engine.config.spotlight).to receive(:iiif_title_fields).at_least(:once).and_return(%w[title_field1 title_field2])
 
         expect(subject.to_solr['title_field1']).to eq 'Test Manifest 1'
         expect(subject.to_solr['title_field2']).to eq 'Test Manifest 1'
@@ -56,7 +56,7 @@ RSpec.describe Spotlight::Resources::IiifManifest do
         it 'uses the configured language to find a value' do
           expect(subject.to_solr['full_title_tesim']).to eq 'Test Manifest 3'
 
-          allow(Spotlight::Engine.config).to receive(:default_json_ld_language).and_return('fr')
+          allow(Spotlight::Engine.config.spotlight).to receive(:default_json_ld_language).and_return('fr')
           expect(subject.to_solr['full_title_tesim']).to eq "Manifeste d'essai 3"
         end
       end
@@ -132,7 +132,7 @@ RSpec.describe Spotlight::Resources::IiifManifest do
 
       context 'custom class' do
         before do
-          allow(Spotlight::Engine.config).to receive(:iiif_metadata_class).and_return(-> { TestMetadataClass })
+          allow(Spotlight::Engine.config.spotlight).to receive(:iiif_metadata_class).and_return(-> { TestMetadataClass })
         end
 
         it 'merges the solr hash from the configured custom metadata class' do
@@ -162,13 +162,13 @@ RSpec.describe Spotlight::Resources::IiifManifest do
         end
 
         it 'extracts data using the configured default language' do
-          allow(Spotlight::Engine.config).to receive(:default_json_ld_language).and_return('de')
+          allow(Spotlight::Engine.config.spotlight).to receive(:default_json_ld_language).and_return('de')
           expect(subject.to_solr).to include 'readonly_verfasser_tesim' => ['Murasaki Shikibu -- (GND: 118985655)'],
                                              'readonly_sprache_tesim' => ['Japanisch']
         end
 
         it 'falls back to a language from the manifest using the IIIF rules' do
-          allow(Spotlight::Engine.config).to receive(:default_json_ld_language).and_return('fr')
+          allow(Spotlight::Engine.config.spotlight).to receive(:default_json_ld_language).and_return('fr')
           expect(subject.to_solr).to include 'readonly_verfasser_tesim' => ['Murasaki Shikibu -- (GND: 118985655)'],
                                              'readonly_sprache_tesim' => ['Japanisch']
         end

--- a/spec/models/spotlight/resources/iiif_manifest_v3_spec.rb
+++ b/spec/models/spotlight/resources/iiif_manifest_v3_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Spotlight::Resources::IiifManifestV3 do
       end
 
       it 'indexes to multiple fields when configured' do
-        allow(Spotlight::Engine.config).to receive(:iiif_title_fields).at_least(:once).and_return(%w[title_field1 title_field2])
+        allow(Spotlight::Engine.config.spotlight).to receive(:iiif_title_fields).at_least(:once).and_return(%w[title_field1 title_field2])
 
         expect(subject.to_solr['title_field1']).to eq 'A Map of the British and French settlements in North America'
         expect(subject.to_solr['title_field2']).to eq 'A Map of the British and French settlements in North America'
@@ -115,7 +115,7 @@ RSpec.describe Spotlight::Resources::IiifManifestV3 do
 
       context 'custom class' do
         before do
-          allow(Spotlight::Engine.config).to receive(:iiif_metadata_class).and_return(-> { TestMetadataClass })
+          allow(Spotlight::Engine.config.spotlight).to receive(:iiif_metadata_class).and_return(-> { TestMetadataClass })
         end
 
         it 'merges the solr hash from the configured custom metadata class' do
@@ -140,13 +140,13 @@ RSpec.describe Spotlight::Resources::IiifManifestV3 do
         end
 
         it 'extracts data using the configured default language' do
-          allow(Spotlight::Engine.config).to receive(:default_json_ld_language).and_return('fr')
+          allow(Spotlight::Engine.config.spotlight).to receive(:default_json_ld_language).and_return('fr')
           expect(subject.to_solr).to include 'readonly_auteur_tesim' => ['Whistler, James Abbott McNeill'],
                                              'readonly_sujet_tesim' => ['McNeill Anna Matilda, mère de Whistler (1804-1881)']
         end
 
         it 'falls back to a language from the manifest using the IIIF rules' do
-          allow(Spotlight::Engine.config).to receive(:default_json_ld_language).and_return('de')
+          allow(Spotlight::Engine.config.spotlight).to receive(:default_json_ld_language).and_return('de')
           expect(subject.to_solr).to include 'readonly_creator_tesim' => ['Whistler, James Abbott McNeill'],
                                              'readonly_subject_tesim' => ['McNeill Anna Matilda, mother of Whistler (1804-1881)']
         end

--- a/spec/models/spotlight/search_spec.rb
+++ b/spec/models/spotlight/search_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Spotlight::Search, type: :model do
 
     context 'with filter_resources_by_exhibit configured' do
       before do
-        allow(Spotlight::Engine.config).to receive(:filter_resources_by_exhibit).and_return(true)
+        allow(Spotlight::Engine.config.spotlight).to receive(:filter_resources_by_exhibit).and_return(true)
       end
 
       it 'includes the exhibit context' do

--- a/spec/models/spotlight/solr_document/atomic_updates_spec.rb
+++ b/spec/models/spotlight/solr_document/atomic_updates_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Spotlight::SolrDocument::AtomicUpdates, type: :model do
 
     context 'when the index is not writable' do
       before do
-        allow(Spotlight::Engine.config).to receive_messages(writable_index: false)
+        allow(Spotlight::Engine.config.spotlight).to receive_messages(writable_index: false)
       end
 
       it "doesn't write" do

--- a/spec/presenters/spotlight/iiif_manifest_presenter_spec.rb
+++ b/spec/presenters/spotlight/iiif_manifest_presenter_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Spotlight::IiifManifestPresenter do
       allow(controller).to receive(:blacklight_config).and_return(blacklight_config)
 
       allow(resource).to receive(:first).with(title_field_name).and_return(title_field_value)
-      allow(resource).to receive(:first).with(Spotlight::Engine.config.upload_description_field).and_return(description_field_value)
+      allow(resource).to receive(:first).with(Spotlight::Engine.config.spotlight.upload_description_field).and_return(description_field_value)
       allow(resource).to receive(:first).with(:spotlight_full_image_width_ssm).and_return(img_width)
       allow(resource).to receive(:first).with(:spotlight_full_image_height_ssm).and_return(img_height)
 

--- a/spec/routing/spotlight/exhibit_catalog_spec.rb
+++ b/spec/routing/spotlight/exhibit_catalog_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Catalog controller', type: :routing do
 
     context 'when the routing constraint is set to allow periods' do
       before do
-        allow(Spotlight::Engine.config.routes).to receive(:solr_documents).and_return(constraints: { id: %r{[^/]+} })
+        allow(Spotlight::Engine.config.spotlight.routes).to receive(:solr_documents).and_return(constraints: { id: %r{[^/]+} })
         Rails.application.reload_routes!
       end
 

--- a/spec/services/spotlight/exhibit_import_export_service_spec.rb
+++ b/spec/services/spotlight/exhibit_import_export_service_spec.rb
@@ -552,7 +552,7 @@ RSpec.describe Spotlight::ExhibitImportExportService do
     end
 
     before do
-      allow(Spotlight::Engine.config).to receive(:exports).and_return(exports)
+      allow(Spotlight::Engine.config.spotlight).to receive(:exports).and_return(exports)
     end
 
     it 'includes nothing' do
@@ -566,7 +566,7 @@ RSpec.describe Spotlight::ExhibitImportExportService do
     end
 
     before do
-      allow(Spotlight::Engine.config).to receive(:exports).and_return(exports)
+      allow(Spotlight::Engine.config.spotlight).to receive(:exports).and_return(exports)
     end
 
     it 'includes only the page-related data' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,8 +51,8 @@ end
 require 'spotlight'
 
 # configure spotlight with all the settings necessary to test functionality
-Spotlight::Engine.config.reindexing_batch_count = 1
-Spotlight::Engine.config.assign_default_roles_to_first_user = false
+Spotlight::Engine.config.spotlight.reindexing_batch_count = 1
+Spotlight::Engine.config.spotlight.assign_default_roles_to_first_user = false
 
 Dir['./spec/support/**/*.rb'].each { |f| require f }
 

--- a/spec/test_app_templates/catalog_controller.rb
+++ b/spec/test_app_templates/catalog_controller.rb
@@ -42,7 +42,7 @@ class CatalogController < ApplicationController
     # solr field configuration for search results/index views
     config.index.title_field = 'full_title_tesim'
     config.index.display_type_field = 'content_metadata_type_ssm'
-    config.index.thumbnail_field = Spotlight::Engine.config.thumbnail_field
+    config.index.thumbnail_field = Spotlight::Engine.config.spotlight.thumbnail_field
 
     config.add_results_collection_tool(:sort_widget)
     config.add_results_collection_tool(:per_page_widget)

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -71,7 +71,7 @@ class TestAppGenerator < Rails::Generators::Base
     copy_file 'fixture.css', 'app/assets/stylesheets/application_modern.css'
     append_to_file 'config/initializers/assets.rb', "\nRails.application.config.assets.precompile += %w( application_modern.css )"
 
-    append_to_file 'config/initializers/spotlight_initializer.rb', "\nSpotlight::Engine.config.exhibit_themes = %w[default modern]"
+    append_to_file 'config/initializers/spotlight_initializer.rb', "\nSpotlight::Engine.config.spotlight.exhibit_themes = %w[default modern]"
   end
 
   def disable_filter_resources_by_exhibit
@@ -79,7 +79,7 @@ class TestAppGenerator < Rails::Generators::Base
       <<-EOF
       # Setting this to false when running tests so that we don't have to set up
       # exhibit specific solr documents for tests that don't use the default exhibit.
-      Spotlight::Engine.config.filter_resources_by_exhibit = false
+      Spotlight::Engine.config.spotlight.filter_resources_by_exhibit = false
       EOF
     end
   end

--- a/spec/uploaders/spotlight/featured_image_uploader_spec.rb
+++ b/spec/uploaders/spotlight/featured_image_uploader_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Spotlight::FeaturedImageUploader do
 
   describe '#extension_allowlist' do
     it 'is the configured array of approved extension to be uploaded' do
-      expect(featured_image_uploader.extension_allowlist).to eq Spotlight::Engine.config.allowed_upload_extensions
+      expect(featured_image_uploader.extension_allowlist).to eq Spotlight::Engine.config.spotlight.allowed_upload_extensions
     end
   end
 

--- a/spec/views/shared/_analytics.html.erb_spec.rb
+++ b/spec/views/shared/_analytics.html.erb_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'shared/_analytics', type: :view do
   end
 
   it 'renders the GA script tag if the web property id is configured' do
-    allow(Spotlight::Engine.config).to receive(:ga_web_property_id).and_return('G-XYZ1234567')
+    allow(Spotlight::Engine.config.spotlight).to receive(:ga_web_property_id).and_return('G-XYZ1234567')
     render
     expect(rendered).to have_css 'script', visible: false
     expect(rendered).to have_text 'G-XYZ1234567'

--- a/spec/views/spotlight/catalog/admin.html.erb_spec.rb
+++ b/spec/views/spotlight/catalog/admin.html.erb_spec.rb
@@ -33,13 +33,13 @@ RSpec.describe 'spotlight/catalog/admin.html.erb', type: :view do
   end
 
   it "renders the 'add items' link if any repository sources are configured" do
-    allow(Spotlight::Engine.config).to receive(:resource_partials).and_return(['a'])
+    allow(Spotlight::Engine.config.spotlight).to receive(:resource_partials).and_return(['a'])
     render
     expect(rendered).to have_link 'Add items'
   end
 
   it "does not render the 'add items' link if no repository sources are configured" do
-    allow(Spotlight::Engine.config).to receive(:resource_partials).and_return([])
+    allow(Spotlight::Engine.config.spotlight).to receive(:resource_partials).and_return([])
     render
     expect(rendered).to have_no_link 'Add items'
   end

--- a/spec/views/spotlight/home_pages/_empty.html.erb_spec.rb
+++ b/spec/views/spotlight/home_pages/_empty.html.erb_spec.rb
@@ -14,13 +14,13 @@ RSpec.describe 'spotlight/home_pages/_empty.html.erb', type: :view do
     end
 
     it 'has a list item with a link to add items when there are resource partials configured' do
-      allow(Spotlight::Engine.config).to receive_messages(resource_partials: [true])
+      allow(Spotlight::Engine.config.spotlight).to receive_messages(resource_partials: [true])
       render
       expect(rendered).to have_css('li a', text: 'Curation > Items')
     end
 
     it 'does not have a list item with a link to add items when there are no resource partials configured' do
-      allow(Spotlight::Engine.config).to receive_messages(resource_partials: [])
+      allow(Spotlight::Engine.config.spotlight).to receive_messages(resource_partials: [])
       render
       expect(rendered).to have_no_css('li a', text: 'Curation > Items')
     end

--- a/spec/views/spotlight/resources/_external_resources_form.html.erb_spec.rb
+++ b/spec/views/spotlight/resources/_external_resources_form.html.erb_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'spotlight/resources/_external_resources_form.html.erb', type: :v
   end
 
   it 'renders the configured partials' do
-    allow(Spotlight::Engine.config).to receive(:external_resources_partials).and_return(%w[a b c])
+    allow(Spotlight::Engine.config.spotlight).to receive(:external_resources_partials).and_return(%w[a b c])
     stub_template '_a.html.erb' => 'a_template'
     stub_template '_b.html.erb' => 'b_template'
     stub_template '_c.html.erb' => 'c_template'

--- a/spec/views/spotlight/resources/new.html.erb_spec.rb
+++ b/spec/views/spotlight/resources/new.html.erb_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'spotlight/resources/new.html.erb', type: :view do
   end
 
   it 'renders the configured partials' do
-    allow(Spotlight::Engine.config).to receive(:resource_partials).and_return(
+    allow(Spotlight::Engine.config.spotlight).to receive(:resource_partials).and_return(
       %w[
         spotlight/resources/external_resources_form
         spotlight/resources/upload/form


### PR DESCRIPTION
All values set on Spotlight::Engine.config are actually stored
in a class variable on Railtie::Configuration. So these pollute
that namespace.  All other railties are encapsulating their configs
onto a single entry in that scope.  This change makes Spotlight do
likewise.

This probably needs to be a major revision