### PR TITLE
Modify browse category edit panels to use flexbox/bootstrap utilities.

### DIFF
--- a/app/assets/stylesheets/spotlight/_curation.scss
+++ b/app/assets/stylesheets/spotlight/_curation.scss
@@ -122,24 +122,17 @@
   }
 }
 
-.card-header.search {
-  &:hover {
-    @include panel-hover-highlighting;
+.search_admin {
+  .pic {
+    flex-basis: 70px;
   }
-  /* widths don't add up to 100% because of padding of the container. */
+
   .main {
-    width: 40%;
-    vertical-align: top;
-    display: inline-block;
-    margin-left: $padding-base-horizontal;
+    flex-basis: 40%;
   }
+
   .description {
-    width: 30%;
-    vertical-align: top;
-    display: inline-block;
-  }
-  .card-title {
-    font-size: 15px;
+    flex-basis: 30%;
   }
 }
 

--- a/app/views/spotlight/searches/_search.html.erb
+++ b/app/views/spotlight/searches/_search.html.erb
@@ -1,34 +1,34 @@
 <% search = f.object %>
 <li class="dd-item dd3-item" data-id="<%= search.id %>">
   <div class="dd3-content card">
-    <div class="row search no-gutters">
-      <div class="col-md-2">
-        <%= image_tag(search.thumbnail_image_url || 'spotlight/default_browse_thumbnail.jpg', class: 'card-img') %>
+    <div class="search d-flex card-body">
+      <div>
+        <%= f.check_box :published, inline: true, hide_label: true %>
       </div>
-      <div class="col-md-7">
-        <div class="card-body pb-0">
-          <h4 class="card-title h6">
-            <%= f.check_box :published, inline: true, hide_label: true %>
-            <%= search.title %>
-          </h4>
 
-          <div class="card-text main">
-            <div class="count"><%= t :'.item_count', count: search.count %></div>
-            <div class="actions"><%= exhibit_view_link(search) %> &bull; <%= exhibit_edit_link(search) %> &bull; <%= exhibit_delete_link(search) %></div>
-            <%= f.hidden_field :id %>
-            <%= f.hidden_field :weight, data: {property: "weight"} %>
-          </div>
+      <div class="pic">
+        <%= image_tag(search.thumbnail_image_url || 'spotlight/default_browse_thumbnail.jpg', class: 'img-thumbnail') %>
+      </div>
+
+      <div class="flex-grow-1 mx-2 main">
+        <h4 class="card-title h6 mb-0">
+          <%= search.title %>
+        </h4>
+
+        <div class="card-text">
+          <div class="count"><%= t :'.item_count', count: search.count %></div>
+          <div class="actions"><%= exhibit_view_link(search) %> &bull; <%= exhibit_edit_link(search) %> &bull; <%= exhibit_delete_link(search) %></div>
+          <%= f.hidden_field :id %>
+          <%= f.hidden_field :weight, data: {property: "weight"} %>
         </div>
       </div>
-      <div class="col-md-3">
-        <div class="card-body">
-          <div class="card-text description">
-            <% if search.long_description.present? %>
-              <%= truncate(search.long_description, length: 89) %>
-            <% else %>
-              <span class="missing-description"><%= t(:'.missing_description_html', link: (link_to action_label(search, :edit_long), [spotlight, :edit, search.exhibit, search])) %></span>
-            <% end %>
-          </div>
+      <div class="flex-grow-1 mx-2 description">
+        <div class="card-text">
+          <% if search.long_description.present? %>
+            <%= truncate(search.long_description, length: 89) %>
+          <% else %>
+            <span class="missing-description"><%= t(:'.missing_description_html', link: (link_to action_label(search, :edit_long), [spotlight, :edit, search.exhibit, search])) %></span>
+          <% end %>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Fixes sul-dlss/exhibits#1551

## Before
<img width="714" alt="before" src="https://user-images.githubusercontent.com/96776/73326680-edcc1280-4207-11ea-8428-005d015c51b9.png">

## After
<img width="717" alt="after" src="https://user-images.githubusercontent.com/96776/73326682-edcc1280-4207-11ea-95bf-8fd9a90141f4.png">
