### PR TITLE
Removes the ability to spoof from emails.

### DIFF
--- a/app/mailers/spotlight/contact_mailer.rb
+++ b/app/mailers/spotlight/contact_mailer.rb
@@ -2,7 +2,7 @@
 
 module Spotlight
   # Mailer for reporting problems to the application contact and/or exhibit administrator
-  class ContactMailer < ActionMailer::Base
+  class ContactMailer < ApplicationMailer
     def report_problem(contact_form)
       @contact_form = contact_form
       mail(@contact_form.headers)

--- a/app/models/spotlight/contact_form.rb
+++ b/app/models/spotlight/contact_form.rb
@@ -21,7 +21,6 @@ module Spotlight
       {
         to: to,
         subject: I18n.t(:'spotlight.contact_form.subject', application_name: application_name),
-        from: %("#{name}" <#{email}>),
         cc: contact_emails.join(', ')
       }
     end


### PR DESCRIPTION
… from address

Related to https://github.com/sul-dlss/dlme/issues/626

Fixes https://github.com/sul-dlss/dlme/issues/813

`Net::SMTPFatalError: 554 Message rejected: Email address is not verified. The following identities failed the check in region US-WEST-2:`

If you use something like Amazon's Simple Email Service (SES) you can't just spoof the `from` header, but must use a verified address. This pull request removes spotlight from spoofing froms.

Adopters should use the ActionMailer `default_options[:from]` https://guides.rubyonrails.org/action_mailer_basics.html#action-mailer-configuration