### PR TITLE
Update solr documents embed column layout logic

### DIFF
--- a/app/assets/javascripts/spotlight/admin/sir-trevor/locales.js
+++ b/app/assets/javascripts/spotlight/admin/sir-trevor/locales.js
@@ -82,7 +82,7 @@ SirTrevor.Locales.en.blocks = $.extend(SirTrevor.Locales.en.blocks, {
 
   solr_documents_embed: {
     title: "Item Embed",
-    description: "This widget embeds exhibit items on a page. Optionally, you can add a heading and/or text to be displayed adjacent to the items.",
+    description: "This widget embeds an exhibit item in a viewer on a page. Optionally, you can add a heading to be displayed above the viewer and/or text to be displayed adjacent to the viewer.",
   },
 
   solr_documents_features: {

--- a/app/views/spotlight/sir_trevor/blocks/_solr_documents_embed_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_solr_documents_embed_block.html.erb
@@ -3,12 +3,20 @@
 <div class="content-block items-block row <%= 'flex-row-reverse' if solr_documents_embed_block.content_align == 'right' %>">
 
   <% if solr_documents_embed_block.documents? %>
-    <div class="items-col spotlight-flexbox <%= solr_documents_embed_block.text? ? "col-md-6" : "col-md-12" %> ">
-      <% solr_documents_embed_block.each_document do |block_options, document| %>
-        <div class="box" data-id="<%= document.id %>">
-          <%= render_document_partials document, blacklight_config.view.embed.partials, (blacklight_config.view.embed.locals || {}).reverse_merge(block: solr_documents_embed_block) %>
-        </div>
+    <div class="items-col <%= solr_documents_embed_block.text? ? "col-md-6" : "col-md-12" %> ">
+      <% unless solr_documents_embed_block.text? %>
+        <% unless solr_documents_embed_block.title.blank? %>
+        
+          <h3><%= solr_documents_embed_block.title %></h3>
+        <% end %>
       <% end %>
+      <div class="spotlight-flexbox">
+        <% solr_documents_embed_block.each_document do |block_options, document| %>
+          <div class="box" data-id="<%= document.id %>">
+            <%= render_document_partials document, blacklight_config.view.embed.partials, (blacklight_config.view.embed.locals || {}).reverse_merge(block: solr_documents_embed_block) %>
+          </div>
+        <% end %>
+      </div>
     </div>
   <% end %>
 

--- a/spec/views/spotlight/sir_trevor/blocks/_solr_documents_embed_block.html.erb_spec.rb
+++ b/spec/views/spotlight/sir_trevor/blocks/_solr_documents_embed_block.html.erb_spec.rb
@@ -24,7 +24,7 @@ describe 'spotlight/sir_trevor/blocks/_solr_documents_embed_block.html.erb', typ
     allow(view).to receive_messages(has_thumbnail?: true, render_thumbnail_tag: 'thumb')
   end
 
-  it 'has a slideshow block' do
+  it 'has a embed block' do
     expect(view).to receive(:render_document_partials).with(doc, %w[a b c], hash_including(a: 1, block: block)).and_return('OSD')
     render partial: p, locals: { solr_documents_embed_block: block }
     expect(rendered).to have_selector 'h3', text: 'Some title'
@@ -32,5 +32,19 @@ describe 'spotlight/sir_trevor/blocks/_solr_documents_embed_block.html.erb', typ
     expect(rendered).to have_selector '.box', text: 'OSD'
     expect(rendered).to have_selector '.items-col'
     expect(rendered).to have_selector '.text-col'
+    expect(rendered).not_to have_selector '.col-md-12'
+  end
+
+  context 'with a block with no text' do
+    let(:block) do
+      SirTrevorRails::Blocks::SolrDocumentsEmbedBlock.new({ type: 'block', data: { title: 'Some title', 'text-align' => 'right' } }, page)
+    end
+
+    it 'does not have a two column layout' do
+      expect(view).to receive(:render_document_partials).with(doc, %w[a b c], hash_including(a: 1, block: block)).and_return('OSD')
+      render partial: p, locals: { solr_documents_embed_block: block }
+      expect(rendered).to have_selector '.col-md-12'
+      expect(rendered).to have_selector '.items-col h3', text: 'Some title'
+    end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/sul-dlss/exhibits/issues/1208

Only uses two column layout when there is no text. This aims to improve the layout for feature pages.

<img width="537" alt="Screen Shot 2020-01-21 at 4 58 10 PM" src="https://user-images.githubusercontent.com/1656824/72853700-63b40500-3c6f-11ea-89ef-8e43cfeaf2ed.png">
