### PR TITLE
Move front page styling to using flexbox approach and native BS4

### DIFF
--- a/app/assets/stylesheets/spotlight/_exhibits_index.scss
+++ b/app/assets/stylesheets/spotlight/_exhibits_index.scss
@@ -38,32 +38,14 @@
 .exhibit-card-title {
   @extend .h5;
   @extend .text-center;
-
-  font-size: $h4-font-size;
-  line-height: 1.2;
-  margin-bottom: 10px;
-  margin-top: 10px;
 }
 
 .card-front {
   transform: rotateY(0deg);
   z-index: 2;
 
-  img {
-    height: $exhibit-card-image-size;
-    object-fit: cover;
-    width: 100%;
-  }
-
-  .exhibit-card-title {
-    @extend .h5;
-    padding-left: $padding-small-horizontal;
-    padding-right: $padding-small-horizontal;
-  }
-
   .unpublished {
     @extend .mx-auto;
-
     display: block;
     font-size: $font-size-base;
     margin-top: -1em;
@@ -74,17 +56,11 @@
 
 .card-back {
   box-shadow: $exhibit-card-shadow;
-  padding: 0 $exhibit-card-gutter;
   transform: rotateY(-180deg);
 
   .card-title {
-    @extend .h5;
-    @extend .text-center;
     border-bottom: 1px dotted $exhibit-card-border;
-    line-height: $headings-line-height;
-    margin-bottom: $padding-base-vertical;
     padding-bottom: $padding-base-vertical;
-    padding-top: $padding-base-vertical;
   }
 
   .subtitle {
@@ -99,7 +75,7 @@
   }
 
   .visit-exhibit {
-    bottom: $exhibit-card-gutter;
+    bottom: 1rem;
     position: absolute;
   }
 }
@@ -115,11 +91,9 @@
     height: $exhibit-card-height - $reduce-exhibit-card-image-size;
   }
 
-  .card-front,
-  .card-back {
-    img {
-      height: $exhibit-card-image-size - $reduce-exhibit-card-image-size;
-    }
+  // Cannot extend .btn-sm within a @media query
+  .center-btn .btn {
+    @include button-size($btn-padding-y-sm, $btn-padding-x-sm, $btn-font-size-sm, $btn-line-height-sm, $btn-border-radius-sm);
   }
 }
 
@@ -130,23 +104,5 @@
   .btn {
     left: -50%;
     position: relative;
-  }
-}
-
-// For the medium breakpoint, reduce the max width of the .exhibit-card to align right-edge of row correctly
-@media (min-width: breakpoint-min("md")) and (max-width: breakpoint-max("lg")) {
-  .exhibit-card {
-
-    // each card is 3 columns wide
-    max-width: 3 * (map-get($container-max-widths, "lg") / $grid-columns) - 5px;
-  }
-}
-
-// For the small breakpoint, reduce the max width of the .exhibit-card to align right-edge of row correctly
-@media (min-width: breakpoint-min("sm")) and (max-width: breakpoint-max("md")) {
-  .exhibit-card {
-
-    // each card is 6 columns wide
-    max-width: 6 * (map-get($container-max-widths, "md") / $grid-columns) - 5px;
   }
 }

--- a/app/views/spotlight/exhibits/_exhibit_card.html.erb
+++ b/app/views/spotlight/exhibits/_exhibit_card.html.erb
@@ -1,9 +1,9 @@
 <div class="col-12 col-sm-6 col-md-4 exhibit-card">
   <div class="flipper">
-    <div class="card-front card-face">
+    <div class="card card-face card-front">
       <%= render 'exhibit_card_front', exhibit: exhibit %>
     </div>
-    <div class="card-back card-face">
+    <div class="card card-face card-back">
       <%= render 'exhibit_card_back', exhibit: exhibit %>
     </div>
   </div>

--- a/app/views/spotlight/exhibits/_exhibit_card_back.html.erb
+++ b/app/views/spotlight/exhibits/_exhibit_card_back.html.erb
@@ -1,23 +1,25 @@
-<h2 class="card-title">
-  <%= exhibit.title %>
-</h2>
+<div class="card-body">
+  <h2 class="card-title h5 text-center">
+    <%= exhibit.title %>
+  </h2>
 
-<p class="subtitle">
-  <%= exhibit.subtitle %>
-</p>
-
-<% if exhibit.description %>
-  <p class="description">
-    <%= truncated_description = exhibit.description.truncate(168, omission: '', separator: ' ') %>
-    <% if exhibit.description.length > 168 %>
-      <%= content_tag(:span,"&hellip;".html_safe, class: "d-sm-block d-md-block") %>
-      <span class="d-sm-none d-md-none">
-        <%= exhibit.description.slice(truncated_description.length, exhibit.description.length) %>
-      </span>
-    <% end %>
+  <p class="subtitle">
+    <%= exhibit.subtitle %>
   </p>
-<% end %>
 
-<div class="visit-exhibit center-btn">
-  <%= link_to t(:'.visit_exhibit'), exhibit, class: "btn btn-primary", role: "button" %>
+  <% if exhibit.description %>
+    <p class="description">
+      <%= truncated_description = exhibit.description.truncate(168, omission: '', separator: ' ') %>
+      <% if exhibit.description.length > 168 %>
+        <%= content_tag(:span,"&hellip;".html_safe, class: "d-sm-block d-md-block") %>
+        <span class="d-sm-none d-md-none">
+          <%= exhibit.description.slice(truncated_description.length, exhibit.description.length) %>
+        </span>
+      <% end %>
+    </p>
+  <% end %>
+
+  <div class="visit-exhibit center-btn">
+    <%= link_to t(:'.visit_exhibit'), exhibit, class: "btn btn-primary", role: "button" %>
+  </div>
 </div>

--- a/app/views/spotlight/exhibits/_exhibit_card_front.html.erb
+++ b/app/views/spotlight/exhibits/_exhibit_card_front.html.erb
@@ -1,11 +1,13 @@
 <% if exhibit.thumbnail.present? && exhibit.thumbnail.iiif_url %>
-  <%= image_tag(exhibit.thumbnail.iiif_url) %>
+  <%= image_tag(exhibit.thumbnail.iiif_url, class: 'card-img-top') %>
 <% else %>
-  <%= image_tag 'spotlight/default_thumbnail.jpg', class: 'default-thumbnail' %>
+  <%= image_tag 'spotlight/default_thumbnail.jpg', class: 'card-img-top default-thumbnail' %>
 <% end %>
 
 <% unless exhibit.published? %>
   <div class="badge badge-warning unpublished"><%= t('.unpublished') %></div>
 <% end %>
 
-<h2 class="exhibit-card-title"><%= exhibit.title %></h2>
+<div class="card-body">
+  <h2 class="card-title h5 text-center"><%= exhibit.title %></h2>
+</div>

--- a/app/views/spotlight/exhibits/_exhibits.html.erb
+++ b/app/views/spotlight/exhibits/_exhibits.html.erb
@@ -1,5 +1,3 @@
-<% exhibits.each_slice(3).each do |row| %>
-  <div class="row no-gutters"><!-- start main content row -->
-    <%= render collection: row, partial: 'exhibit_card', as: 'exhibit' %>
-  </div>
-<% end %>
+<div class="row no-gutters">
+  <%= render collection: exhibits, partial: 'exhibit_card', as: 'exhibit' %>
+</div>

--- a/spec/views/spotlight/exhibits/_exhibit_card_front.html.erb_spec.rb
+++ b/spec/views/spotlight/exhibits/_exhibit_card_front.html.erb_spec.rb
@@ -25,7 +25,7 @@ describe 'spotlight/exhibits/_exhibit_card_front.html.erb', type: :view do
   it 'has a title' do
     render p, exhibit: exhibit
 
-    expect(rendered).to have_selector '.exhibit-card-title', text: exhibit.title
+    expect(rendered).to have_selector '.card-body .card-title', text: exhibit.title
   end
 
   context 'for an unpublished exhibit' do


### PR DESCRIPTION
Fixes https://github.com/sul-dlss/exhibits/issues/1555

This PR aims to do a few different things:
1. Fixes the stacking of 2 x 1 at certain screen resolutions (see gif)
1. Fixes https://github.com/sul-dlss/exhibits/issues/1555
1. aims to reduce the custom Spotlight styling for native BS4 styling

This goes a bit off the rails from what was originally suggested in the ticket, but overall I hope its an improvement in Spotlight for all users.

## Before
![b893fc8ba4ebe02c689042a34d31628a](https://user-images.githubusercontent.com/1656824/73290545-d8c99200-41bb-11ea-85c6-485c7f1db27d.gif)

## After
![Kapture 2020-01-28 at 10 48 26](https://user-images.githubusercontent.com/1656824/73290546-d8c99200-41bb-11ea-8e43-d91286cdcf8e.gif)

## Within an existing Spotlight application
![Screen Shot 2020-01-28 at 10 56 09 AM](https://user-images.githubusercontent.com/1656824/73291223-006d2a00-41bd-11ea-89c2-5c8a399040c3.png)
![Screen Shot 2020-01-28 at 10 56 03 AM](https://user-images.githubusercontent.com/1656824/73291225-0105c080-41bd-11ea-8bbd-35c5aa8c6804.png)


