### PR TITLE
Sanitize exhibit custom field data

### DIFF
--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -73,9 +73,24 @@ describe SolrDocument, type: :model do
       expect(mock_sidecar).to receive(:update).with(data: { 'a' => 1 })
       subject.update exhibit, sidecar: { data: { 'a' => 1 } }
     end
+
     it 'stores tags' do
       subject.update exhibit, exhibit_tag_list: 'paris, normandy'
       expect(subject.sidecar(exhibit).tags_from(exhibit)).to eq %w(paris normandy)
+    end
+
+    it 'converts empty strings to nil' do
+      mock_sidecar = double
+      allow(subject).to receive_messages(sidecar: mock_sidecar)
+      expect(mock_sidecar).to receive(:update).with(data: { 'a' => nil })
+      subject.update exhibit, sidecar: { data: { 'a' => '' } }
+    end
+
+    it 'compacts arrays of empty or nil values' do
+      mock_sidecar = double
+      allow(subject).to receive_messages(sidecar: mock_sidecar)
+      expect(mock_sidecar).to receive(:update).with(data: { 'a' => ['a'] })
+      subject.update exhibit, sidecar: { data: { 'a' => ['', nil, 'a'] } }
     end
   end
 

--- a/spec/models/spotlight/solr_document_sidecar_spec.rb
+++ b/spec/models/spotlight/solr_document_sidecar_spec.rb
@@ -28,5 +28,19 @@ describe Spotlight::SolrDocumentSidecar, type: :model do
 
       its(:to_solr) { should include 'the_solr_field' => 'some value' }
     end
+
+    context 'with blank fields' do
+      before do
+        subject.data = {
+          'a_blank_field' => '',
+          'a_blank_multivalued_field' => ['', ''],
+          'a_multivalued_field_with_some_blanks' => ['', 'a']
+        }
+      end
+
+      its(:to_solr) { should include 'a_blank_field' => nil }
+      its(:to_solr) { should include 'a_blank_multivalued_field' => [] }
+      its(:to_solr) { should include 'a_multivalued_field_with_some_blanks' => ['a'] }
+    end
   end
 end


### PR DESCRIPTION
We're currently storing empty strings when the exhibit custom field is an empty string, leading to empty values getting indexed into solr and then displaying in the UI

This PR makes sure we clean up the data both when it gets persisted to the database and when it gets serialized out for Solr (both may be excessive, but it seems easier than trying  to remediate all the bad data in the world?). 

Fixes https://github.com/sul-dlss/exhibits/issues/1369