### PR TITLE
Fix page hover state

### DIFF
--- a/app/assets/stylesheets/spotlight/_curation.scss
+++ b/app/assets/stylesheets/spotlight/_curation.scss
@@ -79,7 +79,7 @@
   display: none;
 }
 
-.card-body.page {
+.card.page-admin {
   &:hover {
     @include panel-hover-highlighting;
   }

--- a/app/assets/stylesheets/spotlight/_mixins.scss
+++ b/app/assets/stylesheets/spotlight/_mixins.scss
@@ -9,7 +9,7 @@
 }
 
 @mixin panel-hover-highlighting() {
-  background-color: $gray-300;
+  background: $gray-300;
 }
 
 @mixin private-label() {


### PR DESCRIPTION
Without this, the page hover background is applied to the wrong element and overflows its container.