### PR TITLE
Add vertical space between page header and page content

### DIFF
--- a/app/assets/stylesheets/spotlight/_bootstrap_overrides.scss
+++ b/app/assets/stylesheets/spotlight/_bootstrap_overrides.scss
@@ -3,10 +3,11 @@
 }
 
 .page-header {
-  @extend .mb-3;
+  @extend .mb-4;
 
   border-bottom: none;
   small {
+    @extend .text-muted;
     font-size: $h2-font-size;
     display: block;
   }


### PR DESCRIPTION
Small update to add a bit more vertical spacing between the page header (I believe this just affects the admin pages) and the page content. Sometimes the page content starts with another heading and the three stacked headings feel too close together:

<img width="496" alt="Screen Shot 2019-12-06 at 11 33 22 AM" src="https://user-images.githubusercontent.com/101482/70347024-df233980-181c-11ea-8d92-ac6c58edef62.png">

### After
<img width="496" alt="Screen Shot 2019-12-06 at 11 33 58 AM" src="https://user-images.githubusercontent.com/101482/70347033-e64a4780-181c-11ea-8695-3cee88d2899b.png">

(This PR also includes moving the text-muted class I added in PR #2318 since I now see I can add it to an existing selector rather than creating a new one as I did in PR #2318. Same result but probably better code organization.) 
