### PR TITLE
Increase fontweight on active tabs

### DIFF
--- a/app/assets/stylesheets/spotlight/_bootstrap_overrides.scss
+++ b/app/assets/stylesheets/spotlight/_bootstrap_overrides.scss
@@ -79,6 +79,12 @@ label.radio {
   margin-bottom: $line-height-lg * 1rem;
 }
 
+.nav-tabs {
+  .nav-link.active {
+    font-weight: 600;
+  }
+}
+
 .tab-pane {
   > p.instructions:first-child, > fieldset:first-child {
     margin-top: -$padding-base-vertical;


### PR DESCRIPTION
Closes  sul-dlss/exhibits#1588

This increases the font-weight on active `.nav-tabs`. 

### Before
![active tab, light font weight](https://user-images.githubusercontent.com/5402927/73963607-7c562900-48c5-11ea-9332-2c6640efa550.png)

### After
![active tab, more prominent](https://user-images.githubusercontent.com/5402927/73963608-7ceebf80-48c5-11ea-8ad1-f70ec4935946.png)