### PR TITLE
Fixes an issue where translated pages of pages that have UUIDs from F…

### DIFF
--- a/app/models/spotlight/page.rb
+++ b/app/models/spotlight/page.rb
@@ -135,6 +135,7 @@ module Spotlight
         np.locale = locale
         np.default_locale_page = self
         np.published = false
+        np.slug = slug
 
         if !top_level_page? && (parent_translation = parent_page.translated_page_for(locale)).present?
           np.parent_page = parent_translation

--- a/spec/factories/pages.rb
+++ b/spec/factories/pages.rb
@@ -7,6 +7,12 @@ FactoryBot.define do
     published { true }
     content { '[]' }
   end
+  factory :feature_page_static_title, class: 'Spotlight::FeaturePage' do
+    exhibit
+    title { 'FeaturePage' }
+    published { true }
+    content { '[]' }
+  end
   factory :feature_subpage, parent: :feature_page do
     transient do
       exhibit

--- a/spec/models/spotlight/page_spec.rb
+++ b/spec/models/spotlight/page_spec.rb
@@ -172,6 +172,16 @@ describe Spotlight::Page, type: :model do
       end
     end
 
+    context 'when cloning a page that has been deleted with a FriendlyId UUID added' do
+      let(:feature_page_static_title) { FactoryBot.create(:feature_page_static_title, exhibit: exhibit) }
+      let(:feature_page_static_title_two) { FactoryBot.create(:feature_page_static_title, exhibit: exhibit) }
+      it 'translated page has the same UUID' do
+        expect(feature_page_static_title.slug).to eq 'featurepage'
+        expect(feature_page_static_title_two.slug).not_to eq feature_page_static_title.slug
+        expect(feature_page_static_title_two.clone_for_locale('es').slug).to eq feature_page_static_title_two.slug
+      end
+    end
+
     context 'when cloning a parent page whose children pages have already been cloned' do
       let(:parent_page_es) { parent_page.clone_for_locale('es') }
       let(:child_page_es) { child_page.clone_for_locale('es') }


### PR DESCRIPTION
…riendlyID have the incorrect slug

FriendlyID "conveniently" removes the slug for us.

Fixes https://github.com/sul-dlss/vatican_exhibits/issues/411