### PR TITLE
Fix bug in SearchRresults widget

### DIFF
--- a/app/controllers/concerns/spotlight/search_helper.rb
+++ b/app/controllers/concerns/spotlight/search_helper.rb
@@ -1,8 +1,8 @@
 module Spotlight
   # ...
   module SearchHelper
-    def search_service
-      search_service_class.new(config: blacklight_config, user_params: (respond_to?(:search_state, true) ? search_state.to_h : {}), **search_service_context)
+    def search_service(user_params = respond_to?(:search_state, true) ? search_state.to_h : {})
+      search_service_class.new(config: blacklight_config, user_params: user_params, **search_service_context)
     end
 
     def search_service_class

--- a/app/controllers/spotlight/pages_controller.rb
+++ b/app/controllers/spotlight/pages_controller.rb
@@ -118,6 +118,7 @@ module Spotlight
 
     def undo_link
       return unless can? :manage, @page
+      return if @page.versions.blank?
 
       view_context.link_to(t(:'spotlight.versions.undo'), revert_version_path(@page.versions.last), method: :post)
     end

--- a/app/controllers/spotlight/pages_controller.rb
+++ b/app/controllers/spotlight/pages_controller.rb
@@ -116,6 +116,14 @@ module Spotlight
       @_prefixes ||= super + ['catalog']
     end
 
+    # Add a Page specific search_results method that takes user params as
+    # an option and passes that off to the search service to get results
+    # @param [Hash] the query parameters
+    # @return [Object] the search results object from the configured search service
+    def search_results(user_params)
+      search_service(user_params).search_results
+    end
+
     def undo_link
       return unless can? :manage, @page
       return if @page.versions.blank?

--- a/spec/features/javascript/blocks/search_result_block_spec.rb
+++ b/spec/features/javascript/blocks/search_result_block_spec.rb
@@ -11,14 +11,19 @@ describe 'Search Result Block', type: :feature, js: true do
     login_as exhibit_curator
 
     exhibit.searches.each { |x| x.update published: true }
-
     visit spotlight.edit_exhibit_feature_page_path(exhibit, feature_page)
     add_widget 'search_results'
   end
 
-  pending 'allows a curator to select from existing browse categories' do
-    pending('Prefetched autocomplete does not work the same way as solr-backed autocompletes')
-    fill_in_typeahead_field with: 'All Exhibit Items'
+  it 'allows a curator to select from existing browse categories' do
+    # Manually inject the inputs to the widget that the autocomplete would.
+    # fill_in_typeahead_field does not work here for us for some reason.
+    page.execute_script <<-JS
+      $("[data-twitter-typeahead]:visible").after(
+        "<input type='hidden' name='item[item_0][id]' value='all-exhibit-items' />" +
+        "<input type='hidden' name='item[item_0][display]' value='true' />"
+      );
+    JS
 
     check 'Gallery'
     check 'Slideshow'


### PR DESCRIPTION
Blacklight has moved the `search_results` method from where it was. 

Fixes #2332 

