### PR TITLE
Remove top-border for translation page tables

### DIFF
--- a/app/assets/stylesheets/spotlight/_translations.scss
+++ b/app/assets/stylesheets/spotlight/_translations.scss
@@ -14,6 +14,10 @@
   .browse-category-description {
     margin-bottom: $padding-large-vertical * 2;
   }
+
+  .table.table-striped th {
+    border-top: 0;
+  }
 }
 
 .translation-subheading {


### PR DESCRIPTION
Fixes https://github.com/sul-dlss/exhibits/issues/1554

Bootstrap 4 adds for a `.table.table-striped` a top border (BS3 did not have a top border). This reverts for the translation pages the previous table behavior (no top border). 

@ggeisler was there a better way this should be handled that is more globally relevant?

## Before
<img width="816" alt="Screen Shot 2020-01-27 at 2 36 17 PM" src="https://user-images.githubusercontent.com/1656824/73216045-7c5e6800-4112-11ea-8a9e-e787c489c770.png">

## After
<img width="730" alt="Screen Shot 2020-01-27 at 2 35 52 PM" src="https://user-images.githubusercontent.com/1656824/73216046-7c5e6800-4112-11ea-8b50-3a030cade6a9.png">
