### PR TITLE
Enable HTML lang attribute to use I18n.locale value

### DIFF
--- a/app/views/layouts/spotlight/spotlight.html.erb
+++ b/app/views/layouts/spotlight/spotlight.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="no-js">
+<%= content_tag :html, class: 'no-js', **html_tag_attributes do %>
   <head>
     <meta charset="utf-8">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
@@ -52,4 +52,4 @@
 
   <%= render :partial => 'shared/footer' %>
   </body>
-</html>
+<% end %>

--- a/app/views/layouts/spotlight/spotlight.html.erb
+++ b/app/views/layouts/spotlight/spotlight.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<%= content_tag :html, class: 'no-js', **html_tag_attributes do %>
+<%= content_tag :html, class: 'no-js', **(try(:html_tag_attributes) || {}) do %>
   <head>
     <meta charset="utf-8">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">


### PR DESCRIPTION
Backport to v2.x release

Slightly different than #2246 as we are assuming the Blacklight helper is not available. 🤷‍♂ 