### PR TITLE
Add bg-color to image masthead for better a11y

### DIFF
--- a/app/assets/stylesheets/spotlight/_header.scss
+++ b/app/assets/stylesheets/spotlight/_header.scss
@@ -73,6 +73,8 @@
 }
 
 .image-masthead {
+  background-color: $black;
+
   .navbar {
     @extend .navbar-dark;
     background-color: $navbar-transparent-page-bg;


### PR DESCRIPTION
This fixes a potential accessibility problem that @jvine discovered.

If an exhibit has an image masthead, as most exhibits probably do, and during a user's session the image used for the masthead background doesn't load for some reason, the result will be white text on a light background that doesn't pass required color contrast for acceptable accessibility:

<img width="615" alt="Screen Shot 2020-02-07 at 11 01 24 AM" src="https://user-images.githubusercontent.com/101482/74055204-ca8a2b80-499c-11ea-8958-2f18451d178b.png">

This PR makes the background of the `.image-masthead` black, so the new result when the masthead image fails to load will be:

<img width="615" alt="Screen Shot 2020-02-07 at 11 01 07 AM" src="https://user-images.githubusercontent.com/101482/74055262-e988bd80-499c-11ea-8597-49000d2518e0.png">

This shouldn't affect things when the masthead image loads as expected, nor when an image is not used for the masthead.