### PR TITLE
Allow downstream applications to set exhibit specific themes

### DIFF
--- a/app/helpers/spotlight/application_helper.rb
+++ b/app/helpers/spotlight/application_helper.rb
@@ -143,13 +143,13 @@ module Spotlight
       if current_exhibit_theme && current_exhibit.theme != 'default'
         stylesheet_link_tag "#{tag}_#{current_exhibit_theme}"
       else
-        Rails.logger.warn "Exhibit theme '#{current_exhibit_theme}' not in white-list of available themes: #{Spotlight::Engine.config.exhibit_themes}"
+        Rails.logger.warn "Exhibit theme '#{current_exhibit_theme}' not in white-list of available themes: #{current_exhibit.themes}"
         stylesheet_link_tag(tag)
       end
     end
 
     def current_exhibit_theme
-      current_exhibit.theme if current_exhibit && current_exhibit.theme.present? && Spotlight::Engine.config.exhibit_themes.include?(current_exhibit.theme)
+      current_exhibit.theme if current_exhibit && current_exhibit.theme.present? && current_exhibit.themes.include?(current_exhibit.theme)
     end
 
     private

--- a/app/helpers/spotlight/main_app_helpers.rb
+++ b/app/helpers/spotlight/main_app_helpers.rb
@@ -38,16 +38,16 @@ module Spotlight
     end
 
     def exhibit_stylesheet_link_tag(tag)
-      if current_exhibit_theme && current_exhibit.theme != 'default'
+      if current_exhibit_theme && current_exhibit&.theme != 'default'
         stylesheet_link_tag "#{tag}_#{current_exhibit_theme}"
       else
-        Rails.logger.warn "Exhibit theme '#{current_exhibit_theme}' not in white-list of available themes: #{Spotlight::Engine.config.exhibit_themes}"
+        Rails.logger.warn "Exhibit theme '#{current_exhibit_theme}' not in white-list of available themes: #{current_exhibit&.themes}"
         stylesheet_link_tag(tag)
       end
     end
 
     def current_exhibit_theme
-      current_exhibit.theme if current_exhibit && current_exhibit.theme.present? && Spotlight::Engine.config.exhibit_themes.include?(current_exhibit.theme)
+      current_exhibit.theme if current_exhibit && current_exhibit.theme.present? && current_exhibit.themes.include?(current_exhibit.theme)
     end
   end
 end

--- a/app/models/spotlight/exhibit.rb
+++ b/app/models/spotlight/exhibit.rb
@@ -5,6 +5,7 @@ module Spotlight
   ##
   # Spotlight exhibit
   class Exhibit < ActiveRecord::Base
+    class_attribute :themes_selector
     include Spotlight::ExhibitAnalytics
     include Spotlight::ExhibitDefaults
     include Spotlight::ExhibitDocuments
@@ -87,7 +88,11 @@ module Spotlight
     end
 
     def themes
-      Spotlight::Engine.config.exhibit_themes
+      @themes ||= begin
+        return Spotlight::Engine.config.exhibit_themes unless self.class.themes_selector
+
+        self.class.themes_selector.call(self)
+      end
     end
 
     def to_s

--- a/app/models/spotlight/exhibit.rb
+++ b/app/models/spotlight/exhibit.rb
@@ -86,6 +86,10 @@ module Spotlight
       searches.published.any?
     end
 
+    def themes
+      Spotlight::Engine.config.exhibit_themes
+    end
+
     def to_s
       title
     end

--- a/app/views/spotlight/appearances/edit.html.erb
+++ b/app/views/spotlight/appearances/edit.html.erb
@@ -18,14 +18,14 @@
   <% end %>
   <div role="tabpanel">
     <ul class="nav nav-tabs" role="tablist">
-      <% if Spotlight::Engine.config.exhibit_themes.many? %>
+      <% if current_exhibit.themes.many? %>
         <li role="presentation" class="nav-item">
           <a href="#site-theme" aria-controls="site-theme" role="tab" data-toggle="tab" class="nav-link active"><%= t(:'.site_theme.heading') %></a>
         </li>
       <% end %>
 
       <li role="presentation" class="nav-item">
-        <a href="#site-masthead" aria-controls="site-masthead" role="tab" data-toggle="tab" class="nav-link <%= 'active' unless Spotlight::Engine.config.exhibit_themes.many? %>"><%= t(:'.site_masthead.heading') %></a>
+        <a href="#site-masthead" aria-controls="site-masthead" role="tab" data-toggle="tab" class="nav-link <%= 'active' unless current_exhibit.themes.many? %>"><%= t(:'.site_masthead.heading') %></a>
       </li>
 
       <li role="presentation" class="nav-item">
@@ -37,11 +37,11 @@
       </li>
     </ul>
     <div class="tab-content">
-      <% if Spotlight::Engine.config.exhibit_themes.many? %>
+      <% if current_exhibit.themes.many? %>
       <div role="tabpanel" class="tab-pane active" id="site-theme">
         <p class="instructions"><%= t(:'.site_theme.help') %></p>
         <%= f.form_group :theme, label: { text: t(:'.site_theme.label') } do %>
-          <% Spotlight::Engine.config.exhibit_themes.each do |theme| %>
+          <% current_exhibit.themes.each do |theme| %>
             <div class="col-md-6">
               <%= image_tag "spotlight/themes/#{theme}_preview.png", width: 100, height: 100 %>
               <%= f.radio_button :theme, theme, label: t(:".site_theme.#{theme}", default: theme.to_s.titleize), inline: true %>
@@ -51,7 +51,7 @@
       </div>
       <% end %>
 
-      <div role="tabpanel" class="tab-pane <%= 'active' unless Spotlight::Engine.config.exhibit_themes.many? %>" id="site-masthead">
+      <div role="tabpanel" class="tab-pane <%= 'active' unless current_exhibit.themes.many? %>" id="site-masthead">
         <p class="instructions"><%= t(:'.site_masthead.help') %></p>
         <%= f.fields_for(:masthead, current_exhibit.masthead || current_exhibit.build_masthead) do |m| %>
           <%= render '/spotlight/featured_images/form', f: m, initial_crop_selection: Spotlight::Engine.config.masthead_initial_crop_selection, crop_type: :masthead %>

--- a/spec/models/spotlight/exhibit_spec.rb
+++ b/spec/models/spotlight/exhibit_spec.rb
@@ -121,6 +121,12 @@ describe Spotlight::Exhibit, type: :model do
     end
   end
 
+  describe '#themes' do
+    it 'is the configured themes' do
+      expect(subject.themes).to eq Spotlight::Engine.config.exhibit_themes
+    end
+  end
+
   describe 'import' do
     it 'removes the default browse category' do
       subject.save

--- a/spec/models/spotlight/exhibit_spec.rb
+++ b/spec/models/spotlight/exhibit_spec.rb
@@ -122,8 +122,22 @@ describe Spotlight::Exhibit, type: :model do
   end
 
   describe '#themes' do
-    it 'is the configured themes' do
-      expect(subject.themes).to eq Spotlight::Engine.config.exhibit_themes
+    context 'when no themes_selector proc is set' do
+      it 'is the configured themes' do
+        expect(subject.themes).to eq Spotlight::Engine.config.exhibit_themes
+      end
+    end
+
+    context 'when a themes_selector proc is set' do
+      before do
+        allow(described_class).to receive(:themes_selector).and_return(
+          ->(*) { %w[default coolCustomTheme] }
+        )
+      end
+
+      it 'is the array of themes returned by the proc' do
+        expect(subject.themes).to eq(%w[default coolCustomTheme])
+      end
     end
   end
 


### PR DESCRIPTION
This is a stab at an approach that would allow us to resolve sul-dlss/exhibits#1462 downstream without changing behavior in Spotlight proper.

If this approach is agreeable, I'll update https://github.com/projectblacklight/spotlight/wiki/Creating-a-theme to include details of how to configure this downstream.