### PR TITLE
Adds the ability to modify help text blocks for images

### DIFF
--- a/app/views/spotlight/contacts/_form.html.erb
+++ b/app/views/spotlight/contacts/_form.html.erb
@@ -14,6 +14,9 @@
       <div>
         <%= af.radio_button(:source, :remote, label: t(:'.source.remote.label')) %>
         <%= iiif_upload_tag(af) %>
+        <span class="help-block">
+          <%= t(:'.source.remote.help') %>
+        </span>
       </div>
 
       <%= iiif_cropper_tags af, initial_crop_selection: Spotlight::Engine.config.contact_square_size %>

--- a/app/views/spotlight/featured_images/_form.html.erb
+++ b/app/views/spotlight/featured_images/_form.html.erb
@@ -24,6 +24,9 @@
   <div>
     <%= f.radio_button(:source, :remote, label: t(:'.source.remote.label')) %>
     <%= iiif_upload_tag(f) %>
+    <span class="help-block">
+      <%= t(:'.source.remote.help') %>
+    </span>
   </div>
 <% end %>
 <%= field_set_tag(t(:'.source.remote.header')) do %>

--- a/app/views/spotlight/featured_images/_upload_form.html.erb
+++ b/app/views/spotlight/featured_images/_upload_form.html.erb
@@ -6,6 +6,9 @@
   <div>
     <%= f.hidden_field(:source, value: :remote, label: t(:'.source.remote.label')) %>
     <%= iiif_upload_tag(f) %>
+    <span class="help-block">
+      <%= t(:'.source.remote.help') %>
+    </span>
   </div>
 <% end %>
 <%= field_set_tag(t(:'.source.remote.header')) do %>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -272,6 +272,7 @@ en:
           placeholder: First and last name
         source:
           remote:
+            help: ''
             label: Upload an image
         telephone:
           placeholder: Telephone number (optional)
@@ -480,6 +481,7 @@ en:
           header: Image source
           remote:
             header: Cropped image
+            help: ''
             label: Upload an image
       upload_form:
         crop_area:
@@ -492,6 +494,7 @@ en:
           header: Image source
           remote:
             header: Cropped image
+            help: ''
             label: Upload an image
     header_links:
       contact: Feedback

--- a/spec/views/spotlight/contacts/edit.html.erb_spec.rb
+++ b/spec/views/spotlight/contacts/edit.html.erb_spec.rb
@@ -22,6 +22,11 @@ describe 'spotlight/contacts/edit.html.erb' do
           form: {
             new_field: {
               placeholder: 'place'
+            },
+            source: {
+              remote: {
+                help: 'Help!'
+              }
             }
           }
         }
@@ -32,6 +37,7 @@ describe 'spotlight/contacts/edit.html.erb' do
   it 'has an IIIF crop' do
     render
     expect(rendered).to have_content 'Upload an image'
+    expect(rendered).to have_css '.help-block', text: 'Help!'
     expect(rendered).to have_selector '#contact_avatar_attributes_iiif_cropper'
   end
 end

--- a/spec/views/spotlight/featured_images/_form.html.erb_spec.rb
+++ b/spec/views/spotlight/featured_images/_form.html.erb_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+describe 'spotlight/featured_images/_form', type: :view do
+  let(:exhibit) { FactoryBot.create(:exhibit, :with_thumbnail) }
+  let(:builder) { ActionView::Helpers::FormBuilder.new 'z', exhibit.thumbnail, view, {} }
+
+  before do
+    assign(:exhibit, exhibit)
+    allow(builder).to receive_messages(file_field_without_bootstrap: nil)
+    allow(view).to receive_messages(exhibit_thumbnails_path: nil)
+    I18n.backend.backends.second.store_translations(
+      :en,
+      spotlight: {
+        featured_images: {
+          form: {
+            source: {
+              remote: {
+                help: 'Help!'
+              }
+            }
+          }
+        }
+      }
+    )
+  end
+
+  it 'has help block' do
+    render partial: 'spotlight/featured_images/form',
+           locals: { f: builder, initial_crop_selection: [], crop_type: :thumbnail }
+    expect(rendered).to have_css '.help-block', text: 'Help!'
+  end
+end

--- a/spec/views/spotlight/featured_images/_upload_form.html.erb_spec.rb
+++ b/spec/views/spotlight/featured_images/_upload_form.html.erb_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+describe 'spotlight/featured_images/_upload_form', type: :view do
+  let(:exhibit) { FactoryBot.create(:exhibit, :with_thumbnail) }
+  let(:builder) { ActionView::Helpers::FormBuilder.new 'z', exhibit.thumbnail, view, {} }
+
+  before do
+    assign(:exhibit, exhibit)
+    allow(builder).to receive_messages(file_field_without_bootstrap: nil)
+    allow(view).to receive_messages(exhibit_thumbnails_path: nil)
+    I18n.backend.backends.second.store_translations(
+      :en,
+      spotlight: {
+        featured_images: {
+          upload_form: {
+            source: {
+              remote: {
+                help: 'Help!'
+              }
+            }
+          }
+        }
+      }
+    )
+  end
+
+  it 'has help block' do
+    render partial: 'spotlight/featured_images/upload_form',
+           locals: { f: builder, initial_crop_selection: [], crop_type: :thumbnail }
+    expect(rendered).to have_css '.help-block', text: 'Help!'
+  end
+end


### PR DESCRIPTION
This PR adds the ability to customize help blocks for image uploads in various places.

We hope to use this in Exhibits as help text along with #2146 to limit upload sizes.

Related to https://github.com/sul-dlss/exhibits/issues/1342

![Screen Shot 2019-05-14 at 5 04 23 PM](https://user-images.githubusercontent.com/1656824/57737872-7a2ea900-766a-11e9-966a-675aef9594f8.png)
