### PR TITLE
Center the unpublished banner; fixes #2255

### DIFF
--- a/app/assets/stylesheets/spotlight/_exhibits_index.scss
+++ b/app/assets/stylesheets/spotlight/_exhibits_index.scss
@@ -63,6 +63,7 @@
   .unpublished {
     @extend .mx-auto;
 
+    display: block;
     font-size: $font-size-base;
     margin-top: -1em;
     position: relative;


### PR DESCRIPTION
<img width="716" alt="Screen Shot 2019-11-13 at 06 45 01" src="https://user-images.githubusercontent.com/111218/68773950-40226d80-05e1-11ea-9ea8-02144922b3dd.png">
