### PR TITLE
Update masthead font sizes and spacing values

### DIFF
--- a/app/assets/stylesheets/spotlight/_header.scss
+++ b/app/assets/stylesheets/spotlight/_header.scss
@@ -20,7 +20,8 @@
 
 
   .site-title {
-    padding-bottom: $padding-base-vertical;
+    margin-top: $padding-large-vertical;
+    padding-bottom: $padding-base-vertical / 2;
     position: relative;
     white-space: nowrap;
   }
@@ -28,9 +29,9 @@
   small {
     @extend .d-none;
     @extend .d-sm-block;
+    @extend .py-2;
 
-    padding-bottom: $padding-base-vertical;
-    padding-top: $padding-base-vertical;
+    font-size: $h4-font-size;
   }
 
   .navbar {
@@ -66,10 +67,9 @@
 
 .site-title-container {
   @extend .px-4;
+  @extend .py-2;
 
   max-height: $masthead-height - $navbar-brand-height;
-  padding-bottom: $padding-large-vertical;
-  padding-top: $padding-large-vertical;
 }
 
 .image-masthead {
@@ -78,9 +78,9 @@
     background-color: $navbar-transparent-page-bg;
   }
 
-  .h1 {
+  .h2 {
     color: $white;
-    text-shadow: 1px 1px 0 $black;
+    text-shadow: 1px 1px 0 $gray-900;
   }
 
   small {

--- a/app/views/shared/_masthead.html.erb
+++ b/app/views/shared/_masthead.html.erb
@@ -13,7 +13,7 @@
   <%= render 'shared/exhibit_navbar' if current_exhibit && resource_masthead? %>
 
   <div class="container site-title-container">
-    <div class="site-title h1">
+    <div class="site-title h2">
       <% if content_for? :masthead %>
         <%= content_for :masthead %>
       <% elsif current_exhibit %>

--- a/spec/features/browse_category_spec.rb
+++ b/spec/features/browse_category_spec.rb
@@ -20,7 +20,7 @@ feature 'Browse pages' do
           expect(page).to have_selector 'h1', text: 'Some Saved Search'
         end
 
-        expect(page).not_to have_selector '.masthead .h1', text: 'Some Saved Search'
+        expect(page).not_to have_selector '.masthead .h2', text: 'Some Saved Search'
       end
 
       it 'shows the search bar' do
@@ -57,7 +57,7 @@ feature 'Browse pages' do
       it 'has a contextual masthead with the title and resource count' do
         visit spotlight.exhibit_browse_path(exhibit, search)
 
-        expect(page).to have_selector '.masthead .h1', text: 'Some Saved Search'
+        expect(page).to have_selector '.masthead .h2', text: 'Some Saved Search'
 
         within '#main-container' do
           expect(page).not_to have_selector 'h1', text: 'Some Saved Search'

--- a/spec/views/shared/_masthead.html.erb_spec.rb
+++ b/spec/views/shared/_masthead.html.erb_spec.rb
@@ -13,7 +13,7 @@ describe 'shared/_masthead', type: :view do
 
   it 'has the site title and subtitle' do
     render
-    expect(rendered).to have_selector '.h1', text: exhibit.title
+    expect(rendered).to have_selector '.h2', text: exhibit.title
     expect(rendered).to have_selector 'small', text: exhibit.subtitle
   end
 


### PR DESCRIPTION
As a result of the BS4 upgrade some of the default typography and spacing values changed and this resulted in a taller masthead with some extra vertical spacing (on the left below is an exhibit based on BS3, on the right is current with BS4):

<img width="1641" alt="Screen Shot 2019-12-06 at 12 54 48 PM" src="https://user-images.githubusercontent.com/101482/70352269-003d5780-1828-11ea-922c-c43e3c882574.png">

### After
I adjusted the font-sizes and spacing values to get something close to what we saw in BS3. We're still using default BS values, so it should be relatively straightforward for implementers to customize.

<img width="1919" alt="Screen Shot 2019-12-06 at 12 36 45 PM" src="https://user-images.githubusercontent.com/101482/70352357-37ac0400-1828-11ea-978a-28c8996131eb.png">
