### PR TITLE
allow IIIF url helpers to be reconfigured

### DIFF
--- a/app/controllers/spotlight/featured_images_controller.rb
+++ b/app/controllers/spotlight/featured_images_controller.rb
@@ -16,7 +16,10 @@ module Spotlight
     private
 
     def tilesource
-      riiif.info_url(@featured_image.id)
+      Spotlight::Engine.config.iiif_url_helpers.info_url(
+        @featured_image.id,
+        host: request.host_with_port
+      )
     end
 
     # The create action can be called from a number of different forms, so

--- a/app/models/spotlight/featured_image.rb
+++ b/app/models/spotlight/featured_image.rb
@@ -53,8 +53,7 @@ module Spotlight
     def set_tilesource_from_uploaded_resource
       return if iiif_tilesource
 
-      riiif = Riiif::Engine.routes.url_helpers
-      self.iiif_tilesource = riiif.info_path(id)
+      self.iiif_tilesource = Spotlight::Engine.config.iiif_url_helpers.info_path(id)
       save
     end
 

--- a/app/presenters/spotlight/iiif_manifest_presenter.rb
+++ b/app/presenters/spotlight/iiif_manifest_presenter.rb
@@ -74,8 +74,10 @@ module Spotlight
     end
 
     def iiif_url
-      # yes this is hacky, and we are appropriately ashamed.
-      controller.riiif.info_url(uploaded_resource.upload.id).sub(%r{/info\.json\Z}, '')
+      Spotlight::Engine.config.iiif_url_helpers.info_url(
+        uploaded_resource.upload.id,
+        host: controller.request.host_with_port
+      ).sub(%r{/info\.json\Z}, '')
     end
   end
 end

--- a/app/services/spotlight/upload_solr_document_builder.rb
+++ b/app/services/spotlight/upload_solr_document_builder.rb
@@ -31,7 +31,8 @@ module Spotlight
     end
 
     def add_file_versions(solr_hash)
-      solr_hash[Spotlight::Engine.config.thumbnail_field] = riiif.image_path(resource.upload_id, size: '!400,400')
+      solr_hash[Spotlight::Engine.config.thumbnail_field] =
+        Spotlight::Engine.config.iiif_url_helpers.image_path(resource.upload_id, size: '!400,400')
     end
 
     def add_sidecar_fields(solr_hash)
@@ -47,7 +48,7 @@ module Spotlight
     end
 
     def riiif
-      Riiif::Engine.routes.url_helpers
+      Spotlight::Engine.config.iiif_url_helpers
     end
 
     def attached_file?

--- a/lib/generators/spotlight/templates/config/initializers/spotlight_initializer.rb
+++ b/lib/generators/spotlight/templates/config/initializers/spotlight_initializer.rb
@@ -9,6 +9,40 @@
 # Spotlight::Engine.config.catalog_controller_class = '::CatalogController'
 # Spotlight::Engine.config.default_blacklight_config = nil
 
+# ==> IIIF configuration
+# Overriding the riiif url_helpers requires a module with at least the following
+# methods:
+#
+# @param [String] id
+# @param [Hash] options
+# @option options [String] format
+# @option options [String] host
+#
+# @return [String]
+# def info_url(id, options)
+#
+#
+# @param [String] id
+# @param [Hash] options
+# @option options [String] format
+#
+# @return [String]
+# def info_path(id, options)
+#
+#
+# @param [String] id
+# @param [Hash] options
+# @option options [String] region
+# @option options [String] size
+# @option options [String] rotation
+# @option options [String] quality
+# @option options [String] format
+#
+# @return [String]
+# def image_path(id, options)
+#
+# config.iiif_url_helpers = Riiif::Engine.routes.url_helpers
+
 # ==> Appearance configuration
 # Spotlight::Engine.config.exhibit_main_navigation = [:curated_features, :browse, :about]
 # Spotlight::Engine.config.resource_partials = [

--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -244,6 +244,38 @@ module Spotlight
 
     config.exhibit_themes = ['default']
 
+    # Overriding the riiif url_helpers requires a module with at least the
+    # following methods:
+    #
+    # @param [String] id
+    # @param [Hash] options
+    # @option options [String] format
+    # @option options [String] host
+    #
+    # @return [String]
+    # def info_url(id, options)
+    #
+    #
+    # @param [String] id
+    # @param [Hash] options
+    # @option options [String] format
+    #
+    # @return [String]
+    # def info_path(id, options)
+    #
+    #
+    # @param [String] id
+    # @param [Hash] options
+    # @option options [String] region
+    # @option options [String] size
+    # @option options [String] rotation
+    # @option options [String] quality
+    # @option options [String] format
+    #
+    # @return [String]
+    # def image_path(id, options)
+    config.iiif_url_helpers = Riiif::Engine.routes.url_helpers
+
     config.default_page_content_type = 'SirTrevor'
     config.sir_trevor_widgets = %w(
       Heading Text List Quote Iframe Video Oembed Rule UploadedItems Browse LinkToSearch

--- a/spec/presenters/spotlight/iiif_manifest_presenter_spec.rb
+++ b/spec/presenters/spotlight/iiif_manifest_presenter_spec.rb
@@ -13,6 +13,7 @@ describe Spotlight::IiifManifestPresenter do
 
   before do
     allow(resource).to receive(:uploaded_resource).and_return(uploaded_resource)
+    allow(controller).to receive(:request).and_return(double(host_with_port: 'localhost:3000'))
   end
 
   describe 'public methods' do
@@ -118,10 +119,7 @@ describe Spotlight::IiifManifestPresenter do
 
     describe '#iiif_url' do
       it 'returns the info_url from the Riiif engine routes, minus the trailing .json' do
-        riiif_route_helper = double(info_url: 'https://iiif.test/path/info.json')
-        allow(controller).to receive(:riiif).and_return(riiif_route_helper)
-
-        expect(subject.send(:iiif_url)).to eq('https://iiif.test/path')
+        expect(subject.send(:iiif_url)).to eq('http://localhost:3000/images/2')
       end
     end
   end


### PR DESCRIPTION
This change allows Spotlight applications to use an external (non-riiif) IIIF server for image derivative requests.

It does not teach Spotlight to send uploaded resources to that server; currently using this configuration option requires that the images already exist on the IIIF server.