### PR TITLE
Update responsive styling for exhibit navbar

### DIFF
--- a/app/assets/stylesheets/spotlight/_header.scss
+++ b/app/assets/stylesheets/spotlight/_header.scss
@@ -28,7 +28,7 @@
 
   small {
     @extend .d-none;
-    @extend .d-sm-block;
+    @extend .d-md-block;
     @extend .py-2;
 
     font-size: $h4-font-size;

--- a/app/views/shared/_exhibit_navbar.html.erb
+++ b/app/views/shared/_exhibit_navbar.html.erb
@@ -1,4 +1,4 @@
-<div id="exhibit-navbar" class="exhibit-navbar navbar navbar-light navbar-expand-sm" role="navigation">
+<div id="exhibit-navbar" class="exhibit-navbar navbar navbar-light navbar-expand-md" role="navigation">
   <div class="container">
     <% if resource_masthead? %>
       <%= link_to(current_exhibit.title, spotlight.exhibit_path(current_exhibit), class: 'navbar-brand') %>


### PR DESCRIPTION
Fixes #2324

## Small
<img width="928" alt="Screen Shot 2019-12-09 at 4 24 10 PM" src="https://user-images.githubusercontent.com/1656824/70481653-7ea42e80-1aa0-11ea-9ab7-42de4fa870ea.png">

## Medium
<img width="969" alt="Screen Shot 2019-12-09 at 4 24 05 PM" src="https://user-images.githubusercontent.com/1656824/70481654-7ea42e80-1aa0-11ea-8c35-2abe407f472f.png">
