### PR TITLE
Fix up facet configs after Bootstrap 4 upgrade

### DIFF
--- a/app/assets/stylesheets/spotlight/_blacklight_configuration.scss
+++ b/app/assets/stylesheets/spotlight/_blacklight_configuration.scss
@@ -74,3 +74,37 @@
     display: inline;
   }
 }
+
+.facet_fields {
+
+  .dd3-content {
+    border: 1px solid $card-border-color;
+    border-radius: .25rem;
+  }
+
+  .options {
+    padding-left: $table-cell-padding;
+
+    .col-form-label {
+      font-weight: 700;
+    }
+
+    .form-group {
+      align-items: center;
+    }
+  }
+
+  .page {
+    padding: $table-cell-padding 0 $table-cell-padding $table-cell-padding;
+
+    .main {
+      align-items: center;
+      margin-left: 0;
+      margin-right: 0;
+    }
+
+    .form-check {
+      float: left;
+    }
+  }
+}

--- a/app/views/spotlight/search_configurations/_facets.html.erb
+++ b/app/views/spotlight/search_configurations/_facets.html.erb
@@ -1,5 +1,5 @@
 <p class="instructions"><%=t(:'.help') %></p>
-<div class="panel-group dd facet_fields" id="nested-fields" data-behavior="nestable" data-max-depth="1">
+<div class="dd facet_fields" id="nested-fields" data-behavior="nestable" data-max-depth="1">
   <ol class="dd-list">
     <%= f.fields_for :facet_fields do |idxf| %>
       <% @blacklight_configuration.blacklight_config.facet_fields.select { |k, v| blacklight_configuration_context.evaluate_if_unless_configuration(v.original) }.each do |key, config| %>
@@ -8,21 +8,23 @@
         <li class="dd-item" data-id="<%= key.parameterize %>">
           <div class="dd-handle dd3-handle"><%= t :drag %></div>
           <%= idxf.fields_for key do |facet| %>
-            <div class="dd3-content card facet-config-<%= key.parameterize %>">
-              <div class="card-body page">
-                <%= facet.hidden_field :weight, 'data-property' => 'weight' %>
-                <%= facet.check_box :show, checked: config.show, label: "", title: key %>
+            <div class="dd3-content facet-config-<%= key.parameterize %>">
+              <div class="page">
                 <div class="main row">
-                  <div class="col-sm-5">
-                    <h3 class="h6 card-title" data-in-place-edit-target=".edit-in-place" data-in-place-edit-field-target="[data-edit-field-target='true']">
-                      <a href="#edit-in-place" class="field-label edit-in-place"><%= facet_field_label(key) %></a>
-                      <%= facet.hidden_field :label, value: facet_field_label(key), class: 'form-control form-control-sm', data: {:"edit-field-target" => 'true'} %>
+                  <div class="col-sm-4">
+                    <h3 class="h6">
+                      <%= facet.hidden_field :weight, 'data-property' => 'weight' %>
+                      <%= facet.check_box :show, checked: config.show, hide_label: true, title: key %>
+                      <span class="d-inline-block w-75" data-in-place-edit-target=".edit-in-place" data-in-place-edit-field-target="[data-edit-field-target='true']">
+                        <a href="#edit-in-place" class="field-label edit-in-place"><%= facet_field_label(key) %></a>
+                        <%= facet.hidden_field :label, value: facet_field_label(key), class: 'form-control form-control-sm', data: {:"edit-field-target" => 'true'} %>
+                      </span>
                     </h3>
                   </div>
                   <div class="facet-metadata col-sm-5">
                     <%= render partial: 'facet_metadata', locals: { metadata: metadata } %>
                   </div>
-                  <div class="col-sm-2 float-right">
+                  <div class="col-sm-3 float-right">
                     <a class="btn btn-link collapse-toggle collapsed" role="button" data-toggle="collapse" href="#<%= key.parameterize %>_facet_options" aria-expanded="false" aria-controls="<%= key.parameterize %>_facet_options">
                       Options
                     </a>
@@ -30,8 +32,8 @@
                   </div>
                 </div>
               </div>
-                <div id="<%= key.parameterize %>_facet_options" class="options card-footer bg-light collapse">
-                  <%= facet.form_group :terms, label_col: 'col-md-2', label: { text: t(:'.sort_by.label') } do %>
+                <div id="<%= key.parameterize %>_facet_options" class="options collapse">
+                  <%= facet.form_group :terms, label_col: 'col-md-2 offset-md-1', label: { text: t(:'.sort_by.label') } do %>
                     <%= facet.radio_button :sort, 'count', label: t(:'.sort_by.count'), inline: true, checked: (config.sort.to_s == 'count' || config.sort.nil?) %>
                     <%= facet.radio_button :sort, 'index', label: t(:'.sort_by.index'), inline: true, checked: (config.sort.to_s == 'index') %>
                   <% end %>


### PR DESCRIPTION
Closes #2234

## Before
<img width="853" alt="facet elements breaking onto next line" src="https://user-images.githubusercontent.com/96776/68328351-f5a26d80-0083-11ea-85e0-4555fb97de34.png">

## After
![facet elements inline](https://user-images.githubusercontent.com/5402927/68633594-49a7ba80-04a7-11ea-9d74-cc9e4ec71e38.png)

