### PR TITLE
Disable turbolinks when changing locales

### DIFF
--- a/app/views/spotlight/shared/_locale_picker.html.erb
+++ b/app/views/spotlight/shared/_locale_picker.html.erb
@@ -6,7 +6,7 @@
     <ul class="dropdown-menu">
       <% locale_selecter_dropown_options.each do |language| %>
         <li>
-          <%= link_to language.to_native, (spotlight.url_for(locale: lanaguage.locale) rescue url_for(locale: language.locale)), class: 'dropdown-item' %>
+          <%= link_to language.to_native, (spotlight.url_for(locale: lanaguage.locale) rescue url_for(locale: language.locale)), class: 'dropdown-item', data: { turbolinks: false } %>
         </li>
       <% end %>
     </ul>


### PR DESCRIPTION
It seems like things get a little funny because the locales/rtl stuff works based on changes to the `<html>` DOM element, which may not get reloaded.