### PR TITLE
Tweak metadata config checkbox alignment

### DIFF
--- a/app/assets/stylesheets/spotlight/_blacklight_configuration.scss
+++ b/app/assets/stylesheets/spotlight/_blacklight_configuration.scss
@@ -59,6 +59,12 @@
 #nested-fields {
   margin-bottom: 1em;
 
+  .metadata_fields {
+    .checkbox-cell {
+      vertical-align: middle;
+    }
+  }
+
   .metadata-select {
     display: inline-block;
     min-width: 72px;


### PR DESCRIPTION
Fixes #2295

## Before
<img width="801" alt="checkboxes top aligned" src="https://user-images.githubusercontent.com/5402927/68981891-df9a5880-07b9-11ea-8fb8-21dd14929208.png">

## After
<img width="783" alt="checkboxes middle aligned" src="https://user-images.githubusercontent.com/5402927/68984857-4ffba680-07c7-11ea-8389-f93ef01fe055.png">
