### PR TITLE
Remove bottom-border on .sort-pagination on the items admin page…

### DIFF
--- a/app/assets/stylesheets/spotlight/_catalog.scss
+++ b/app/assets/stylesheets/spotlight/_catalog.scss
@@ -61,6 +61,10 @@
   .add-items-nav {
     margin-bottom: $padding-large-vertical;
   }
+
+  .sort-pagination {
+    border-bottom: 0;
+  }
 }
 
 form.edit_solr_document {


### PR DESCRIPTION
… (the table below now had a border and this double border looks odd)

Closes sul-dlss/exhibits#1530

## Before
<img width="847" alt="before" src="https://user-images.githubusercontent.com/96776/72646586-59220480-392b-11ea-8554-e1e63c8a2efb.png">

## After
<img width="851" alt="after" src="https://user-images.githubusercontent.com/96776/72646589-59220480-392b-11ea-9afb-b3477959f6fe.png">
