### PR TITLE
Allow applications to provide different page content types and editors

### DIFF
--- a/app/helpers/spotlight/pages_helper.rb
+++ b/app/helpers/spotlight/pages_helper.rb
@@ -6,6 +6,16 @@ module Spotlight
   module PagesHelper
     include Spotlight::RenderingHelper
 
+    def content_editor_class(page)
+      page_content = page.content_type
+
+      if page_content == 'SirTrevor'
+        'js-st-instance'
+      else
+        "js-#{page_content.parameterize}-instance"
+      end
+    end
+
     ##
     # Override the default #sir_trevor_markdown so we can use
     # a more complete markdown rendered

--- a/app/models/spotlight/page.rb
+++ b/app/models/spotlight/page.rb
@@ -34,7 +34,6 @@ module Spotlight
     scope :for_default_locale, -> { for_locale(I18n.default_locale) }
 
     has_one :lock, as: :on, dependent: :destroy
-    sir_trevor_content :content
     has_paper_trail
 
     accepts_nested_attributes_for :thumbnail, update_only: true, reject_if: proc { |attr| attr['iiif_tilesource'].blank? }
@@ -49,6 +48,16 @@ module Spotlight
 
     def content_changed!
       @content = nil
+    end
+
+    def content
+      @content ||= begin
+        Spotlight::PageContent.for(self, :content)
+      end
+    end
+
+    def content_type
+      self[:content_type] || Spotlight::Engine.config.default_page_content_type
     end
 
     def content=(content)

--- a/app/models/spotlight/page.rb
+++ b/app/models/spotlight/page.rb
@@ -40,7 +40,6 @@ module Spotlight
 
     # display_sidebar should be set to true by default
     before_create do
-      self.content ||= [].to_json
       self.display_sidebar = true
     end
 

--- a/app/models/spotlight/page_content.rb
+++ b/app/models/spotlight/page_content.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Spotlight
+  # Factory for picking the right page content renderer
+  module PageContent
+    def self.for(page, attribute)
+      content_type = page.content_type
+      content_class = Spotlight::PageContent.const_get(content_type) if Spotlight::PageContent.const_defined?(content_type)
+      content_class ||= default_page_content_class
+
+      content_class.parse(page, attribute)
+    end
+
+    def self.default_page_content_class
+      Spotlight::PageContent.const_get(Spotlight::Engine.config.default_page_content_type)
+    end
+  end
+end

--- a/app/models/spotlight/page_content/sir_trevor.rb
+++ b/app/models/spotlight/page_content/sir_trevor.rb
@@ -6,6 +6,8 @@ module Spotlight
     class SirTrevor
       def self.parse(page, attribute)
         content = page.read_attribute(attribute)
+        content ||= [].to_json
+
         return SirTrevorRails::BlockArray.new if content.blank?
 
         SirTrevorRails::BlockArray.from_json(content, page)

--- a/app/models/spotlight/page_content/sir_trevor.rb
+++ b/app/models/spotlight/page_content/sir_trevor.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Spotlight
+  module PageContent
+    # Sir-Trevor created content
+    class SirTrevor
+      def self.parse(page, attribute)
+        content = page.read_attribute(attribute)
+        return SirTrevorRails::BlockArray.new if content.blank?
+
+        SirTrevorRails::BlockArray.from_json(content, page)
+      end
+    end
+  end
+end

--- a/app/views/spotlight/pages/_form.html.erb
+++ b/app/views/spotlight/pages/_form.html.erb
@@ -40,7 +40,7 @@
         </div>
         <div class="form-group">
           <%= f.label :content, class: 'sr-only' %>
-          <%= f.text_area_without_bootstrap :content, value: { data: f.object.content.as_json }.to_json, class: 'js-st-instance', data: { 'block-types': Spotlight::Engine.config.sir_trevor_widgets } %>
+          <%= f.text_area_without_bootstrap :content, value: { data: f.object.content.as_json }.to_json, class: content_editor_class(f.object), data: { 'block-types': Spotlight::Engine.config.sir_trevor_widgets } %>
         </div>
       </div>
 

--- a/db/migrate/20190807085432_add_content_type_to_pages.rb
+++ b/db/migrate/20190807085432_add_content_type_to_pages.rb
@@ -1,0 +1,5 @@
+class AddContentTypeToPages < ActiveRecord::Migration[4.2]
+  def up
+    add_column :spotlight_pages, :content_type, :string
+  end
+end

--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -244,6 +244,7 @@ module Spotlight
 
     config.exhibit_themes = ['default']
 
+    config.default_page_content_type = 'SirTrevor'
     config.sir_trevor_widgets = %w(
       Heading Text List Quote Iframe Video Oembed Rule UploadedItems Browse LinkToSearch
       FeaturedPages SolrDocuments SolrDocumentsCarousel SolrDocumentsEmbed

--- a/spec/helpers/spotlight/pages_helper_spec.rb
+++ b/spec/helpers/spotlight/pages_helper_spec.rb
@@ -100,4 +100,18 @@ describe Spotlight::PagesHelper, type: :helper do
       expect(helper.sir_trevor_markdown(nil)).to be_blank
     end
   end
+
+  describe '#content_editor_class' do
+    context 'with a sir-trevor backed page' do
+      it 'has a custom class' do
+        expect(helper.content_editor_class(Spotlight::Page.new)).to eq 'js-st-instance'
+      end
+    end
+
+    context 'with a sir-trevor backed page' do
+      it 'derives a css class name from the editor type' do
+        expect(helper.content_editor_class(Spotlight::Page.new(content_type: 'Something::Custom'))).to eq 'js-something-custom-instance'
+      end
+    end
+  end
 end

--- a/spec/models/spotlight/page_spec.rb
+++ b/spec/models/spotlight/page_spec.rb
@@ -65,6 +65,28 @@ describe Spotlight::Page, type: :model do
       page.content = []
       expect(page.content).to be_a_kind_of SirTrevorRails::BlockArray
     end
+
+    context 'with an alternate page content type' do
+      let(:page) { FactoryBot.create(:feature_page, content_type: 'Static') }
+      let(:fake_class) do
+        Class.new do
+          def self.parse(*_args)
+            'xyz'
+          end
+        end
+      end
+
+      before do
+        # needed so we don't accidentally stub Spotlight::PageContent below
+        require 'spotlight/page_content'
+        stub_const('Spotlight::PageContent::Static', fake_class)
+      end
+
+      it 'works' do
+        page.content = [].to_json
+        expect(page.content).to eq 'xyz'
+      end
+    end
   end
 
   describe '#content?' do
@@ -78,6 +100,19 @@ describe Spotlight::Page, type: :model do
     it 'has content when the page has a widget' do
       page.content = [{ type: 'rule' }]
       expect(page).to have_content
+    end
+  end
+
+  describe '#content_type' do
+    let(:page) { FactoryBot.create(:feature_page) }
+
+    it 'can be set as an attribute' do
+      page.content_type = 'Xyz'
+      expect(page.content_type).to eq 'Xyz'
+    end
+
+    it 'defauts to SirTrevor' do
+      expect(page.content_type).to eq 'SirTrevor'
     end
   end
 


### PR DESCRIPTION
This lays the groundwork for alternative page editors (other than SirTrevor) by allowing applications (or perhaps other plugins) to provide a different page editor or custom rendering.

To add a new editor, one must:

1. Implement `Spotlight::PageContent::SomeClass` with a class-level parse method that returns something Rails can render, e.g.:

```
class Spotlight::PageContent::Identity
  def self.parse(page, attribute)
    page.read_attribute(attribute)
  end
end
```

2. Inject some javascript into the application to provide an editing experience. The text area will have the class 'js-some-class-instance' (using a parameterized version of your implementation). Replace the textarea with whatever editor you want, but make sure to serialize the editor state back to a form field of the same `name`.

3. Configure `Spotlight::Engine.config.default_page_content_type` with the name of your implementation (matching the name of the class without the `Spotlight::PageContent` namespace, e.g. `Spotlight::Engine.config.default_page_content_type = 'SomeClass'`)