### PR TITLE
Add exhibit-specific configuration for custom search fields

### DIFF
--- a/app/controllers/spotlight/custom_search_fields_controller.rb
+++ b/app/controllers/spotlight/custom_search_fields_controller.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module Spotlight
+  # CRUD actions for exhibit custom search field management.
+  class CustomSearchFieldsController < ApplicationController
+    before_action :authenticate_user!
+
+    load_and_authorize_resource :exhibit, class: Spotlight::Exhibit
+    load_and_authorize_resource through: :exhibit
+    before_action :attach_breadcrumbs, only: [:new, :edit]
+
+    # GET /custom_search_fields/new
+    def new
+      add_breadcrumb t(:'helpers.action.spotlight/custom_search_field.create'), new_exhibit_custom_search_field_path(@exhibit)
+    end
+
+    # GET /custom_search_fields/1/edit
+    def edit
+      add_breadcrumb @custom_search_field.label, edit_exhibit_custom_search_field_path(@custom_search_field.exhibit, @custom_search_field)
+    end
+
+    # POST /custom_search_fields
+    def create
+      @custom_search_field.attributes = custom_search_field_params
+      @custom_search_field.exhibit = current_exhibit
+
+      if @custom_search_field.save
+        redirect_to edit_exhibit_search_configuration_path(@custom_search_field.exhibit),
+                    notice: t(:'helpers.submit.custom_search_field.created', model: @custom_search_field.class.model_name.human.downcase)
+      else
+        render action: 'new'
+      end
+    end
+
+    # PATCH/PUT /custom_search_fields/1
+    def update
+      if @custom_search_field.update(custom_search_field_params)
+        redirect_to edit_exhibit_search_configuration_path(@custom_search_field.exhibit),
+                    notice: t(:'helpers.submit.custom_search_field.updated', model: @custom_search_field.class.model_name.human.downcase)
+      else
+        render :edit
+      end
+    end
+
+    def destroy
+      @custom_search_field.destroy
+
+      redirect_to edit_exhibit_search_configuration_path(@custom_search_field.exhibit),
+                  notice: t(:'helpers.submit.custom_search_field.destroyed', model: @custom_search_field.class.model_name.human.downcase)
+    end
+
+    private
+
+    def attach_breadcrumbs
+      add_breadcrumb t(:'spotlight.exhibits.breadcrumb', title: @exhibit.title), @exhibit
+      add_breadcrumb t(:'spotlight.configuration.sidebar.header'), exhibit_dashboard_path(@exhibit)
+      add_breadcrumb t(:'spotlight.configuration.sidebar.search_configuration'), edit_exhibit_search_configuration_path(@exhibit)
+    end
+
+    # Only allow a trusted parameter "white list" through.
+    def custom_search_field_params
+      params.require(:custom_search_field).permit(:slug, :field, :label)
+    end
+  end
+end

--- a/app/models/spotlight/ability.rb
+++ b/app/models/spotlight/ability.rb
@@ -29,6 +29,7 @@ module Spotlight
         Spotlight::Page,
         Spotlight::Contact,
         Spotlight::CustomField,
+        Spotlight::CustomSearchField,
         Translation
       ], exhibit_id: user.exhibit_roles.pluck(:resource_id)
 

--- a/app/models/spotlight/blacklight_configuration.rb
+++ b/app/models/spotlight/blacklight_configuration.rb
@@ -136,6 +136,7 @@ module Spotlight
 
         config.show_fields = config.index_fields
 
+        config.search_fields.merge! custom_search_fields(config)
         unless search_fields.blank?
           config.search_fields = Hash[config.search_fields.sort_by { |k, _v| field_weight(search_fields, k) }]
 
@@ -224,6 +225,18 @@ module Spotlight
         field.enabled = false
         field.limit = true
         [x.field, field]
+      end]
+    end
+
+    def custom_search_fields(blacklight_config)
+      Hash[exhibit.custom_search_fields.reject(&:new_record?).map do |custom_field|
+        original_config = blacklight_config.search_fields[custom_field.field] || {}
+        field = Blacklight::Configuration::SearchField.new original_config.merge(
+          custom_field.configuration.merge(
+            key: custom_field.slug, solr_parameters: { qf: custom_field.field }, custom_field: true
+          )
+        )
+        [custom_field.slug, field]
       end]
     end
 

--- a/app/models/spotlight/custom_search_field.rb
+++ b/app/models/spotlight/custom_search_field.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Spotlight
+  # Exhibit-specific custom search fields
+  class CustomSearchField < ApplicationRecord
+    serialize :configuration, Hash
+    belongs_to :exhibit
+
+    def label=(label)
+      configuration['label'] = label
+
+      update_blacklight_configuration_label label
+    end
+
+    def label
+      conf = if slug && blacklight_configuration && blacklight_configuration.search_fields.key?(slug)
+               blacklight_configuration.search_fields[slug].reverse_merge(configuration)
+             else
+               configuration
+             end
+      conf['label']
+    end
+
+    protected
+
+    def blacklight_configuration
+      exhibit&.blacklight_configuration
+    end
+
+    def update_blacklight_configuration_label(label)
+      return unless slug && blacklight_configuration && blacklight_configuration.search_fields.key?(slug)
+
+      blacklight_configuration.search_fields[slug]['label'] = label
+      blacklight_configuration.save
+    end
+  end
+end

--- a/app/models/spotlight/exhibit.rb
+++ b/app/models/spotlight/exhibit.rb
@@ -46,6 +46,7 @@ module Spotlight
           end]
       end
     end
+    has_many :custom_search_fields, dependent: :delete_all
 
     has_many :feature_pages, -> { for_default_locale }, extend: FriendlyId::FinderMethods
     has_many :main_navigations, dependent: :delete_all

--- a/app/views/spotlight/custom_search_fields/_form.html.erb
+++ b/app/views/spotlight/custom_search_fields/_form.html.erb
@@ -1,7 +1,7 @@
-<%= bootstrap_form_for @custom_search_field.new_record? ? [current_exhibit, @custom_search_field] : [@custom_search_field.exhibit, @custom_search_field], layout: :horizontal, label_col: 'col-md-3', control_col: 'col-sm-5', html: {class: 'col-md-9', id: 'edit-search-field'} do |f| %>
+<%= bootstrap_form_for @custom_search_field.new_record? ? [current_exhibit, @custom_search_field] : [@custom_search_field.exhibit, @custom_search_field], layout: :horizontal, label_col: 'col-md-3', control_col: 'col-md-9', html: {class: 'col-md-9', id: 'edit-search-field'} do |f| %>
 
   <%= f.text_field :slug %>
-  <%= f.text_field :field %>
+  <%= f.text_field :field, help: t('.field.help') %>
   <%= f.text_field :label %>
 
   <div class="form-actions">

--- a/app/views/spotlight/custom_search_fields/_form.html.erb
+++ b/app/views/spotlight/custom_search_fields/_form.html.erb
@@ -1,0 +1,13 @@
+<%= bootstrap_form_for @custom_search_field.new_record? ? [current_exhibit, @custom_search_field] : [@custom_search_field.exhibit, @custom_search_field], layout: :horizontal, label_col: 'col-md-3', control_col: 'col-sm-5', html: {class: 'col-md-9', id: 'edit-search-field'} do |f| %>
+
+  <%= f.text_field :slug %>
+  <%= f.text_field :field %>
+  <%= f.text_field :label %>
+
+  <div class="form-actions">
+    <div class="primary-actions">
+      <%= link_to t(:"cancel"), edit_exhibit_search_configuration_path(current_exhibit), class: "btn btn-link" %>
+      <%= f.submit nil, class: 'btn btn-primary' %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/spotlight/custom_search_fields/edit.html.erb
+++ b/app/views/spotlight/custom_search_fields/edit.html.erb
@@ -1,0 +1,5 @@
+<%= render 'spotlight/shared/exhibit_sidebar' %>
+<div id="content" class="col-md-9">
+  <%= configuration_page_title %>
+  <%= render 'form' %>
+</div>

--- a/app/views/spotlight/custom_search_fields/new.html.erb
+++ b/app/views/spotlight/custom_search_fields/new.html.erb
@@ -1,0 +1,5 @@
+<%= render 'spotlight/shared/exhibit_sidebar' %>
+<div id="content" class="col-md-9">
+  <%= configuration_page_title %>
+  <%= render 'form' %>
+</div>

--- a/app/views/spotlight/search_configurations/_search_fields.html.erb
+++ b/app/views/spotlight/search_configurations/_search_fields.html.erb
@@ -55,3 +55,30 @@
     </div>
   <% end %>
 <% end %>
+
+<% if can? :manage, Spotlight::CustomSearchField.new(exhibit: current_exhibit) %>
+  <h3><%= t(:'.exhibit_specific.header') %></h3>
+  <p class="instructions"><%= t(:'.exhibit_specific.instructions') %></p>
+
+  <table class="table table-striped" id="exhibit-specific-fields">
+    <tbody>
+      <% @exhibit.custom_search_fields.each do |field| %>
+        <tr>
+          <td>
+            <div class="field-label"><%= field.label %></div>
+            <div class="actions">
+              <%= exhibit_edit_link field, class: 'btn btn-link' %> &middot;
+              <%= exhibit_delete_link field, class: 'btn btn-link' %>
+            </div>
+          </td>
+          <td class="field-description">
+            <%= field.field %>
+          </td>
+        </tr>
+      <% end %>
+
+    </tbody>
+  </table>
+
+  <%= exhibit_create_link Spotlight::CustomSearchField.new, class: 'btn btn-primary' %>
+<% end %>

--- a/app/views/spotlight/search_configurations/edit.html.erb
+++ b/app/views/spotlight/search_configurations/edit.html.erb
@@ -41,6 +41,5 @@
         <%= f.submit nil, class: 'btn btn-primary' %>
       </div>
     </div>
-
   <% end %>
 </div>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -37,6 +37,7 @@ ignore_unused:
   - activerecord.attributes.spotlight/exhibit.published # app/views/spotlight/sites/_exhibit.html.erb
   - activerecord.attributes.spotlight/masthead.display # app/views/spotlight/appearances/edit.html.erb
   - activerecord.attributes.spotlight/custom_field.is_multiple # app/views/spotlight/custom_fields/_form.html.erb
+  - activerecord.attributes.spotlight/custom_search_field.field # app/views/spotlight/custom_search_fields/_form.html.erb
   - helpers.label.spotlight/filter.{field,value} # app/views/spotlight/filters/_form.html.erb
   - spotlight.catalog.admin.{title,header} # app/helpers/spotlight/title_helper.rb
   - spotlight.{contacts,pages,searches}.edit.{title,header} # app/helpers/spotlight/title_helper.rb
@@ -46,8 +47,9 @@ ignore_unused:
   - spotlight.metadata_configurations.edit.{select_all,deselect_all} # app/helpers/spotlight/application_helper.rb
   - spotlight.featured_images.upload_form.{non_iiif_alert_html,source.exhibit.help,source.exhibit.label} # app/views/spotlight/featured_images/_form.html.erb
   - spotlight.feature_pages.page_options.published # app/views/spotlight/feature_pages/_page_options.html.erb
-  - spotlight.{exhibits,custom_fields}.{new,edit}.header # configuration_page_title
+  - spotlight.{exhibits,custom_fields,custom_search_fields}.{new,edit}.header # configuration_page_title
   - helpers.submit.custom_field.{batch_error,batch_updated,create,submit,update} # Generic repeated template
+  - helpers.submit.custom_search_field.{batch_error,batch_updated,create,submit,update} # Generic repeated template
   - helpers.submit.exhibit.{batch_error,batch_updated,create,submit,update} # Generic repeated template
   - helpers.submit.search.{create,submit,update} # Generic repeated template
   - helpers.submit.site.{batch_error,batch_updated,create,created,destroyed,submit,update} # Generic repeated template

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -323,6 +323,9 @@ en:
     custom_search_fields:
       edit:
         header: Edit Exhibit-Specific Field
+      form:
+        field:
+          help: Specify fields to be searched and their boost values (e.g., full_title_tesim^100 personal_name_tesim^50).
       new:
         header: Add Exhibit-Specific Field
     dashboards:

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -6,6 +6,8 @@ en:
         avatar: Photo
       spotlight/custom_field:
         is_multiple: Is the field data multi-valued? (cannot be changed)
+      spotlight/custom_search_field:
+        field: Solr specification
       spotlight/exhibit:
         published: Published?
       spotlight/language:
@@ -39,6 +41,8 @@ en:
         create: Add contact
       spotlight/custom_field:
         create: Add new field
+      spotlight/custom_search_field:
+        create: Add new field
       spotlight/role:
         create: Add a new user
         destroy: Remove from site
@@ -66,6 +70,13 @@ en:
         create: Send
         created: Thanks. Your feedback has been sent.
       custom_field:
+        batch_error: There was an error updating the requested %{model}.
+        batch_updated: "%{model} were successfully updated."
+        create: Save
+        created: The %{model} was created.
+        destroyed: The %{model} was deleted.
+        updated: The %{model} was successfully updated.
+      custom_search_field:
         batch_error: There was an error updating the requested %{model}.
         batch_updated: "%{model} were successfully updated."
         create: Save
@@ -307,6 +318,11 @@ en:
           vocab: Controlled vocabulary
         is_multiple:
           label: Multi-valued?
+      new:
+        header: Add Exhibit-Specific Field
+    custom_search_fields:
+      edit:
+        header: Edit Exhibit-Specific Field
       new:
         header: Add Exhibit-Specific Field
     dashboards:
@@ -691,6 +707,9 @@ en:
           label: 'Sort by:'
       search_fields:
         enable_feature: Display search box
+        exhibit_specific:
+          header: Exhibit-specific search fields
+          instructions: You can add custom search fields to supplement the search fields that are part of the default configuration.
         header: Field-based search
         help: If the search box is displayed, you can also enable field-based search. Field-based search adds a dropdown menu to your exhibit site's search box that provides the user with an option to restrict a search query to a single metadata field.
         instructions: If enabled, you can select below the metadata fields that are available for searching. Click a field name to edit its display label.  Drag and drop fields to specify the order they are displayed in the search box dropdown menu.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,6 +68,7 @@ Spotlight::Engine.routes.draw do
     end
 
     resources :custom_fields
+    resources :custom_search_fields
 
     resource :dashboard, only: [:show] do
       get :analytics

--- a/db/migrate/20190910200927_create_spotlight_custom_search_fields.rb
+++ b/db/migrate/20190910200927_create_spotlight_custom_search_fields.rb
@@ -1,0 +1,12 @@
+class CreateSpotlightCustomSearchFields < ActiveRecord::Migration[5.1]
+  def change
+    create_table :spotlight_custom_search_fields do |t|
+      t.string :slug
+      t.string :field
+      t.text :configuration
+      t.references :exhibit
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/controllers/spotlight/custom_search_fields_controller_spec.rb
+++ b/spec/controllers/spotlight/custom_search_fields_controller_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+describe Spotlight::CustomSearchFieldsController, type: :controller do
+  routes { Spotlight::Engine.routes }
+  let(:exhibit) { FactoryBot.create(:exhibit) }
+
+  describe 'when signed in as an exhibit admin' do
+    let(:user) { FactoryBot.create(:exhibit_admin, exhibit: exhibit) }
+    before { sign_in user }
+
+    describe 'GET new' do
+      it 'assigns a new custom field' do
+        expect(controller).to receive(:add_breadcrumb).with('Home', exhibit)
+        expect(controller).to receive(:add_breadcrumb).with('Configuration', exhibit_dashboard_path(exhibit))
+        expect(controller).to receive(:add_breadcrumb).with('Search', edit_exhibit_search_configuration_path(exhibit))
+        expect(controller).to receive(:add_breadcrumb).with('Add new field', new_exhibit_custom_search_field_path(exhibit))
+        get :new, params: { exhibit_id: exhibit }
+        expect(assigns(:custom_search_field)).to be_a_new(Spotlight::CustomSearchField)
+      end
+    end
+
+    describe 'GET edit' do
+      let(:field) { FactoryBot.create(:custom_search_field, exhibit: exhibit) }
+      it 'assigns the requested custom_field' do
+        expect(controller).to receive(:add_breadcrumb).with('Home', exhibit)
+        expect(controller).to receive(:add_breadcrumb).with('Configuration', exhibit_dashboard_path(exhibit))
+        expect(controller).to receive(:add_breadcrumb).with('Search', edit_exhibit_search_configuration_path(exhibit))
+        expect(controller).to receive(:add_breadcrumb).with(field.label, edit_exhibit_custom_search_field_path(exhibit, field))
+        get :edit, params: { exhibit_id: exhibit, id: field }
+        expect(assigns(:custom_search_field)).to eq field
+        expect(assigns(:exhibit)).to eq exhibit
+      end
+    end
+
+    describe 'POST create' do
+      describe 'with valid params' do
+        it 'creates a new Page' do
+          expect do
+            post :create, params: { custom_search_field: { label: 'MyString' }, exhibit_id: exhibit }
+          end.to change(Spotlight::CustomSearchField, :count).by(1)
+        end
+
+        it 'redirects to the exhibit metadata page' do
+          post :create, params: { custom_search_field: { label: 'MyString' }, exhibit_id: exhibit }
+          expect(response).to redirect_to(edit_exhibit_search_configuration_path(exhibit))
+        end
+      end
+
+      describe 'with invalid params' do
+        it "re-renders the 'new' template" do
+          # Trigger the behavior that occurs when invalid params are submitted
+          allow_any_instance_of(Spotlight::CustomSearchField).to receive(:save).and_return(false)
+          post :create, params: { custom_search_field: { label: 'MyString' }, exhibit_id: exhibit }
+          expect(assigns(:custom_search_field)).to be_a_new(Spotlight::CustomSearchField)
+          expect(response).to render_template('new')
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/custom_search_fields.rb
+++ b/spec/factories/custom_search_fields.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :custom_search_field, class: Spotlight::CustomSearchField do
+    exhibit
+    field { 'field_name_tesim^60' }
+    configuration { { 'label' => 'Some Field' } }
+  end
+end

--- a/spec/features/exhibits/custom_search_fields_spec.rb
+++ b/spec/features/exhibits/custom_search_fields_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+describe 'Adding custom search fields', type: :feature do
+  let(:exhibit) { FactoryBot.create(:exhibit) }
+  let(:admin) { FactoryBot.create(:exhibit_admin, exhibit: exhibit) }
+
+  before do
+    login_as(admin)
+  end
+
+  it 'works' do
+    # Add
+
+    visit spotlight.edit_exhibit_search_configuration_path exhibit
+    click_on 'Add new field'
+    fill_in 'Label', with: 'My new custom field'
+    fill_in 'Slug', with: 'Foo'
+    fill_in 'Solr specification', with: 'title^50'
+
+    click_on 'Save'
+
+    expect(page).to have_content 'The custom search field was created.'
+    within '#exhibit-specific-fields' do
+      expect(page).to have_selector '.field-label', text: 'My new custom field'
+      expect(page).to have_selector '.field-description', text: 'title^50'
+      # Edit
+      click_link 'Edit'
+    end
+
+    # on the edit form
+    expect(find_field('Label').value).to eq 'My new custom field'
+    expect(find_field('Slug').value).to eq 'Foo'
+    expect(find_field('Solr specification').value).to eq 'title^50'
+    fill_in 'Solr specification', with: 'title^50 description^26'
+
+    click_button 'Save changes'
+
+    expect(page).to have_content 'The custom search field was successfully updated.'
+
+    within '#exhibit-specific-fields' do
+      expect(page).to have_selector '.field-label', text: 'My new custom field'
+      expect(page).to have_selector '.field-description', text: 'title^50 description^26'
+      # Destroy
+      click_link 'Delete'
+    end
+
+    expect(page).to have_content 'The custom search field was deleted.'
+  end
+
+  it 'has breadcrumbs' do
+    visit spotlight.edit_exhibit_search_configuration_path exhibit
+    click_on 'Add new field'
+    expect(page).to have_breadcrumbs 'Home', 'Configuration', 'Search', 'Add new field'
+  end
+end

--- a/spec/models/spotlight/custom_search_field_spec.rb
+++ b/spec/models/spotlight/custom_search_field_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+describe Spotlight::CustomSearchField, type: :model do
+  describe '#label' do
+    subject { described_class.new configuration: { 'label' => 'the configured label' }, slug: 'foo' }
+
+    describe "when the exhibit doesn't have a config" do
+      its(:label) { is_expected.to eq 'the configured label' }
+    end
+
+    describe 'when the exhibit has a config' do
+      let(:exhibit) { FactoryBot.create(:exhibit) }
+      before { subject.exhibit = exhibit }
+
+      describe 'that overrides the label' do
+        before do
+          exhibit.blacklight_configuration.search_fields['foo'] = { 'label' => 'overridden' }
+        end
+
+        its(:label) { is_expected.to eq 'overridden' }
+      end
+
+      describe "that doesn't override the label" do
+        its(:label) { is_expected.to eq 'the configured label' }
+      end
+    end
+  end
+
+  describe '#label=' do
+    subject { described_class.new slug: 'foo' }
+
+    describe "when the exhibit doesn't have a config" do
+      before { subject.label = 'the configured label' }
+
+      its(:configuration) { is_expected.to eq('label' => 'the configured label') }
+    end
+
+    describe 'when the exhibit has a config' do
+      let(:exhibit) { FactoryBot.create(:exhibit) }
+      before { subject.exhibit = exhibit }
+
+      describe 'that overrides the label' do
+        before do
+          exhibit.blacklight_configuration.search_fields['foo'] = { 'label' => 'overridden' }
+          subject.label = 'edited'
+        end
+
+        it 'has updated the exhibit' do
+          expect(subject.exhibit.blacklight_configuration.search_fields['foo']['label']).to eq 'edited'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
<img width="753" alt="Screen Shot 2019-09-10 at 13 49 33" src="https://user-images.githubusercontent.com/111218/64649496-d95eb900-d3d1-11e9-8933-1f02f1544d06.png">
