### PR TITLE
Improve contact info alignment when using contact photo

### DIFF
--- a/app/assets/stylesheets/spotlight/_pages.scss
+++ b/app/assets/stylesheets/spotlight/_pages.scss
@@ -113,7 +113,7 @@
 
 // Indent contact fields so they align evenly, only when there is a contact photo
 .sidenav.contacts .contact-photo + div[itemprop] ~ div[itemprop] {
-  margin-left: 87px;
+  margin-left: 85px;
 }
 
 .item-grid-block {


### PR DESCRIPTION
Super minor update but I noticed that when using a contact photo, the contact info below the name is indented 2px further right than the name (it's subtle but true):

<img width="285" alt="Screen Shot 2019-12-06 at 10 28 25 AM" src="https://user-images.githubusercontent.com/101482/70343139-bf3b4800-1813-11ea-8dc4-7cc84215c819.png">

### After
<img width="285" alt="Screen Shot 2019-12-06 at 10 28 01 AM" src="https://user-images.githubusercontent.com/101482/70343183-d9752600-1813-11ea-8cca-332f6939a751.png">
