### PR TITLE
Unify about page header styling

### DIFF
--- a/app/views/spotlight/about_pages/_contacts.html.erb
+++ b/app/views/spotlight/about_pages/_contacts.html.erb
@@ -1,4 +1,4 @@
-<h4 class='contacts-header'><%= t :'.header' %></h4>
+<h4 class='contacts-header nav-heading'><%= t :'.header' %></h4>
 <ol class="nav sidenav contacts flex-column">
   <% current_exhibit.contacts.published.each do |contact| %>
     <li itemscope itemtype="http://schema.org/Person">


### PR DESCRIPTION
Closes sul-dlss/exhibits#1543

This PR applies the same styling to the "About" and "Contacts" headings on about pages. 

## Before
!["Contacts" uses different styling as "About"](https://user-images.githubusercontent.com/5402927/73223866-635ab480-411c-11ea-91b2-9a1878c68d94.png)

## After
!["Contacts" uses same styling as "About"](https://user-images.githubusercontent.com/5402927/73223865-635ab480-411c-11ea-95d9-e9540d0bb5ef.png)

