### PR TITLE
Add some bootstrap classes and custom css for a better responsive …

### DIFF
--- a/app/assets/stylesheets/spotlight/_exhibit_navbar.scss
+++ b/app/assets/stylesheets/spotlight/_exhibit_navbar.scss
@@ -1,0 +1,10 @@
+.exhibit-navbar {
+  .navbar-nav,
+  .exhibit-search-form {
+    width: 100%;
+
+    @media (min-width: breakpoint-min("md")) {
+      width: auto;
+    }
+  }
+}

--- a/app/assets/stylesheets/spotlight/_spotlight.scss
+++ b/app/assets/stylesheets/spotlight/_spotlight.scss
@@ -13,6 +13,7 @@
 @import "spotlight/croppable";
 @import "spotlight/curation";
 @import "spotlight/exhibit_admin";
+@import "spotlight/exhibit_navbar";
 @import "spotlight/edit_in_place";
 @import "spotlight/featured_browse_categories_block";
 @import "spotlight/item_text_block";

--- a/app/views/shared/_exhibit_navbar.html.erb
+++ b/app/views/shared/_exhibit_navbar.html.erb
@@ -1,5 +1,5 @@
 <div id="exhibit-navbar" class="exhibit-navbar navbar navbar-light navbar-expand-md" role="navigation">
-  <div class="container">
+  <div class="container flex-column flex-md-row">
     <% if resource_masthead? %>
       <%= link_to(current_exhibit.title, spotlight.exhibit_path(current_exhibit), class: 'navbar-brand') %>
     <% end %>
@@ -11,7 +11,7 @@
       <% end %>
     </ul>
     <% if should_render_spotlight_search_bar? %>
-      <div class="navbar-right navbar-nav">
+      <div class="navbar-right navbar-nav exhibit-search-form mt-3 mt-md-0">
         <%= render_search_bar %>
       </div>
     <% end %>


### PR DESCRIPTION
…exhibit navbar.

Closes sul-dlss/exhibits#1618

## Small Screen Before
<img width="706" alt="sm-before" src="https://user-images.githubusercontent.com/96776/73979864-df56b880-48e3-11ea-9fd1-4a78566a31e8.png">

## Small Screen After
<img width="762" alt="sm-after" src="https://user-images.githubusercontent.com/96776/73979870-e2ea3f80-48e3-11ea-86d4-19250af7be29.png">

## Medium Screen Before/After (unchanged)
<img width="727" alt="md-before-n-fater" src="https://user-images.githubusercontent.com/96776/73979871-e382d600-48e3-11ea-85d7-4d4803b4cce1.png">


