### PR TITLE
Remove the top padding from col-form-label when labeling checkboxes…

### DIFF
--- a/app/views/spotlight/exhibits/_form.html.erb
+++ b/app/views/spotlight/exhibits/_form.html.erb
@@ -11,7 +11,7 @@
     <span id='another-email' class="btn btn-sm btn-info"><%= t('.add_contact_email_button') %></span>
     <small class="form-text text-muted"><%= t(:'.fields.contact_emails.help_block') %></small>
   <% end %>
-  <%= f.form_group :published, label: { text: nil, class: nil }, help: nil do %>
+  <%= f.form_group :published, label: { text: nil, class: 'pt-0' }, help: nil do %>
     <%= f.check_box :published, label: "" %>
     <small class="form-text text-muted"><%= t(:'.fields.published.help_block') %></small>
   <% end %>

--- a/app/views/spotlight/search_configurations/_default_per_page.html.erb
+++ b/app/views/spotlight/search_configurations/_default_per_page.html.erb
@@ -1,4 +1,4 @@
-<%= f.form_group :default_per_page, label: { text: t(:'.label')} do %>
+<%= f.form_group :default_per_page, label: { text: t(:'.label'), class: 'pt-0'} do %>
   <% @blacklight_configuration.default_blacklight_config.per_page.each do |key| %>
     <%= f.radio_button :default_per_page, key, label: key.to_s %>
   <% end %>

--- a/app/views/spotlight/search_configurations/_document_index_view_types.html.erb
+++ b/app/views/spotlight/search_configurations/_document_index_view_types.html.erb
@@ -1,4 +1,4 @@
-<%= f.form_group :document_index_view_types, label: {text: t(:'.label')} do %>
+<%= f.form_group :document_index_view_types, label: {text: t(:'.label'), class: 'pt-0'} do %>
   <%= f.fields_for :document_index_view_types, @blacklight_configuration.document_index_view_types_selected_hash do |vt| %>
     <% @blacklight_configuration.default_blacklight_config.view.select { |_k, v| v.if != false }.keys.each do |key| %>
       <%= vt.check_box key, label: view_label(key) %>

--- a/app/views/spotlight/searches/_form.html.erb
+++ b/app/views/spotlight/searches/_form.html.erb
@@ -30,10 +30,10 @@
       <div role="tabpanel" class="tab-pane active" id="search-description">
         <%= f.text_field :title, control_col: "col-sm-5" %>
         <%= f.text_area :long_description, rows: 5 %>
-        <%= f.form_group :search_box, label: { text: t(:'.search_box.label'), class: nil }, help: t(:'.search_box.help_block') do %>
+        <%= f.form_group :search_box, label: { text: t(:'.search_box.label'), class: 'pt-0' }, help: t(:'.search_box.help_block') do %>
           <%= f.check_box :search_box, label: t(:'.search_box.checkbox_label') %>
         <% end %>
-        <%= f.form_group label: { text: t(:".default_index_view_type") } do %>
+        <%= f.form_group label: { text: t(:".default_index_view_type"), class: 'pt-0' } do %>
           <% available_document_index_views.each do |view| %>
             <%= f.radio_button :default_index_view_type, view, label: view_label(view) %>
           <% end %>


### PR DESCRIPTION
…or radios (in-line with the [Bootstrap documentation](https://getbootstrap.com/docs/4.1/components/forms/#horizontal-form) for stacked checkbox/radios).

Closes sul-dlss/exhibits#1603

## Before
### Search config
<img width="361" alt="search-config-before" src="https://user-images.githubusercontent.com/96776/73989904-4aac8480-48fc-11ea-8b26-6a1b6343bbca.png">

### Browse edit
<img width="667" alt="browse-edit-before" src="https://user-images.githubusercontent.com/96776/73989905-4c764800-48fc-11ea-8dc9-197b75ce15bf.png">

## After
### Search config
<img width="435" alt="search-config-after" src="https://user-images.githubusercontent.com/96776/73989906-4d0ede80-48fc-11ea-9a6e-0c7f1a6d120d.png">

### Browse edit
<img width="639" alt="browse-edit-after" src="https://user-images.githubusercontent.com/96776/73989907-4da77500-48fc-11ea-885b-fa2900a24600.png">

(This also updates the published checkbox, but I didn't add a screenshot, because...you get the idea)