### PR TITLE
Wrap the browse category search box in a row; part of #2262

### DIFF
--- a/app/assets/stylesheets/spotlight/_browse.scss
+++ b/app/assets/stylesheets/spotlight/_browse.scss
@@ -106,8 +106,11 @@ $image-overlay-bottom-margin: 36px;
 
 .search-box-container {
   margin: 0 auto;
-  text-align: center;
   width: 100%;
+
+  .col-form-label {
+    text-align: right;
+  }
 
   .browse-search-form {
     .browse-search-expand {

--- a/app/controllers/spotlight/browse_controller.rb
+++ b/app/controllers/spotlight/browse_controller.rb
@@ -6,8 +6,7 @@ module Spotlight
   # for the curator's create-update-delete actions)
   class BrowseController < Spotlight::ApplicationController
     load_and_authorize_resource :exhibit, class: 'Spotlight::Exhibit'
-    include Spotlight::Base
-    include Spotlight::SearchHelper
+    include Spotlight::Catalog
     include Blacklight::Facet
 
     load_and_authorize_resource :search, except: :index, through: :exhibit, parent: false
@@ -126,6 +125,10 @@ module Spotlight
 
     def presenter(document)
       view_context.index_presenter(document)
+    end
+
+    def render_save_this_search?
+      false
     end
   end
 end

--- a/app/views/spotlight/browse/_search_box.html.erb
+++ b/app/views/spotlight/browse/_search_box.html.erb
@@ -1,8 +1,8 @@
 <div class="search-box-container">
   <%= form_tag exhibit_browse_path(current_exhibit, search), method: :get, class: 'browse-search-form form-horizontal', role: 'browse-search' do %>
     <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :exhibit_id, :browse_q, :qt, :page, :utf8)) %>
-    <div class="form-group">
-        <label class="col-sm-4 col-form-label" for="browse_q"><%= t(:'.label') %></label>
+    <div class="form-group row">
+      <label class="col-sm-4 col-form-label" for="browse_q"><%= t(:'.label') %></label>
       <div class="col-sm-6">
         <div class="input-group">
           <%= text_field_tag :browse_q, params[:browse_q], placeholder: t(:'.placeholder'), class: "form-control", id: "browse_q" %>

--- a/app/views/spotlight/browse/_search_box.html.erb
+++ b/app/views/spotlight/browse/_search_box.html.erb
@@ -2,7 +2,7 @@
   <%= form_tag exhibit_browse_path(current_exhibit, search), method: :get, class: 'browse-search-form form-horizontal', role: 'browse-search' do %>
     <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :exhibit_id, :browse_q, :qt, :page, :utf8)) %>
     <div class="form-group row">
-      <label class="col-sm-4 col-form-label" for="browse_q"><%= t(:'.label') %></label>
+      <label class="col-sm-4 col-form-label h6" for="browse_q"><%= t(:'.label') %></label>
       <div class="col-sm-6">
         <div class="input-group">
           <%= text_field_tag :browse_q, params[:browse_q], placeholder: t(:'.placeholder'), class: "form-control", id: "browse_q" %>

--- a/app/views/spotlight/browse/_sort_and_per_page.html.erb
+++ b/app/views/spotlight/browse/_sort_and_per_page.html.erb
@@ -1,7 +1,5 @@
-<div id="sortAndPerPage" class="clearfix">
-  <div class="search-widgets float-right">
-    <%= render :partial => 'sort_widget' %>
-    <%= render :partial => 'per_page_widget' %>
-    <%= render :partial => 'view_type_group' %>
+<div id="sortAndPerPage" class="sort-pagination clearfix">
+  <div class="search-widgets float-md-right">
+    <%= render_results_collection_tools wrapping_class: "search-widgets float-md-right" %>
   </div>
 </div>

--- a/spec/views/spotlight/browse/_sort_and_per_page.html.erb_spec.rb
+++ b/spec/views/spotlight/browse/_sort_and_per_page.html.erb_spec.rb
@@ -1,23 +1,12 @@
 # frozen_string_literal: true
 
 describe 'spotlight/browse/_sort_and_per_page', type: :view do
-  let :blacklight_config do
-    Blacklight::Configuration.new
-  end
-
   before do
-    allow(view).to receive_messages(blacklight_config: blacklight_config)
+    allow(view).to receive_messages(render_results_collection_tools: 'collection tools')
   end
 
   it 'renders the pagination, sort, per page and view type controls' do
-    stub_template '_paginate_compact.html.erb' => "paginate_compact\n"
-    stub_template '_sort_widget.html.erb' => "sort_widget\n"
-    stub_template '_per_page_widget.html.erb' => "per_page_widget\n"
-    stub_template '_view_type_group.html.erb' => "view_type_group\n"
     render
-    expect(rendered).to_not have_content 'paginate_compact'
-    expect(rendered).to have_content 'sort_widget'
-    expect(rendered).to have_content 'per_page_widget'
-    expect(rendered).to have_content 'view_type_group'
+    expect(rendered).to have_content 'collection tools'
   end
 end


### PR DESCRIPTION
<img width="948" alt="Screen Shot 2019-11-15 at 08 28 43" src="https://user-images.githubusercontent.com/111218/68958945-f9b84480-0781-11ea-9bf9-32dfbf30c50a.png">

Fixes #2262
