### PR TITLE
Add min-width the admin thumbnails displayed in a table, or the brows…

### DIFF
--- a/app/assets/stylesheets/spotlight/_catalog.scss
+++ b/app/assets/stylesheets/spotlight/_catalog.scss
@@ -1,6 +1,10 @@
 #documents.table {
   font-size: $font-size-base;
 
+  .thumbnail-column {
+    min-width: 60px;
+  }
+
   .document-thumbnail {
     border: none;
     margin-bottom: 0;

--- a/app/assets/stylesheets/spotlight/_curation.scss
+++ b/app/assets/stylesheets/spotlight/_curation.scss
@@ -171,6 +171,7 @@ h1,h2,h3,h4,h5,h6 {
   height: auto;
   min-height: 0;
 }
+
 .spotlight-admin-thumbnail {
   position: relative;
   .badge {

--- a/app/views/spotlight/catalog/_document_admin_table.html.erb
+++ b/app/views/spotlight/catalog/_document_admin_table.html.erb
@@ -2,7 +2,7 @@
 <table id="documents" class="table">
   <thead>
     <tr>
-      <th></th>
+      <th class="thumbnail-column"></th>
       <th scope="col"><%= t(:'spotlight.catalog.fields.title') %></th>
       <th scope="col" class="text-nowrap"><%= t(:'spotlight.catalog.fields.date_added') %></th>
       <th scope="col" class="checkbox-toggle"><%= t(:'spotlight.catalog.fields.visibility') %></th>


### PR DESCRIPTION
…er may compact them to nothing

Before:
<img width="312" alt="Screen Shot 2020-01-17 at 08 39 45" src="https://user-images.githubusercontent.com/111218/72629319-ef8eff80-3904-11ea-84c8-cce1ae4f4313.png">

After:
<img width="263" alt="Screen Shot 2020-01-17 at 08 44 53" src="https://user-images.githubusercontent.com/111218/72629674-a4c1b780-3905-11ea-9cce-da16e9a02bc0.png">
