### PR TITLE
AdminUsers: allow superadmins to view all registered users 

### DIFF
--- a/app/controllers/spotlight/admin_users_controller.rb
+++ b/app/controllers/spotlight/admin_users_controller.rb
@@ -6,6 +6,8 @@ module Spotlight
   class AdminUsersController < Spotlight::ApplicationController
     before_action :authenticate_user!
     before_action :load_site
+    before_action :load_users
+
     load_and_authorize_resource :site, class: 'Spotlight::Site'
 
     def index; end
@@ -17,6 +19,19 @@ module Spotlight
       else
         flash[:error] = t('spotlight.admin_users.create.error')
       end
+
+      redirect_to spotlight.admin_users_path
+    end
+
+    def update
+      user = Spotlight::Engine.user_class.find(params[:id])
+      if user
+        Spotlight::Role.create(user_key: user.email, role: 'admin', resource: @site).save
+        flash[:notice] = t('spotlight.admin_users.create.success')
+      else
+        flash[:error] = t('spotlight.admin_users.create.error')
+      end
+
       redirect_to spotlight.admin_users_path
     end
 
@@ -31,6 +46,10 @@ module Spotlight
     end
 
     private
+
+    def load_users
+      @users ||= ::User.all.reject(&:guest?)
+    end
 
     def load_site
       @site ||= Spotlight::Site.instance

--- a/app/views/spotlight/admin_users/index.html.erb
+++ b/app/views/spotlight/admin_users/index.html.erb
@@ -48,10 +48,10 @@
     </div>
   <% end %>
 
-  <p class="instructions"><%= t :'.all_users' %></p>
-  <div id="all_users" class="well well-sm">
+  <p class="instructions"><%= t :'.admins_curators' %></p>
+  <div id="admins_curators" class="well well-sm">
       <div class='btn-toolbar pull-right'>
-          <button class="btn btn-xs btn-default copy-email-addresses" data-clipboard-target="#all_users">
+          <button class="btn btn-xs btn-default copy-email-addresses" data-clipboard-target="#admins_curators">
               <%= t('.copy') %>
           </button>
       </div>

--- a/app/views/spotlight/admin_users/index.html.erb
+++ b/app/views/spotlight/admin_users/index.html.erb
@@ -1,7 +1,7 @@
 <div id="content" class="col-md-9 admin-users">
   <%= page_title(t('.section'), t('.page_title')) %>
   <%= bootstrap_form_for Spotlight::Engine.user_class.new, url: spotlight.admin_users_path do |f| %>
-    <p class="instructions"><%= t :'.instructions' %></p>
+    <h3 class="instructions"><%= t :'.instructions' %></h3>
     <table class="table table-striped ">
       <thead>
         <tr>
@@ -43,20 +43,50 @@
 
     <div class="form-actions">
       <div class="primary-actions">
-        <%= link_to(t('.add'), 'javascript:;', class: 'btn btn-default', data: { behavior: 'new-user' }) %>
+        <%= link_to(t('.create'), 'javascript:;', class: 'btn btn-default', data: { behavior: 'new-user' }) %>
       </div>
     </div>
-  <% end %>
 
-  <p class="instructions"><%= t :'.admins_curators' %></p>
-  <div id="admins_curators" class="well well-sm">
+    <h3 class="instructions"><%= t :'.admins_curators' %></h3>
+    <div id="admins_curators" class="well well-sm">
       <div class='btn-toolbar pull-right'>
-          <button class="btn btn-xs btn-default copy-email-addresses" data-clipboard-target="#admins_curators">
-              <%= t('.copy') %>
-          </button>
+        <button class="btn btn-xs btn-default copy-email-addresses" data-clipboard-target="#admins_curators">
+          <%= t('.copy') %>
+        </button>
       </div>
       <%= Spotlight::Engine.user_class.with_roles.pluck(:email).sort.join(', ') %>
-  </div>
+    </div>
+
+    <h3 class="instructions"><%= t :'.all_users' %></h3>
+    <table class="table table-striped ">
+      <thead>
+        <tr>
+          <th><%= Spotlight::Engine.user_class.human_attribute_name(:email)  %></th>
+          <th><%= Spotlight::Engine.user_class.human_attribute_name(:role)  %></th>
+        </tr>
+      </thead>
+      <tbody class="table">
+        <% @users.each do |user| %>
+          <tr>
+            <td class="<%= 'invite-pending' if user.invite_pending? %>">
+              <%= user.email %>
+              <span class='label label-warning pending-label'><%= t('.pending') %></span>
+            </td>
+            <td class="role">
+              <%= user.roles.map { |r| r.role.titleize }.uniq.join(", ") %>
+            </td>
+            <td>
+              <% if user.superadmin? %>
+                <%= link_to(t('.destroy'), admin_user_path(user), method: :delete, class: 'btn btn-danger pull-right') unless user == current_user %>
+              <% else %>
+                <%= link_to(t('.update'), admin_user_path(user), method: :patch, class: 'btn btn-default pull-right') %>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
 </div>
 
 <aside class="col-md-3">

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -178,7 +178,7 @@ en:
         success: User removed from site adminstrator role
       index:
         add: Add new administrator
-        all_users: Administrators and curators of all exhibits
+        admins_curators: Administrators and curators of all exhibits
         copy: Copy
         destroy: Remove from role
         instructions: Existing exhibits administrators

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -172,20 +172,22 @@ en:
     admin_users:
       create:
         error: There was a problem adding the user as an exhibits adminstrator
-        success: Added user as an exhibits adminstrator
+        success: Added user as an adminstrator
       destroy:
         error: There was a problem removing the user from the site adminstrator role
         success: User removed from site adminstrator role
       index:
-        add: Add new administrator
         admins_curators: Administrators and curators of all exhibits
+        all_users: All registered users
         copy: Copy
-        destroy: Remove from role
+        create: Add new administrator
+        destroy: Remove from admin role
         instructions: Existing exhibits administrators
-        page_title: Manage administrators
+        page_title: Manage users
         pending: pending
         save: Add role
         section: Manage exhibits
+        update: Make user an administrator
     appearances:
       edit:
         header: Appearance

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Spotlight::Engine.routes.draw do
 
   get '/exhibits/edit', to: 'sites#edit_exhibits', as: 'edit_site_exhibits'
 
-  resources :admin_users, only: [:index, :create, :destroy]
+  resources :admin_users, only: [:index, :create, :update, :destroy]
 
   resources :exhibits, path: '/', except: [:show] do
     member do

--- a/spec/controllers/spotlight/admin_users_controller_spec.rb
+++ b/spec/controllers/spotlight/admin_users_controller_spec.rb
@@ -35,5 +35,15 @@ RSpec.describe Spotlight::AdminUsersController, type: :controller do
         expect(Spotlight::Site.instance.roles.where(user_id: user.id)).to be_none
       end
     end
+
+    describe 'PATCH update' do
+      let(:non_admin) { FactoryBot.create(:exhibit_visitor) }
+      it 'adds the site admin role to the given user' do
+        patch :update, params: { id: non_admin.id }
+        expect(response).to redirect_to(admin_users_path)
+        expect(flash[:notice]).to eq 'Added user as an adminstrator'
+        expect(non_admin.roles.map(&:role)).to eq ['admin']
+      end
+    end
   end
 end

--- a/spec/features/site_admin_management_spec.rb
+++ b/spec/features/site_admin_management_spec.rb
@@ -17,10 +17,10 @@ describe 'Site admin management', js: true do
 
   describe 'copy email addresses' do
     it 'displays only email addresses of users w/ roles' do
-      expect(page).to have_css('div#all_users', text: user.email)
-      expect(page).to have_css('div#all_users', text: exhibit_admin.email)
-      expect(page).to have_css('div#all_users', text: exhibit_curator.email)
-      expect(page).not_to have_css('div#all_users', text: existing_user.email)
+      expect(page).to have_css('div#admins_curators', text: user.email)
+      expect(page).to have_css('div#admins_curators', text: exhibit_admin.email)
+      expect(page).to have_css('div#admins_curators', text: exhibit_curator.email)
+      expect(page).not_to have_css('div#admins_curators', text: existing_user.email)
       expect(page).to have_css('button.copy-email-addresses')
     end
   end

--- a/spec/features/site_users_management_spec.rb
+++ b/spec/features/site_users_management_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe 'Site admin management', js: true do
+describe 'Site users management', js: true do
   let(:user) { FactoryBot.create(:site_admin) }
   let!(:existing_user) { FactoryBot.create(:exhibit_visitor) }
   let!(:exhibit_admin) { FactoryBot.create(:exhibit_admin) }
@@ -25,17 +25,6 @@ describe 'Site admin management', js: true do
     end
   end
 
-  it 'allows for existing users to be added as site adminstrators' do
-    expect(page).not_to have_css('td', text: existing_user.email)
-    click_link 'Add new administrator'
-
-    fill_in 'user_email', with: existing_user.email
-    click_button 'Add role'
-
-    expect(page).to have_content('Added user as an exhibits adminstrator')
-    expect(page).to have_css('td', text: existing_user.email)
-  end
-
   it 'allows non-existing users to be invited' do
     click_link 'Add new administrator'
 
@@ -55,15 +44,13 @@ describe 'Site admin management', js: true do
 
     expect(page).to have_css(:td, text: 'not-an-admin@example.com')
 
-    expect(page).to have_css(:a, text: 'Remove from role', count: 2)
+    expect(page).to have_css(:a, text: 'Remove from admin role', count: 4)
     within(all('table tbody tr').last) do
-      click_link 'Remove from role'
+      click_link 'Remove from admin role'
     end
 
     expect(page).to have_content 'User removed from site adminstrator role'
-    expect(page).to have_css(:a, text: 'Remove from role', count: 1)
-
-    expect(page).not_to have_css(:td, text: 'not-an-admin@example.com')
+    expect(page).to have_css(:a, text: 'Remove from admin role', count: 2)
   end
 
   it 'sends an invitation email to users who do not exist' do
@@ -82,6 +69,6 @@ describe 'Site admin management', js: true do
 
     expect(page).to have_css('td', text: user.email)
     # There are two users, the original site admin and our admin user so only one button
-    expect(page).to have_css(:a, text: 'Remove from role', count: 1)
+    expect(page).to have_css(:a, text: 'Remove from admin role', count: 2)
   end
 end


### PR DESCRIPTION
This PR creates a new table on the AdminUsers page that lists all registered users and their roles:

<img width="977" alt="Screen Shot 2019-10-21 at 4 04 28 PM" src="https://user-images.githubusercontent.com/985416/67285849-efb26700-f49d-11e9-8ec6-d73e3bff2c5a.png">

Fixes GH-2108.