### PR TITLE
Validate the FeaturedImage object if provided.

### DIFF
--- a/app/models/spotlight/resources/upload.rb
+++ b/app/models/spotlight/resources/upload.rb
@@ -4,7 +4,7 @@ module Spotlight
     ##
     # Exhibit-specific resources, created using uploaded and custom fields
     class Upload < Spotlight::Resource
-      belongs_to :upload, class_name: 'Spotlight::FeaturedImage', optional: true
+      belongs_to :upload, class_name: 'Spotlight::FeaturedImage', optional: true, validate: true
 
       # we want to do this before reindexing
       after_create :update_document_sidecar


### PR DESCRIPTION
It seems that, with optional associations, if an associated object is invalid it'll just get dropped. For uploaded objects, if the image is invalid we want to alert the user and cancel the upload.  