### PR TITLE
Add Arabic to curator menu

### DIFF
--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -140,6 +140,7 @@ en:
       submit: Save changes
       update: Save changes
   locales:
+    ar: Arabic
     de: German
     en: English
     es: Spanish

--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -202,6 +202,7 @@ module Spotlight
     Blacklight::Engine.config.inject_blacklight_helpers = false
 
     config.i18n_locales = {
+      ar: 'العربية',
       de: 'Deutsch',
       en: 'English',
       es: 'Español',

--- a/spec/helpers/spotlight/languages_helper_spec.rb
+++ b/spec/helpers/spotlight/languages_helper_spec.rb
@@ -8,6 +8,7 @@ describe Spotlight::LanguagesHelper, type: :helper do
       expect(helper.add_exhibit_language_dropdown_options).to match_array(
         [
           ['Albanian', :sq],
+          ['Arabic', :ar],
           ['Chinese', :zh],
           ['Dutch', :nl],
           ['French', :fr],


### PR DESCRIPTION
Follow-on to #2214 
sul-dlss/dlme#606 

This PR makes Arabic available in the Configuration > General > Languages menu. 

<img width="623" alt="Screen Shot 2019-10-30 at 12 11 53 PM" src="https://user-images.githubusercontent.com/5402927/67890734-7d312f00-fb0e-11e9-909b-b4da90aef0f3.png">