### PR TITLE
Update the items tables to not use bootstrap column classes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,6 @@ matrix:
     - rvm: 2.4.6
       env: "RAILS_VERSION=5.1.6"
 
-before_install:
-  - gem update --system
-  - gem install --no-document bundler
-
 before_cache:
   - rm /home/travis/build/projectblacklight/spotlight/.internal_test_app/db/test.sqlite3
   - rm /home/travis/build/projectblacklight/spotlight/.internal_test_app/log/test.log

--- a/app/views/spotlight/catalog/_document_admin_table.html.erb
+++ b/app/views/spotlight/catalog/_document_admin_table.html.erb
@@ -4,7 +4,7 @@
     <tr>
       <th></th>
       <th scope="col"><%= t(:'spotlight.catalog.fields.title') %></th>
-      <th scope="col"><%= t(:'spotlight.catalog.fields.date_added') %></th>
+      <th scope="col" class="text-nowrap"><%= t(:'spotlight.catalog.fields.date_added') %></th>
       <th scope="col" class="checkbox-toggle"><%= t(:'spotlight.catalog.fields.visibility') %></th>
     </tr>
   </thead>

--- a/app/views/spotlight/catalog/_document_admin_table.html.erb
+++ b/app/views/spotlight/catalog/_document_admin_table.html.erb
@@ -2,10 +2,10 @@
 <table id="documents" class="table">
   <thead>
     <tr>
-      <th class="col-sm-1"></th>
-      <th class="col-sm-5"><%= t(:'spotlight.catalog.fields.title') %></th>
-      <th class="col-sm-2"><%= t(:'spotlight.catalog.fields.date_added') %></th>
-      <th class="col-sm-1 checkbox-toggle"><%= t(:'spotlight.catalog.fields.visibility') %></th>
+      <th></th>
+      <th scope="col"><%= t(:'spotlight.catalog.fields.title') %></th>
+      <th scope="col"><%= t(:'spotlight.catalog.fields.date_added') %></th>
+      <th scope="col" class="checkbox-toggle"><%= t(:'spotlight.catalog.fields.visibility') %></th>
     </tr>
   </thead>
   <%= render partial: 'document_row', collection: documents, as: :document %>

--- a/app/views/spotlight/catalog/_index_compact_default.html.erb
+++ b/app/views/spotlight/catalog/_index_compact_default.html.erb
@@ -11,11 +11,10 @@
   </div>
 </td>
 
-<td>
+<td class="text-nowrap">
   <%= l Date.parse(document[blacklight_config.index.timestamp_field]) if document[blacklight_config.index.timestamp_field] %>
 </td>
 
 <td class="checkbox-toggle">
   <%= render partial: 'document_visibility_control', locals: { document: document} %>
 </td>
-


### PR DESCRIPTION
Fixes #2339 

## Dashboard landing page (before)
<img width="845" alt="dashboard-before" src="https://user-images.githubusercontent.com/96776/70950719-3f348f80-2016-11ea-926a-2d4ae65c2af5.png">

## Curation -> Items (before)
<img width="838" alt="curation-items-before" src="https://user-images.githubusercontent.com/96776/70950718-3f348f80-2016-11ea-9b56-3728174e7c78.png">

---

## Dashboard landing page (after)
<img width="841" alt="dashboard-after" src="https://user-images.githubusercontent.com/96776/70950720-3f348f80-2016-11ea-886d-897fe31d4648.png">

## Curation -> Items (after)
<img width="851" alt="curation-items-after" src="https://user-images.githubusercontent.com/96776/70950721-3f348f80-2016-11ea-90dd-c03f71b44b75.png">
