### PR TITLE
More closely style homepage card fixes #2407

### DIFF
--- a/app/assets/stylesheets/spotlight/_curation.scss
+++ b/app/assets/stylesheets/spotlight/_curation.scss
@@ -79,6 +79,19 @@
   display: none;
 }
 
+.home_page .card {
+  .card-body {
+    @extend .py-2;
+    @extend .px-3;
+  }
+
+  .card-title {
+    @extend .mb-0;
+    @extend .py-2;
+  }
+}
+
+
 .card.page-admin {
   &:hover {
     @include panel-hover-highlighting;

--- a/app/views/spotlight/feature_pages/_header.html.erb
+++ b/app/views/spotlight/feature_pages/_header.html.erb
@@ -2,16 +2,16 @@
   <% page = p.object %>
   <div class="home_page">
     <h3><%= t('spotlight.pages.index.feature_pages.home_pages_header') %></h3>
-    <div class="card container">
-      <div class="card-body bg-light page main row">
-        <div class="col-sm-8">
+    <div class="card d-flex">
+      <div class="card-body d-flex bg-light page main">
+        <div class="flex-grow-1 align-self-center">
           <%= p.hidden_field :id, value: page.id , class: 'form-control form-control-sm' %>
           <h3 class="h6 card-title" data-in-place-edit-target=".edit-in-place" data-in-place-edit-field-target="[data-edit-field-target='true']">
             <a href="#edit-in-place" class="field-label edit-in-place"><%= page.title %></a>
             <%= p.hidden_field :title, value: page.title , class: 'form-control form-control-sm title-field', data: {:"edit-field-target" => 'true'} %>
           </h3>
         </div>
-        <div class="col-sm-4 page-links">
+        <div class="page-links">
           <%= exhibit_view_link page, exhibit_root_path(page.exhibit), class: 'btn btn-link' %> &middot;
           <%= exhibit_edit_link page, edit_exhibit_home_page_path(page.exhibit), class: 'btn btn-link', data: { turbolinks: false } %>
         </div>


### PR DESCRIPTION
While the height is not exactly the same, this brings things together much more inline with how the draggable page cards are styled.
## Before
![Screen Shot 2020-02-10 at 12 22 33 PM](https://user-images.githubusercontent.com/1656824/74182293-083abe80-4c00-11ea-8bf6-e5e245527f78.png)

## After
![Screen Shot 2020-02-10 at 12 22 16 PM](https://user-images.githubusercontent.com/1656824/74182296-08d35500-4c00-11ea-8200-4d474238169b.png)
