### PR TITLE
ExhibitExportSerializer: remove confirmation token

### DIFF
--- a/app/serializers/spotlight/exhibit_export_serializer.rb
+++ b/app/serializers/spotlight/exhibit_export_serializer.rb
@@ -83,7 +83,7 @@ module Spotlight
     end
 
     collection :contact_emails, class: Spotlight::ContactEmail do
-      (Spotlight::ContactEmail.attribute_names - %w(id exhibit_id)).each do |prop|
+      (Spotlight::ContactEmail.attribute_names - %w(id exhibit_id confirmation_token)).each do |prop|
         property prop
       end
     end


### PR DESCRIPTION
This avoids the edge case where exporting an exhibit with a contact email then
importing it into the same Spotlight instance causes this sort of error:
```
F, [2019-07-29T12:32:28.849634 #15168] FATAL -- : [157062cd-0728-432e-8acb-252372f37ce0] ActiveRecord::RecordNotUnique (PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "index_spotlight_contact_emails_on_confirmation_token"
DETAIL:  Key (confirmation_token)=(R6A-skseGTy41-9EHs5T) already exists.
: INSERT INTO "spotlight_contact_emails" ("exhibit_id", "email", "confirmation_token", "confirmed_at", "confirmation_sent_at", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING "id"):
```