### PR TITLE
Add top margin to admin page headers

### DIFF
--- a/app/assets/stylesheets/spotlight/_translations.scss
+++ b/app/assets/stylesheets/spotlight/_translations.scss
@@ -23,6 +23,7 @@
 .translation-subheading {
   border-bottom: 1px solid $border-color;
   margin-bottom: 20px;
+  @extend .mt-4;
 }
 
 .form-group.translation-form {

--- a/app/views/spotlight/about_pages/_contacts_form.html.erb
+++ b/app/views/spotlight/about_pages/_contacts_form.html.erb
@@ -1,6 +1,6 @@
 <%= bootstrap_form_for @exhibit, url: exhibit_contacts_path(@exhibit),
     style: :horizontal, html: {class: 'exhibit-contacts'} do |f| %>
-  <h3><%= t :".header" %></h3>
+  <h3 class="mt-4"><%= t :".header" %></h3>
   <p class="instructions"><%= t :'.instructions' %></p>
   <div class="panel-group dd contacts_admin" data-behavior="nestable" data-max-depth="1">
     <ol class="dd-list">

--- a/app/views/spotlight/pages/_order_pages.html.erb
+++ b/app/views/spotlight/pages/_order_pages.html.erb
@@ -2,7 +2,7 @@
 <%= bootstrap_form_for @exhibit, url: polymorphic_path([:update_all, @exhibit, page_collection_name]), layout: :horizontal, control_col: 'col-sm-10', html: {:'data-form-observer' => true} do |f| %>
 
     <%= render partial: 'header', locals: {f: f} %>
-    <h3><%= t :'.pages_header' %></h3>
+    <h3 class="mt-4"><%= t :'.pages_header' %></h3>
     <p class="instructions"><%= t :'.instructions' %></p>
     <div class="panel-group dd <%= page_collection_name %>_admin" id="nested-pages" data-behavior="nestable" <%= nestable_data_attributes(page_collection_name).html_safe %> >
       <ol class="dd-list">


### PR DESCRIPTION
The headings on a few admin pages don't have any top margin and get too close to the content above:

<img width="714" alt="Screen Shot 2020-02-07 at 5 16 33 PM" src="https://user-images.githubusercontent.com/101482/74074989-d5a97f80-49cd-11ea-8f9f-b4e3726780dd.png">

---

<img width="714" alt="Screen Shot 2020-02-07 at 5 16 09 PM" src="https://user-images.githubusercontent.com/101482/74074996-db9f6080-49cd-11ea-8b54-d9195133cf29.png">

---


### After
This PR adds the `mt-4` class used elsewhere for headings in the admin to the headings where we need some top margin:

<img width="714" alt="Screen Shot 2020-02-07 at 5 14 23 PM" src="https://user-images.githubusercontent.com/101482/74075036-0f7a8600-49ce-11ea-8daf-64bd2941e074.png">

---

<img width="714" alt="Screen Shot 2020-02-07 at 5 14 35 PM" src="https://user-images.githubusercontent.com/101482/74075045-1acdb180-49ce-11ea-9632-4847037a7ca9.png">

---

Plus all the Curation > Translation pages (not shown) via an `@extend`.