### PR TITLE
Update feature page sidebar structure and styling

### DIFF
--- a/app/assets/stylesheets/spotlight/_mixins.scss
+++ b/app/assets/stylesheets/spotlight/_mixins.scss
@@ -1,8 +1,3 @@
-@mixin link-highlighting() {
-  // background-color: $nav-link-hover-bg;
-  text-decoration: none;
-}
-
 @mixin edit-in-place-highlighting() {
   background: #F7F7D0;
   cursor: text;

--- a/app/assets/stylesheets/spotlight/_pages.scss
+++ b/app/assets/stylesheets/spotlight/_pages.scss
@@ -69,29 +69,15 @@
   ol.sidenav {
     li {
       color: $gray-900;
-      a {
-        &:hover, &:focus {
-          @include link-highlighting();
-        }
-      }
-      > h4 {
-        font-size: ceil(($font-size-base * 1.05));
-        margin-top: 3 * $padding-large-vertical;
-        > a {
-          color: $text-color;
-          display: block;
-          font-weight: 400;
-        }
-      }
+      margin-top: $padding-large-vertical;
     }
+
     ol.subsection {
       padding-left: 0;
       li {
         list-style: square;
         margin-left: 18px;
-        > a {
-          display: block;
-        }
+        margin-top: $padding-small-vertical;
       }
     }
   }

--- a/app/views/spotlight/feature_pages/_sidebar.html.erb
+++ b/app/views/spotlight/feature_pages/_sidebar.html.erb
@@ -2,7 +2,7 @@
   <ol class="nav sidenav flex-column">
     <% @exhibit.feature_pages.for_locale.published.at_top_level.each do |feature_section| %>
       <li class="<%= 'active' if current_page? [spotlight, @exhibit, feature_section] %>">
-        <h4><%= link_to_unless_current feature_section.title, [spotlight, @exhibit, feature_section] %></h4>
+        <%= link_to_unless_current feature_section.title, [spotlight, @exhibit, feature_section] %>
         <ol class="subsection">
           <% feature_section.child_pages.published.each do |page| %>
             <li class="<%= 'active' if current_page? [spotlight, @exhibit, page] %>"><%= link_to_unless_current page.title, [spotlight, @exhibit, page] %></li>

--- a/spec/features/feature_page_spec.rb
+++ b/spec/features/feature_page_spec.rb
@@ -42,7 +42,7 @@ describe 'Feature page', type: :feature, versioning: true do
         # the sidebar should display
         within('#sidebar') do
           # the current page should be the sidebar header
-          expect(page).to have_css('h4', text: parent_feature_page.title)
+          expect(page).to have_css('li', text: parent_feature_page.title)
           # within the sidebar navigation
           within('ol.sidenav') do
             # there should be a link to the child page

--- a/spec/views/spotlight/feature_pages/_sidebar.html.erb_spec.rb
+++ b/spec/views/spotlight/feature_pages/_sidebar.html.erb_spec.rb
@@ -21,10 +21,10 @@ describe 'spotlight/feature_pages/_sidebar.html.erb', type: :view do
     allow(view).to receive(:current_page?).and_return(true, false)
     render
     # Checking that they are sorted accoding to weight
-    expect(rendered).to have_selector 'li.active h4', text: 'Parent Page'
+    expect(rendered).to have_selector 'li.active', text: 'Parent Page'
     expect(rendered).to have_selector 'ol.sidenav li:nth-child(1) a', text: 'Five'
     expect(rendered).to have_selector 'ol.sidenav li:nth-child(2) a', text: 'Three'
-    expect(rendered).to have_selector 'li h4 a', text: 'Two' # a different parent page
+    expect(rendered).to have_selector 'li a', text: 'Two' # a different parent page
     expect(rendered).to have_link 'Four' # different parent
     expect(rendered).not_to have_link 'Six' # not published
     expect(rendered).not_to have_link 'Seven' # different exhibit
@@ -34,7 +34,7 @@ describe 'spotlight/feature_pages/_sidebar.html.erb', type: :view do
     assign(:page, child1)
     render
     # Checking that they are sorted accoding to weight
-    expect(rendered).to have_selector 'h4', text: 'Parent Page'
+    expect(rendered).to have_selector 'li', text: 'Parent Page'
     expect(rendered).to have_selector 'ol.sidenav li:nth-child(1) a', text: 'Five'
     expect(rendered).to have_selector 'ol.sidenav li:nth-child(2) a', text: 'Three'
     expect(rendered).to have_content 'Two' # not selected page


### PR DESCRIPTION
I think the BS4 upgrade affected the styling of the links in the feature page sidebar, which are now too large:

<img width="907" alt="Screen Shot 2019-12-09 at 1 52 22 PM" src="https://user-images.githubusercontent.com/101482/70471949-742b6a00-1a8b-11ea-9bd8-ca540b88e280.png">

I think this has to do with the fact that the parent sidebar links are `<h4>`s, which I don't think they need/should be (all other sidebars in the app just use `<li><a>`s for the sidebar links).

So this PR removes the `<h4>`s and associated styling, and cuts down on other related styling to produce a pretty generic sidebar. Implementors will most likely want to fine-tune the styling of this sidebar to match the way their institution treats links, etc. so my goal was to have something that is readable when there are feature pages with child links to display but otherwise fairly basic.

### After
<img width="802" alt="Screen Shot 2019-12-09 at 1 51 21 PM" src="https://user-images.githubusercontent.com/101482/70472321-219e7d80-1a8c-11ea-84d7-827b734f45d0.png">
