### PR TITLE
Move dropdown-item class to links instead of <li>

### DIFF
--- a/app/views/shared/_curated_features_navbar.html.erb
+++ b/app/views/shared/_curated_features_navbar.html.erb
@@ -5,7 +5,7 @@
       <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown"><%= navigation.label_or_default %> <b class="caret"></b></a>
       <ul class="dropdown-menu">
         <% published_top_level_feature_pages.each do |page| %>
-          <li class="dropdown-item"><%= link_to page.title, [spotlight, page.exhibit, page] %></li>
+          <li><%= link_to page.title, [spotlight, page.exhibit, page], class: 'dropdown-item' %></li>
         <% end %>
       </ul>
     </li>

--- a/app/views/shared/_user_util_links.html.erb
+++ b/app/views/shared/_user_util_links.html.erb
@@ -11,26 +11,26 @@
       <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown"><%=current_user%> <b class="caret"></b></a>
       <ul class="dropdown-menu">
         <% if can? :manage, Spotlight::Site.instance %>
-          <li class="dropdown-item"><%= link_to t(:'spotlight.header_links.edit_site'), spotlight.edit_site_path %></li>
+          <li><%= link_to t(:'spotlight.header_links.edit_site'), spotlight.edit_site_path, class: 'dropdown-item' %></li>
         <% end %>
         <% if can? :create, Spotlight::Exhibit %>
-          <li class="dropdown-item">
-            <%= link_to t(:'spotlight.header_links.create_exhibit'), spotlight.new_exhibit_path %>
+          <li>
+            <%= link_to t(:'spotlight.header_links.create_exhibit'), spotlight.new_exhibit_path, class: 'dropdown-item' %>
           </li>
           <li class="dropdown-divider"></li>
         <% end %>
         <% if current_exhibit && can?(:curate, current_exhibit) %>
-          <li class="dropdown-item">
-            <%= link_to t('spotlight.header_links.dashboard'), spotlight.exhibit_dashboard_path(current_exhibit) %>
+          <li>
+            <%= link_to t('spotlight.header_links.dashboard'), spotlight.exhibit_dashboard_path(current_exhibit), class: 'dropdown-item' %>
           </li>
           <li class="dropdown-divider"></li>
         <% end %>
 
-        <li class="dropdown-item">
-          <%= link_to "Change Password", main_app.edit_user_registration_path %>
+        <li>
+          <%= link_to "Change Password", main_app.edit_user_registration_path, class: 'dropdown-item' %>
         </li>
-        <li class="dropdown-item">
-          <%= link_to t('spotlight.header_links.logout'), main_app.destroy_user_session_path %>
+        <li>
+          <%= link_to t('spotlight.header_links.logout'), main_app.destroy_user_session_path, class: 'dropdown-item' %>
         </li>
       </ul>
     </li>


### PR DESCRIPTION
Fixes #2309 This was causing some styling display issues. BS4 updated
how these elements should be styled.

We could go further by removing the `<li>` but I've kept that for
consistency.

## Before
![Screen Shot 2019-11-20 at 3 23 28 PM](https://user-images.githubusercontent.com/1656824/69283981-bfe4a500-0baa-11ea-8ab3-3f20a59dbc4a.png)

## After
![Screen Shot 2019-11-20 at 3 29 02 PM](https://user-images.githubusercontent.com/1656824/69283980-bfe4a500-0baa-11ea-8ed9-76f83042f7d4.png)


