### PR TITLE
IIIF manifests for uploaded resources should match host protocol

### DIFF
--- a/app/presenters/spotlight/iiif_manifest_presenter.rb
+++ b/app/presenters/spotlight/iiif_manifest_presenter.rb
@@ -76,7 +76,8 @@ module Spotlight
     def iiif_url
       Spotlight::Engine.config.iiif_url_helpers.info_url(
         uploaded_resource.upload.id,
-        host: controller.request.host_with_port
+        host: controller.request.host_with_port,
+        protocol: controller.request.protocol
       ).sub(%r{/info\.json\Z}, '')
     end
   end

--- a/spec/presenters/spotlight/iiif_manifest_presenter_spec.rb
+++ b/spec/presenters/spotlight/iiif_manifest_presenter_spec.rb
@@ -119,7 +119,8 @@ describe Spotlight::IiifManifestPresenter do
 
     describe '#iiif_url' do
       it 'returns the info_url from the Riiif engine routes, minus the trailing .json' do
-        expect(subject.send(:iiif_url)).to eq('http://localhost:3000/images/2')
+        controller.request.stub(:protocol).and_return('https')
+        expect(subject.send(:iiif_url)).to eq('https://localhost:3000/images/2')
       end
     end
   end


### PR DESCRIPTION
A small follow-up to #2203. 
### Summary
This ensures that `#iiif_url` uses the same protocol as the host. I noticed that our Spotlight instance started serving up manifests with HTTP image service IDs instead of HTTPS ids (see below). 

### Context
So I _think_ what's happening here... 
`IIIFManifest::IIIFEndpoint` is instantiated with the URL provided by `#iiif_url`.
https://github.com/projectblacklight/spotlight/blob/62b3c7b056d5fcfa3e4a8877780c73cb4b157c46/app/presenters/spotlight/iiif_manifest_presenter.rb#L72-L74

Spotlight uses the `iiif_manifest` gem to construct manifests for uploaded resources. In this case it passes the HTTP URL on to `iiif_manifest`'s [image service builder](https://github.com/samvera/iiif_manifest/blob/15676e227b0ff3fcc68ac8eb4204468d0e997912/lib/iiif_manifest/manifest_builder/image_service_builder.rb#L10-L12): 

```
      def apply(resource)
        service['@context'] = iiif_endpoint.context
        service['@id'] = iiif_endpoint.url
```

OSD doesn't mind, but when I tried to use Mirdor 3 in this context it threw `Blocked loading mixed active content` errors for requesting an HTTP info.json. 

### Example
 https://exhibits.stanford.edu/sup125/catalog/103-24973/manifest
```json
...
images ": [
  {
    "@type": "oa:Annotation",
    "motivation": "sc:painting",
    "resource": {
      "@type": "dctypes:Image",
      "@id": "107-6912",
      "height": 3024,
      "width": 4032,
      "format": "image/jpeg",
      "service": {
        "@context": "http://iiif.io/api/image/2/context.json",
        "@id": "http://exhibits-stage.stanford.edu/images/4175",
        "profile": "http://iiif.io/api/image/2/level2.json"
      }
    },
    "on": "https://exhibits-stage.stanford.edu/external-iiif-and-upload-images-test-august-2019/catalog/107-6912/manifest/canvas/107-6912"
  }
]
...
```