### PR TITLE
Add back landing page card title margins

### DIFF
--- a/app/assets/stylesheets/spotlight/_exhibits_index.scss
+++ b/app/assets/stylesheets/spotlight/_exhibits_index.scss
@@ -40,6 +40,8 @@
 
   font-size: $h4-font-size;
   line-height: 1.2;
+  margin-bottom: 10px;
+  margin-top: 10px;
 }
 
 .card-front {


### PR DESCRIPTION
Addresses https://github.com/sul-dlss/exhibits/issues/1488

## Before
<img width="697" alt="Screen Shot 2020-01-15 at 2 20 13 PM" src="https://user-images.githubusercontent.com/1656824/72472738-62cc3080-37a2-11ea-91bf-9bcf11a9ef32.png">

## After
<img width="634" alt="Screen Shot 2020-01-15 at 2 19 52 PM" src="https://user-images.githubusercontent.com/1656824/72472739-62cc3080-37a2-11ea-9c3f-76f284c2d1e5.png">
