### PR TITLE
Update carousel next/prev icons

### DIFF
--- a/app/assets/images/blacklight/arrow_back_ios.svg
+++ b/app/assets/images/blacklight/arrow_back_ios.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path opacity=".87" fill="none" d="M0 0h24v24H0V0z"/><path d="M17.51 3.87L15.73 2.1 5.84 12l9.9 9.9 1.77-1.77L9.38 12l8.13-8.13z"/></svg>

--- a/app/assets/images/blacklight/arrow_forward_ios.svg
+++ b/app/assets/images/blacklight/arrow_forward_ios.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path opacity=".87" fill="none" d="M24 24H0V0h24v24z"/><path d="M6.49 20.13l1.77 1.77 9.9-9.9-9.9-9.9-1.77 1.77L14.62 12l-8.13 8.13z"/></svg>

--- a/app/assets/images/blacklight/chevron_left.svg
+++ b/app/assets/images/blacklight/chevron_left.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="none" d="M0 0h24v24H0V0z"/><path d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12l4.58-4.59z"/></svg>

--- a/app/views/spotlight/sir_trevor/blocks/_solr_documents_carousel_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_solr_documents_carousel_block.html.erb
@@ -41,10 +41,10 @@
 
     <!-- Controls -->
     <a class="left carousel-control-prev" href="#<%= html_id %>" data-slide="prev">
-      <%= blacklight_icon('chevron_left') %>
+      <%= blacklight_icon('arrow_back_ios') %>
     </a>
     <a class="right carousel-control-next" href="#<%= html_id %>" data-slide="next">
-      <%= blacklight_icon('chevron_right') %>
+      <%= blacklight_icon('arrow_forward_ios') %>
     </a>
   </div>
 <% end %>

--- a/app/views/spotlight/sir_trevor/blocks/_solr_documents_carousel_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_solr_documents_carousel_block.html.erb
@@ -4,7 +4,7 @@
 <div class="content-block carousel-block carousel-height-<%= solr_documents_carousel_block.max_height %>">
 <% if solr_documents_carousel_block.documents? %>
   <div id="<%= html_id %>" class="carousel slide" data-ride="carousel"  data-interval="<%= solr_documents_carousel_block.interval %>">
-    <div class="carousel-inner">
+    <div class="carousel-inner text-center">
     <% solr_documents_carousel_block.each_document.each_with_index do |(block_options, document), index| %>
       <% doc_presenter = index_presenter(document) %>
       <div class="carousel-item <%= 'active' if index == 0 %>" data-id="<%= document.id %>">


### PR DESCRIPTION
Fixes #2336 

## Before
<img width="884" alt="carousel-before" src="https://user-images.githubusercontent.com/96776/70670545-1e42f780-1c2e-11ea-938d-64b809b9db64.png">

## After
<img width="895" alt="carousel-after" src="https://user-images.githubusercontent.com/96776/70670546-1e42f780-1c2e-11ea-9d9c-700e4c6d60df.png">
