### PR TITLE
ExhibitExportSerializer: ignore theme when unavailable

### DIFF
--- a/app/serializers/spotlight/exhibit_export_serializer.rb
+++ b/app/serializers/spotlight/exhibit_export_serializer.rb
@@ -34,6 +34,10 @@ module Spotlight
       property prop
     end
 
+    property :theme, setter: lambda { |fragment:, represented:, **|
+      represented.theme = fragment if Spotlight::Engine.config.exhibit_themes.include? fragment
+    }
+
     collection :searches, populator: ->(fragment, options) { options[:represented].searches.find_or_initialize_by(slug: fragment['slug']) },
                           class: Spotlight::Search do
       (Spotlight::Search.attribute_names - %w(id scope exhibit_id masthead_id thumbnail_id)).each do |prop|


### PR DESCRIPTION
When the target instance does not have the same theme, errors occur: https://gitlab.com/surfliner/surfliner/issues/145#note_203830948