### PR TITLE
Add engine configuration to enable/disable exporting parts of an exhibit

### DIFF
--- a/app/serializers/spotlight/page_representer.rb
+++ b/app/serializers/spotlight/page_representer.rb
@@ -28,6 +28,6 @@ module Spotlight
                              class: Spotlight::FeaturePage,
                              extend: NestedPageRepresenter
 
-    property :thumbnail, class: Spotlight::FeaturedImage, decorator: FeaturedImageRepresenter
+    property :thumbnail, class: Spotlight::FeaturedImage, decorator: FeaturedImageRepresenter, if: Spotlight::ExhibitExportSerializer.config?(:attachments)
   end
 end

--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -254,5 +254,13 @@ module Spotlight
 
     config.routes = OpenStruct.new
     config.routes.solr_documents = {}
+
+    config.exports = {
+      attachments: true,
+      blacklight_configuration: true,
+      config: true,
+      pages: true,
+      resources: true
+    }
   end
 end

--- a/spec/serializers/spotlight/exhibit_export_serializer_spec.rb
+++ b/spec/serializers/spotlight/exhibit_export_serializer_spec.rb
@@ -360,4 +360,32 @@ describe Spotlight::ExhibitExportSerializer do
       end
     end
   end
+
+  context 'with engine configuration disabling all export types' do
+    let(:exports) do
+      {}
+    end
+
+    before do
+      allow(Spotlight::Engine.config).to receive(:exports).and_return(exports)
+    end
+
+    it 'includes nothing' do
+      expect(subject).to be_blank
+    end
+  end
+
+  context 'with engine configuration enabling only pages' do
+    let(:exports) do
+      { pages: true }
+    end
+
+    before do
+      allow(Spotlight::Engine.config).to receive(:exports).and_return(exports)
+    end
+
+    it 'includes only the page-related data' do
+      expect(subject.keys).to match_array %w[searches about_pages feature_pages home_page contacts]
+    end
+  end
 end


### PR DESCRIPTION
This should allow e.g. implementors to exclude resources and solr documents from their exports which is most likely to contribute to bloating export size + time.

I think the technical approach is potentially amenable to run-time selection (by the admin), but I figured that'd make a good phase 2.