### PR TITLE
Role masking for Site Admin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ _site/
 .internal_test_app
 pkg/
 /spec/examples.txt
+**/.DS_Store

--- a/app/controllers/spotlight/admin_users_controller.rb
+++ b/app/controllers/spotlight/admin_users_controller.rb
@@ -29,9 +29,45 @@ module Spotlight
       end
       redirect_to spotlight.admin_users_path
     end
+    
+    def mask_role
+       url = request.referrer
+       role = site_admin_role
+       if (params[:role] && !role.nil?)
+         #Set the role in the db
+         #First role since the only people that mask are Site Admins
+         if (Spotlight::Role::ROLES.include?(params[:role]))
+           role.update ({:role_mask => params[:role]})
+         end   
+       end
+       if (!url.nil?)
+         #Redirect to the previous url
+         redirect_to url
+       else
+         redirect_to main_app.root_url
+       end
+     end
+     
+     def clear_mask_role
+       url = request.referrer
+       role = site_admin_role
+       if (!role.nil?)
+         role.update({:role_mask => nil})
+       end
+       if (!url.nil?)
+         #Redirect to the previous url
+         redirect_to url
+       else
+         redirect_to main_app.root_url
+       end
+     end
 
     private
-
+    
+    def site_admin_role
+      current_user.roles.where(role: 'admin', resource: Spotlight::Site.instance).first
+    end
+    
     def load_site
       @site ||= Spotlight::Site.instance
     end

--- a/app/views/shared/_masthead.html.erb
+++ b/app/views/shared/_masthead.html.erb
@@ -32,5 +32,7 @@
 
   <%= render 'shared/exhibit_navbar' if current_exhibit && !resource_masthead? %>
 </div>
-
+  <% if (current_user && (current_user.superadmin? || current_user.is_masked?)) %>
+  	<%= render partial: 'shared/role_mask' %>
+  <% end %>
 <%= render 'shared/breadcrumbs' unless resource_masthead? %>

--- a/app/views/shared/_role_mask.html.erb
+++ b/app/views/shared/_role_mask.html.erb
@@ -1,0 +1,14 @@
+<div id="admin_role_toggle">
+<!-- check to see if the user is already using a masked role-->
+<% if (current_user.is_masked?) %>
+  	<span id="mask_label"><label>Current role mask: <%=current_user.get_formatted_mask %></label></span><%= link_to "Clear Role", "/admin_users/clear_mask_role" , class: "btn btn-primary", role: "button" %>	
+<% else %>
+	<li class="dropdown">
+		<a href="#" class="dropdown-toggle" data-toggle="dropdown" aria-expanded="false">View As <b class="caret"></b></a>
+			<ul class="dropdown-menu">
+				<li><%= link_to "Exhibit Admin", '/admin_users/mask_role/admin' %></li>
+			  	<li><%= link_to "Curator", '/admin_users/mask_role/curator'  %></li>
+			</ul>
+	</li>
+ <% end %>
+ </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,10 @@ Spotlight::Engine.routes.draw do
   get '/exhibits/edit', to: 'sites#edit_exhibits', as: 'edit_site_exhibits'
 
   resources :admin_users, only: [:index, :create, :destroy]
-
+    
+  get '/admin_users/clear_mask_role', to: 'admin_users#clear_mask_role'
+  get '/admin_users/mask_role/:role', to: 'admin_users#mask_role'
+  
   resources :exhibits, path: '/', except: [:show] do
     member do
       get 'exhibit', to: 'exhibits#show', as: 'get'

--- a/db/migrate/20190612182308_add_role_mask_to_roles.rb
+++ b/db/migrate/20190612182308_add_role_mask_to_roles.rb
@@ -1,0 +1,5 @@
+class AddRoleMaskToRoles < ActiveRecord::Migration[5.2]
+  def change
+    add_column :spotlight_roles, :role_mask, :string
+  end
+end

--- a/lib/generators/spotlight/install_generator.rb
+++ b/lib/generators/spotlight/install_generator.rb
@@ -48,6 +48,7 @@ module Spotlight
     end
 
     def assets
+      copy_file 'masked_role.css', 'app/assets/stylesheets/masked_role.css'
       copy_file 'spotlight.scss', 'app/assets/stylesheets/spotlight.scss'
       copy_file 'spotlight.js', 'app/assets/javascripts/spotlight.js'
     end

--- a/lib/generators/spotlight/templates/masked_role.css
+++ b/lib/generators/spotlight/templates/masked_role.css
@@ -1,0 +1,31 @@
+
+#admin_role_toggle {
+  width: 100%;
+  margin-top: -25px;
+  padding-bottom: 25px;
+}
+#admin_role_toggle li.dropdown {
+    list-style: none;
+}
+#admin_role_toggle .dropdown-toggle {
+  padding: 10px 20px;
+}
+#admin_role_toggle .navbar-nav {
+  width: 75%;
+}
+#admin_role_toggle .dropdown-menu {
+  left: 0;
+}
+#admin_role_toggle .navbar-nav > li {
+  float: right;
+}
+
+#admin_role_toggle .btn.btn-primary {
+    font-size: 10px;
+    padding: 2px 5px;
+}
+
+#mask_label {
+    margin-right: 20px;
+    margin-left: 10px;
+}

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -27,5 +27,17 @@ FactoryBot.define do
 
     factory :exhibit_visitor do
     end
+    
+    factory :site_admin_exhibit_admin_mask do
+      after(:create) do |user, _evaluator|
+        user.roles.create role: 'admin', resource: Spotlight::Site.instance, role_mask: 'admin'
+      end
+    end
+
+    factory :site_admin_curator_mask do
+      after(:create) do |user, _evaluator|
+        user.roles.create role: 'admin', resource: Spotlight::Site.instance, role_mask: 'curator'
+      end
+    end        
   end
 end

--- a/spec/models/spotlight/ability_spec.rb
+++ b/spec/models/spotlight/ability_spec.rb
@@ -86,4 +86,57 @@ describe Spotlight::Ability, type: :model do
     it { is_expected.not_to be_able_to(:manage, language) }
     it { is_expected.to be_able_to(:read, language) }
   end
+  
+  describe 'a superadmin with an exhibit admin mask' do
+    let(:user) { FactoryBot.create(:site_admin_exhibit_admin_mask) }
+    let(:role) { FactoryBot.create(:role, resource: exhibit) }
+    let(:blacklight_config) { exhibit.blacklight_configuration }
+    
+    it { is_expected.to be_able_to(:update, exhibit) }
+
+    it { is_expected.to be_able_to(:index, role) }
+    it { is_expected.to be_able_to(:destroy, role) }
+    it { is_expected.to be_able_to(:update, role) }
+    it { is_expected.to be_able_to(:create, Spotlight::Role) }
+    it { is_expected.not_to be_able_to(:create, Spotlight::Exhibit) }
+    it { is_expected.to be_able_to(:import, exhibit) }
+    it { is_expected.to be_able_to(:process_import, exhibit) }
+    it { is_expected.to be_able_to(:destroy, exhibit) }
+    it { is_expected.to be_able_to(:manage, language) }
+  end
+ 
+  describe 'a superadmin with curate mask' do
+    let(:user) { FactoryBot.create(:site_admin_curator_mask) }
+    let(:contact) { FactoryBot.build_stubbed(:contact, exhibit: exhibit) }
+    let(:blacklight_config) { exhibit.blacklight_configuration }
+
+    it { is_expected.not_to be_able_to(:update, exhibit) }
+    it { is_expected.to be_able_to(:curate, exhibit) }
+    it { is_expected.to be_able_to(:read, exhibit) }
+
+    it { is_expected.to be_able_to(:create, Spotlight::Search) }
+    it { is_expected.to be_able_to(:update_all, Spotlight::Search) }
+    it { is_expected.to be_able_to(:update, search) }
+    it { is_expected.to be_able_to(:destroy, search) }
+
+    it { is_expected.to be_able_to(:create, Spotlight::Page) }
+    it { is_expected.to be_able_to(:update_all, Spotlight::Page) }
+    it { is_expected.to be_able_to(:update, page) }
+    it { is_expected.to be_able_to(:destroy, page) }
+
+    it { is_expected.to be_able_to(:create, Translation) }
+    it { is_expected.to be_able_to(:update_all, Translation) }
+    it { is_expected.to be_able_to(:update, translation) }
+    it { is_expected.to be_able_to(:destroy, translation) }
+
+    it { is_expected.to be_able_to(:tag, exhibit) }
+
+    it { is_expected.to be_able_to(:edit, contact) }
+    it { is_expected.to be_able_to(:new, contact) }
+    it { is_expected.to be_able_to(:create, contact) }
+    it { is_expected.to be_able_to(:destroy, contact) }
+    it { is_expected.not_to be_able_to(:manage, language) }
+    it { is_expected.to be_able_to(:read, language) }
+  end 
+ 
 end


### PR DESCRIPTION
This allows Site Admin users to toggle between Exhibit Admin and Curator roles to see different views and permissions without having to create separate users.  This is particularly useful when using an authentication system outside of Spotlight that does not permit the creation of mock users.

A migration was added to add a role_mask field to the spotlight_roles table.  The Can Can ability.rb file has been edited to take into account the new role mask.  

When a Site Administrator is logged in, a simple 'View As' menu appears on all screens under the navigation:

<img width="164" alt="ViewAs" src="https://user-images.githubusercontent.com/6585049/60530982-00a95380-9cc8-11e9-9f35-5785391e9515.png">

When a mask is in place, a notification appears in the same place with an option to clear:

<img width="421" alt="Clear" src="https://user-images.githubusercontent.com/6585049/60531034-19196e00-9cc8-11e9-95fc-6cdc0229297e.png">

The Exhibit Admin and Curator masks do not limit visibility to specific exhibits so all exhibits will still be available under the masks.