### PR TITLE
Fix "Export data" link in the Delete Exhibit alert

### DIFF
--- a/app/assets/javascripts/spotlight/admin/tabs.js
+++ b/app/assets/javascripts/spotlight/admin/tabs.js
@@ -1,6 +1,6 @@
 Spotlight.onLoad(function(){
   if ($('[role=tabpanel]').length > 0 && window.location.hash) {
     var tabpanel = $(window.location.hash).closest('[role=tabpanel]');
-    $('a[role=tab][href=#'+tabpanel.attr('id')+']').tab('show');  
+    $('a[role=tab][href="#'+tabpanel.attr('id')+'"]').tab('show');
   }
 });

--- a/app/views/spotlight/exhibits/_delete.html.erb
+++ b/app/views/spotlight/exhibits/_delete.html.erb
@@ -2,7 +2,7 @@
   <div class="alert alert-danger">
     <h4 class="alert-heading"><%= t(:".heading") %></h4>
     <div class="row">
-      <p class='col-9'><%= t(:".warning_html", export_link: link_to(t(:'spotlight.exhibits.export.download'), spotlight.import_exhibit_path(current_exhibit))) %></p>
+      <p class='col-9'><%= t(:".warning_html", export_link: link_to(t(:'spotlight.exhibits.export.download'), spotlight.edit_exhibit_path(current_exhibit, anchor: 'export'))) %></p>
       <div class='col-3'>
         <%= delete_link current_exhibit, class: 'btn btn-secondary' %>
       </div>

--- a/spec/views/spotlight/exhibits/edit.html.erb_spec.rb
+++ b/spec/views/spotlight/exhibits/edit.html.erb_spec.rb
@@ -23,7 +23,7 @@ describe 'spotlight/exhibits/edit', type: :view do
     expect(rendered).to have_selector "form[action=\"#{spotlight.exhibit_path(exhibit)}\"]"
     expect(rendered).to have_selector '.alert.alert-danger'
     expect(rendered).to have_content 'This action is irreversible'
-    expect(rendered).to have_link 'Export data', href: spotlight.import_exhibit_path(exhibit)
+    expect(rendered).to have_link 'Export data', href: spotlight.edit_exhibit_path(exhibit, anchor: 'export')
     expect(rendered).to have_button 'Import data'
   end
 end


### PR DESCRIPTION
Closes #2406 

This also fixes a bug where the tabs would not be loaded when the relevant anchor was in the URL.