### PR TITLE
Update bootstrap styling to take into account that the grid layout is…

### DIFF
--- a/app/assets/stylesheets/spotlight/_pages.scss
+++ b/app/assets/stylesheets/spotlight/_pages.scss
@@ -110,12 +110,9 @@
   }
 
   .items-col {
+    display: flex;
     margin-bottom: 1em;
     z-index: 1;
-    display: flex;
-    flex-flow: row wrap;
-    justify-content: space-between;
-    align-content: stretch;
 
     @media (max-width: breakpoint-max("md")) {
       margin-bottom: $line-height-lg;
@@ -137,10 +134,12 @@
 
   .img-thumbnail {
     border: 1px solid $gray-600;
-    width: 100%;
+    border-radius: 0;
     height: 110px;
     object-fit: cover;
     overflow: hidden;
+    padding: 0;
+    width: 100%;
 
     @media (min-width: breakpoint-min("lg")) {
       height: 160px; // default: no sidebar, no text column

--- a/app/assets/stylesheets/spotlight/_pages.scss
+++ b/app/assets/stylesheets/spotlight/_pages.scss
@@ -102,6 +102,9 @@
 }
 
 .item-grid-block {
+  margin-left: -($grid-gutter-width / 2);
+  margin-right: -($grid-gutter-width / 2);
+
   h3 { margin-top: 0; }
 
   .text-col {

--- a/app/assets/stylesheets/spotlight/_pages.scss
+++ b/app/assets/stylesheets/spotlight/_pages.scss
@@ -129,10 +129,6 @@
     min-width: 25%;
     order: 1;
     padding: 5px;
-
-    @media (min-width: breakpoint-min("md")) and (max-width: breakpoint-max("lg")) {
-      min-width: 128px;
-    }
   }
 
   .img-thumbnail {
@@ -165,6 +161,10 @@
   .item-1,
   .item-2 {
     order: 0;
+
+    .img-thumbnail {
+      height: 270px;
+    }
   }
 }
 

--- a/app/views/spotlight/sir_trevor/blocks/_solr_documents_grid_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_solr_documents_grid_block.html.erb
@@ -1,6 +1,6 @@
 <% solr_documents_grid_block.with_solr_helper(self) %>
 <div class="content-block item-grid-block row <%= 'flex-row-reverse' if solr_documents_grid_block.content_align == 'right' %>">
-  <div class="items-col <%= solr_documents_grid_block.text? ? 'col-md-9' : 'col-md-12' %>">
+  <div class="items-col align-content-start justify-content-between flex-wrap <%= solr_documents_grid_block.text? ? 'col-md-9' : 'col-md-12' %>">
     <% if solr_documents_grid_block.documents? %>
         <% solr_documents_grid_block.each_document.each_with_index do |(block_options, document), index| %>
           <div class="box item-<%= index %>" data-id="<%= document.id %>">

--- a/app/views/spotlight/sir_trevor/blocks/_solr_documents_grid_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_solr_documents_grid_block.html.erb
@@ -1,6 +1,6 @@
 <% solr_documents_grid_block.with_solr_helper(self) %>
-<div class="content-block item-grid-block row <%= 'flex-row-reverse' if solr_documents_grid_block.content_align == 'right' %>">
-  <div class="items-col align-content-start justify-content-between flex-wrap <%= solr_documents_grid_block.text? ? 'col-md-9' : 'col-md-12' %>">
+<div class="content-block item-grid-block">
+  <div class="items-col align-content-start justify-content-between flex-wrap <%= solr_documents_grid_block.text? ? 'col-md-9' : 'col-md-12' %> <%= solr_documents_grid_block.content_align == 'right' ? 'float-right' : 'float-left' %>">
     <% if solr_documents_grid_block.documents? %>
         <% solr_documents_grid_block.each_document.each_with_index do |(block_options, document), index| %>
           <div class="box item-<%= index %>" data-id="<%= document.id %>">
@@ -18,7 +18,7 @@
 
 
   <% if solr_documents_grid_block.text? %>
-    <div class="text-col col-md-3">
+    <div class="text-col col-md-3 mw-100">
       <% unless solr_documents_grid_block.title.blank? %>
         <h3><%= solr_documents_grid_block.title %></h3>
       <% end %>


### PR DESCRIPTION
… also done by flexbox now.

Closes sul-dlss/exhibits#1624

## Before
<img width="646" alt="item-grid-before" src="https://user-images.githubusercontent.com/96776/74006029-59f8f580-492f-11ea-943e-464704cfc82e.png">


## After
<img width="729" alt="item-grid-after" src="https://user-images.githubusercontent.com/96776/74006035-5cf3e600-492f-11ea-99f6-3c280f78c3c9.png">

