### PR TITLE
Put browse category links into a row so they align correctly; fixes #2263

### DIFF
--- a/app/views/spotlight/browse/index.html.erb
+++ b/app/views/spotlight/browse/index.html.erb
@@ -1,6 +1,6 @@
 <% set_html_page_title %>
 <h1 class="sr-only"><%= t :'.header' %></h1>
 
-<div class="browse-landing">
+<div class="browse-landing row">
   <%= render collection: @searches, partial: 'spotlight/browse/search' %>
 </div>


### PR DESCRIPTION
<img width="831" alt="Screen Shot 2019-11-13 at 06 52 13" src="https://user-images.githubusercontent.com/111218/68774564-259cc400-05e2-11ea-9f89-65debec3bc1d.png">
