### PR TITLE
Updates browse / page embed styling

### DIFF
--- a/app/assets/stylesheets/spotlight/_featured_browse_categories_block.scss
+++ b/app/assets/stylesheets/spotlight/_featured_browse_categories_block.scss
@@ -1,5 +1,5 @@
 $featured-browse-category-border-color: $border-color;
-$featured-browse-category-caption-color: $gray-700;
+$featured-browse-category-caption-color: $white;
 $container-tablet: 720px;
 $container-desktop: 960px;
 $container-large-desktop: 1140px;
@@ -44,7 +44,7 @@ $aspect-ratio-factor-medium-image: 1; // 1:1 width: height
   .category-caption {
     color: $featured-browse-category-caption-color;
     position: absolute;
-    bottom: $line-height-lg;
+    bottom: 16px; // assumes default font-size of 16px, using browser default of 1 rem == 16px
     text-align: center;
     text-shadow: 0 1px 0 #000000;
     width: 100%;
@@ -53,7 +53,7 @@ $aspect-ratio-factor-medium-image: 1; // 1:1 width: height
     font-size: $font-size-lg;
     line-height: 1.2;
     margin: 0;
-    padding: spacers(1);
+    padding: $spacer / 4;
   }
   .item-count {
     font-size: $font-size-base;


### PR DESCRIPTION
Fixes #2323

Seems like just some cruft from BS4 upgrade

Specified in the issue some things I wasn't really able to recreate:
 - Tiles too tall (fixing might take care of next couple of items?)
 - Spacing between category tiles
 - Row extends past right-edge of page content area

I'm happy to look into this further, but not exactly sure how to proceed.

## Before
<img width="1140" alt="Screen Shot 2019-12-09 at 2 59 57 PM" src="https://user-images.githubusercontent.com/1656824/70476772-a5f4fe80-1a94-11ea-9efb-cdf037537e5e.png">

## After
<img width="1138" alt="Screen Shot 2019-12-09 at 2 58 25 PM" src="https://user-images.githubusercontent.com/1656824/70476773-a68d9500-1a94-11ea-8985-ed4c97e1eea0.png">
