### PR TITLE
Align resource-specific mastheads to the right; part of #2281

### DIFF
--- a/app/views/shared/_exhibit_navbar.html.erb
+++ b/app/views/shared/_exhibit_navbar.html.erb
@@ -4,7 +4,7 @@
       <%= link_to(current_exhibit.title, spotlight.exhibit_path(current_exhibit), class: 'navbar-brand') %>
     <% end %>
 
-    <ul class="navbar-nav mr-auto">
+    <ul class="navbar-nav <%= resource_masthead? ? 'justify-content-md-end' : 'mr-auto' %>">
       <li class="nav-item <%= "active" if current_page?([spotlight, current_exhibit]) %>"><%= link_to t(:'spotlight.curation.nav.home'), [spotlight, current_exhibit], class: 'nav-link' %></li>
       <% current_exhibit.main_navigations.displayable.each do |navigation| %>
         <%= render partial: "shared/#{navigation.nav_type}_navbar", locals: { navigation: navigation } %>


### PR DESCRIPTION
<img width="306" alt="Screen Shot 2019-11-14 at 13 48 19" src="https://user-images.githubusercontent.com/111218/68898978-7ea15080-06e5-11ea-9698-2b13bc4bbf8d.png">
