### PR TITLE
Use flexbox to align buttons fixes #2420

### DIFF
--- a/app/views/catalog/_save_search.html.erb
+++ b/app/views/catalog/_save_search.html.erb
@@ -15,8 +15,8 @@
         <%= select_tag :id, options_for_select(current_exhibit.searches.map { |s| [s.title, s.id] }), include_blank: true, class: 'form-control' %>
         <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:qt, :page, :utf8)) %>
       </div>
-      <div class="modal-footer">
-        <%= f.submit nil, class: 'btn btn-primary float-right' %>
+      <div class="modal-footer d-flex flex-row-reverse justify-content-start">
+        <%= f.submit nil, class: 'btn btn-primary' %>
         <button type="button" class="btn btn-link" data-dismiss="modal"><%= t :cancel %></button>
       </div>
     </div>


### PR DESCRIPTION
Also preserves the tab order of save first

<img width="599" alt="Screen Shot 2020-02-10 at 6 56 44 PM" src="https://user-images.githubusercontent.com/1656824/74206086-2374f080-4c37-11ea-9196-f58454d6b41e.png">
