### PR TITLE
Update help-block to form-text

### DIFF
--- a/app/views/spotlight/contacts/_form.html.erb
+++ b/app/views/spotlight/contacts/_form.html.erb
@@ -14,7 +14,7 @@
       <div>
         <%= af.radio_button(:source, :remote, label: t(:'.source.remote.label')) %>
         <%= iiif_upload_tag(af) %>
-        <span class="help-block">
+        <span class="form-text">
           <%= t(:'.source.remote.help') %>
         </span>
       </div>

--- a/app/views/spotlight/featured_images/_form.html.erb
+++ b/app/views/spotlight/featured_images/_form.html.erb
@@ -24,7 +24,7 @@
   <div>
     <%= f.radio_button(:source, :remote, label: t(:'.source.remote.label')) %>
     <%= iiif_upload_tag(f) %>
-    <span class="help-block">
+    <span class="form-text">
       <%= t(:'.source.remote.help') %>
     </span>
   </div>

--- a/app/views/spotlight/featured_images/_upload_form.html.erb
+++ b/app/views/spotlight/featured_images/_upload_form.html.erb
@@ -6,7 +6,7 @@
   <div>
     <%= f.hidden_field(:source, value: :remote, label: t(:'.source.remote.label')) %>
     <%= iiif_upload_tag(f) %>
-    <span class="help-block">
+    <span class="form-text">
       <%= t(:'.source.remote.help') %>
     </span>
   </div>

--- a/spec/views/spotlight/contacts/edit.html.erb_spec.rb
+++ b/spec/views/spotlight/contacts/edit.html.erb_spec.rb
@@ -37,7 +37,7 @@ describe 'spotlight/contacts/edit.html.erb' do
   it 'has an IIIF crop' do
     render
     expect(rendered).to have_content 'Upload an image'
-    expect(rendered).to have_css '.help-block', text: 'Help!'
+    expect(rendered).to have_css '.form-text', text: 'Help!'
     expect(rendered).to have_selector '#contact_avatar_attributes_iiif_cropper'
   end
 end

--- a/spec/views/spotlight/featured_images/_form.html.erb_spec.rb
+++ b/spec/views/spotlight/featured_images/_form.html.erb_spec.rb
@@ -27,6 +27,6 @@ describe 'spotlight/featured_images/_form', type: :view do
   it 'has help block' do
     render partial: 'spotlight/featured_images/form',
            locals: { f: builder, initial_crop_selection: [], crop_type: :thumbnail }
-    expect(rendered).to have_css '.help-block', text: 'Help!'
+    expect(rendered).to have_css '.form-text', text: 'Help!'
   end
 end

--- a/spec/views/spotlight/featured_images/_upload_form.html.erb_spec.rb
+++ b/spec/views/spotlight/featured_images/_upload_form.html.erb_spec.rb
@@ -27,6 +27,6 @@ describe 'spotlight/featured_images/_upload_form', type: :view do
   it 'has help block' do
     render partial: 'spotlight/featured_images/upload_form',
            locals: { f: builder, initial_crop_selection: [], crop_type: :thumbnail }
-    expect(rendered).to have_css '.help-block', text: 'Help!'
+    expect(rendered).to have_css '.form-text', text: 'Help!'
   end
 end


### PR DESCRIPTION
Related to https://github.com/sul-dlss/exhibits/issues/1591

https://getbootstrap.com/docs/4.4/components/forms/#help-text

> Block-level help text in forms can be created using .form-text (previously known as .help-block in v3). Inline help text can be flexibly implemented using any inline HTML element and utility classes like .text-muted.