### PR TITLE
Use box-sizing: content-box for the thumbnail column

### DIFF
--- a/app/assets/stylesheets/spotlight/_catalog.scss
+++ b/app/assets/stylesheets/spotlight/_catalog.scss
@@ -2,7 +2,9 @@
   font-size: $font-size-base;
 
   .thumbnail-column {
+    box-sizing: content-box;
     min-width: 60px;
+    
   }
 
   .document-thumbnail {


### PR DESCRIPTION
This way the browser reserves 60px for the image content, not just  content and padding

Fixes https://github.com/sul-dlss/exhibits/issues/1559