### PR TITLE
Remove the nav-link class from the Create Exhibit button.

### DIFF
--- a/app/views/shared/_site_sidebar.html.erb
+++ b/app/views/shared/_site_sidebar.html.erb
@@ -14,6 +14,6 @@
 </ul>
 
 <ul class="nav sidenav nav-pills nav-stacked">
-  <li class="nav-item"><%= link_to t(:'spotlight.sites.new.page_title'), spotlight.new_exhibit_path, class: 'btn btn-outline-secondary btn-nav nav-link', role: 'button' if can? :create, Spotlight::Exhibit %></li>
+  <li class="nav-item"><%= link_to t(:'spotlight.sites.new.page_title'), spotlight.new_exhibit_path, class: 'btn btn-outline-secondary btn-nav', role: 'button' if can? :create, Spotlight::Exhibit %></li>
 </ul>
 <% end %>


### PR DESCRIPTION
_I'm pretty sure this was a larger button previously, feel free to 🔪 this if we decide it's not a good idea._

## Before
<img width="1153" alt="before" src="https://user-images.githubusercontent.com/96776/69099464-a6f3bc80-0a0f-11ea-97ea-ed006d696803.png">

## After
<img width="1138" alt="after" src="https://user-images.githubusercontent.com/96776/69099466-a6f3bc80-0a0f-11ea-9715-e9d6f7614bbe.png">
