### PR TITLE
Allow applications to configure solr document routing constraints and…

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,7 +56,8 @@ Spotlight::Engine.routes.draw do
     resources :solr_documents,
               except: [:index],
               path: '/catalog',
-              controller: 'catalog' do
+              controller: 'catalog',
+              **Spotlight::Engine.config.routes.solr_documents do
       concerns :exportable
 
       member do

--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -283,5 +283,8 @@ module Spotlight
       FeaturedPages SolrDocuments SolrDocumentsCarousel SolrDocumentsEmbed
       SolrDocumentsFeatures SolrDocumentsGrid SearchResults
     )
+
+    config.routes = OpenStruct.new
+    config.routes.solr_documents = {}
   end
 end

--- a/spec/routing/spotlight/exhibit_catalog_spec.rb
+++ b/spec/routing/spotlight/exhibit_catalog_spec.rb
@@ -15,5 +15,20 @@ RSpec.describe 'Catalog controller', type: :routing do
     it 'routes to #manifest' do
       expect(get('/1/catalog/1-1/manifest.json')).to route_to('spotlight/catalog#manifest', exhibit_id: '1', id: '1-1', format: 'json')
     end
+
+    context 'when the routing constraint is set to allow periods' do
+      before do
+        allow(Spotlight::Engine.config.routes).to receive(:solr_documents).and_return(constraints: { id: %r{[^/]+} })
+        Rails.application.reload_routes!
+      end
+
+      after do
+        Rails.application.reload_routes!
+      end
+
+      it 'routes to #show as expected' do
+        expect(get('/1/catalog/gallica.bnf.fr')).to route_to('spotlight/catalog#show', exhibit_id: '1', id: 'gallica.bnf.fr')
+      end
+    end
   end
 end


### PR DESCRIPTION
… other parameters using engine configuration.

This restores the configurability from 60a80b13f3de79c91ea2c218a5afdbfded17237c (which was removed upstream, as it isn't needed in Blacklight itself)