### PR TITLE
Add translations to the exhibit export

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -64,6 +64,7 @@ Metrics/ClassLength:
   Max: 120
   Exclude:
     - 'app/models/spotlight/resources/iiif_manifest.rb'
+    - 'app/serializers/**/*'
     - 'lib/generators/spotlight/**/*' # Generators tend to have longer class lengths due to their lengthy public API
 
 Naming/PredicateName:

--- a/spec/serializers/spotlight/exhibit_export_serializer_spec.rb
+++ b/spec/serializers/spotlight/exhibit_export_serializer_spec.rb
@@ -64,6 +64,14 @@ describe Spotlight::ExhibitExportSerializer do
     expect(subject['attachments']).to have(source_exhibit.attachments.count).items
   end
 
+  it 'has languages' do
+    expect(subject['languages']).to have(source_exhibit.languages.count).items
+  end
+
+  it 'has translations' do
+    expect(subject['translations']).to have(source_exhibit.translations.count).items
+  end
+
   it 'has resources' do
     expect(subject['resources']).to have(source_exhibit.resources.count).items
   end
@@ -146,6 +154,30 @@ describe Spotlight::ExhibitExportSerializer do
         it 'has contacts' do
           expect(subject.contacts.count).to eq 1
         end
+      end
+    end
+
+    context 'for exhibits with languages and translations' do
+      let!(:language) do
+        source_exhibit.languages.create!(locale: 'zz', public: true, text: 'abc')
+      end
+
+      let!(:translation) do
+        source_exhibit.translations.create!(locale: 'zz', key: 'abc', value: '123')
+      end
+
+      it 'has the language' do
+        expect(subject.languages.count).to eq 1
+
+        language = subject.languages.first
+        expect(language).to have_attributes(locale: 'zz', public: true, text: 'abc')
+      end
+
+      it 'has translations' do
+        expect(subject.translations.count).to eq 1
+
+        translation = subject.translations.unscope(where: :locale).first
+        expect(translation).to have_attributes(locale: 'zz', key: 'abc', value: '123')
       end
     end
 


### PR DESCRIPTION
Add translations and languages configuration to the exhibit export.

Part of https://github.com/sul-dlss/dlme/issues/814