### PR TITLE
Reduce fieldset's vertical margins

### DIFF
--- a/app/assets/stylesheets/spotlight/_bootstrap_overrides.scss
+++ b/app/assets/stylesheets/spotlight/_bootstrap_overrides.scss
@@ -90,8 +90,8 @@ label.radio {
     margin-top: -$padding-base-vertical;
   }
   fieldset {
-    margin-bottom: $padding-large-vertical * 3;
-    margin-top: $padding-large-vertical * 2;
+    margin-bottom: $padding-large-vertical * 2;
+    margin-top: $padding-large-vertical * 1;
   }
   legend {
     margin-bottom: $padding-large-vertical;


### PR DESCRIPTION
The top and bottom margins for the `fieldset` element, used several places in the admin pages, seem bigger than necessary, creating more whitespace between sections than ideal:

<img width="714" alt="Screen Shot 2020-02-07 at 3 21 52 PM" src="https://user-images.githubusercontent.com/101482/74070333-0386c800-49be-11ea-8400-33de923a1aca.png">

### After
This PR just reduces the top and bottom margins by `1rem` each, which is not dramatic but feels a bit more normal for spacing between sections:

<img width="714" alt="Screen Shot 2020-02-07 at 3 20 36 PM" src="https://user-images.githubusercontent.com/101482/74070416-3c26a180-49be-11ea-9ebd-9d5b4005a2e4.png">

--- 

<img width="714" alt="Screen Shot 2020-02-07 at 3 20 04 PM" src="https://user-images.githubusercontent.com/101482/74070425-45177300-49be-11ea-90a5-d5ea0f8d0e65.png">


