### PR TITLE
Restore drag handles to browse category config after Bootstrap 4 upgrade

### DIFF
--- a/app/views/spotlight/searches/_search.html.erb
+++ b/app/views/spotlight/searches/_search.html.erb
@@ -1,6 +1,5 @@
 <% search = f.object %>
 <li class="dd-item dd3-item" data-id="<%= search.id %>">
-  <div class="dd-handle dd3-handle"><%= t :drag %></div>
   <div class="dd3-content card">
     <div class="row search no-gutters">
       <div class="col-md-2">
@@ -33,4 +32,5 @@
         </div>
       </div>
     </div>
+    <div class="dd-handle dd3-handle"><%= t :drag %></div>
 </li>


### PR DESCRIPTION
## Before
![no-drag-handles](https://user-images.githubusercontent.com/5402927/68703179-f123fc00-053e-11ea-9baa-2c8b3b1b2ebe.png)

## After
![restored-drag-handles](https://user-images.githubusercontent.com/5402927/68703180-f123fc00-053e-11ea-95fc-def31de52d62.png)
