### PR TITLE
Update heading structure of user facing and admin pages

### DIFF
--- a/app/helpers/spotlight/main_app_helpers.rb
+++ b/app/helpers/spotlight/main_app_helpers.rb
@@ -5,6 +5,8 @@ module Spotlight
   # Helpers that are injected into the main application (because they used in layouts)
   module MainAppHelpers
     include Spotlight::NavbarHelper
+    include Spotlight::MastheadHelper
+
     def cache_key_for_spotlight_exhibits
       "#{Spotlight::Exhibit.count}/#{Spotlight::Exhibit.maximum(:updated_at).try(:utc)}"
     end

--- a/app/helpers/spotlight/masthead_helper.rb
+++ b/app/helpers/spotlight/masthead_helper.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Spotlight
+  ##
+  # Helper module for content in mastheads
+  module MastheadHelper
+    def masthead_heading_content
+      return current_exhibit.title if current_exhibit
+
+      application_name
+    end
+
+    def masthead_subheading_content
+      return current_exhibit&.subtitle&.presence if current_exhibit
+
+      current_site&.subtitle&.presence
+    end
+  end
+end

--- a/app/views/shared/_masthead.html.erb
+++ b/app/views/shared/_masthead.html.erb
@@ -13,21 +13,18 @@
   <%= render 'shared/exhibit_navbar' if current_exhibit && resource_masthead? %>
 
   <div class="container site-title-container">
-    <div class="site-title h2">
-      <% if content_for? :masthead %>
+    <% if content_for? :masthead %>
+      <h1 class="site-title h2">
         <%= content_for :masthead %>
-      <% elsif current_exhibit %>
-        <%= current_exhibit.title %>
-        <% if current_exhibit.subtitle.present? %>
-          <small><%= current_exhibit.subtitle %></small>
-        <% end %>
-      <% else %>
-        <%= application_name %>
-        <% if current_site.subtitle.present? %>
-          <small><%= current_site.subtitle %></small>
-        <% end %>
+      </h1>
+    <% else %>
+      <h1 class="site-title h2">
+        <%= masthead_heading_content %>
+      </h1>
+      <% if masthead_subheading_content %>
+        <small><%= masthead_subheading_content %></small>
       <% end %>
-    </div>
+    <% end %>
   </div>
 
   <%= render 'shared/exhibit_navbar' if current_exhibit && !resource_masthead? %>

--- a/app/views/spotlight/about_pages/_contacts.html.erb
+++ b/app/views/spotlight/about_pages/_contacts.html.erb
@@ -1,4 +1,4 @@
-<h4 class='contacts-header nav-heading'><%= t :'.header' %></h4>
+<h2 class='contacts-header nav-heading h4'><%= t :'.header' %></h2>
 <ol class="nav sidenav contacts flex-column">
   <% current_exhibit.contacts.published.each do |contact| %>
     <li itemscope itemtype="http://schema.org/Person">

--- a/app/views/spotlight/about_pages/_contacts_form.html.erb
+++ b/app/views/spotlight/about_pages/_contacts_form.html.erb
@@ -1,6 +1,6 @@
 <%= bootstrap_form_for @exhibit, url: exhibit_contacts_path(@exhibit),
     style: :horizontal, html: {class: 'exhibit-contacts'} do |f| %>
-  <h3 class="mt-4"><%= t :".header" %></h3>
+  <h2 class="mt-4"><%= t :".header" %></h2>
   <p class="instructions"><%= t :'.instructions' %></p>
   <div class="panel-group dd contacts_admin" data-behavior="nestable" data-max-depth="1">
     <ol class="dd-list">

--- a/app/views/spotlight/about_pages/_sidebar.html.erb
+++ b/app/views/spotlight/about_pages/_sidebar.html.erb
@@ -1,5 +1,5 @@
 <% cache_unless current_user, [current_exhibit, @page] do %>
-  <h4 class="nav-heading"><%= current_exhibit.main_navigations.about.label_or_default %></h4>
+  <h2 class="nav-heading h4"><%= current_exhibit.main_navigations.about.label_or_default %></h2>
   <ul class="nav sidenav flex-column">
     <% current_exhibit.about_pages.for_locale.published.each do |page| %>
       <li class="nav-item <%= 'active' if current_page? [spotlight, current_exhibit, page] %>">

--- a/app/views/spotlight/browse/index.html.erb
+++ b/app/views/spotlight/browse/index.html.erb
@@ -1,5 +1,6 @@
-<% set_html_page_title %>
-<h1 class="sr-only"><%= t :'.header' %></h1>
+<% title = current_exhibit.main_navigations.browse.label_or_default %>
+<% set_html_page_title(title) %>
+<h1 class="sr-only"><%= title %></h1>
 
 <div class="browse-landing row">
   <%= render collection: @searches, partial: 'spotlight/browse/search' %>

--- a/app/views/spotlight/dashboards/_analytics.html.erb
+++ b/app/views/spotlight/dashboards/_analytics.html.erb
@@ -1,5 +1,5 @@
 <%= cache current_exhibit, expires_in: 1.hour do %>
-  <h3><%= t :'.monthly_header' %></h3>
+  <h2><%= t :'.monthly_header' %></h2>
   <table class="table analytics">
     <tr>
     <% current_exhibit.analytics_provider.metrics.elements.each do |e| %>

--- a/app/views/spotlight/dashboards/_page_activity.html.erb
+++ b/app/views/spotlight/dashboards/_page_activity.html.erb
@@ -1,4 +1,4 @@
-<h3><%= t :'.header' %></h3>
+<h2><%= t :'.header' %></h2>
 
 <% unless @pages.empty? %>
   <table class="table table-striped">

--- a/app/views/spotlight/dashboards/_reindexing_activity.html.erb
+++ b/app/views/spotlight/dashboards/_reindexing_activity.html.erb
@@ -1,4 +1,4 @@
-<h3><%= t :'.header' %></h3>
+<h2><%= t :'.header' %></h2>
 
 <% unless @recent_reindexing.empty? %>
   <table class="table table-striped">

--- a/app/views/spotlight/dashboards/_solr_document_activity.html.erb
+++ b/app/views/spotlight/dashboards/_solr_document_activity.html.erb
@@ -1,4 +1,4 @@
-<h3><%= t :'.header' %></h3>
+<h2><%= t :'.header' %></h2>
 
 <% unless @solr_documents.empty? %>
   <%= render partial: 'spotlight/catalog/document_admin_table', locals: { documents: @solr_documents } %>

--- a/app/views/spotlight/exhibits/_delete.html.erb
+++ b/app/views/spotlight/exhibits/_delete.html.erb
@@ -1,6 +1,6 @@
 <div role="tabpanel" class="tab-pane" id="delete">
   <div class="alert alert-danger">
-    <h4 class="alert-heading"><%= t(:".heading") %></h4>
+    <h2 class="alert-heading h4"><%= t(:".heading") %></h2>
     <div class="row">
       <p class='col-9'><%= t(:".warning_html", export_link: link_to(t(:'spotlight.exhibits.export.download'), spotlight.edit_exhibit_path(current_exhibit, anchor: 'export'))) %></p>
       <div class='col-3'>

--- a/app/views/spotlight/exhibits/_languages.html.erb
+++ b/app/views/spotlight/exhibits/_languages.html.erb
@@ -11,7 +11,7 @@
     </div>
   <% end %>
 
-  <h3 class="mt-4"><%= t :'spotlight.exhibits.languages.current_header' %></h3>
+  <h2 class="mt-4"><%= t :'spotlight.exhibits.languages.current_header' %></h2>
 
   <% if current_exhibit.languages.any? && current_exhibit.languages.last.persisted? %>
     <p class="instructions"><%= t :'spotlight.exhibits.languages.current_instructions' %></p>

--- a/app/views/spotlight/feature_pages/_header.html.erb
+++ b/app/views/spotlight/feature_pages/_header.html.erb
@@ -1,7 +1,7 @@
 <%= f.fields_for "home_page" do |p| %>
   <% page = p.object %>
   <div class="home_page">
-    <h3><%= t('spotlight.pages.index.feature_pages.home_pages_header') %></h3>
+    <h2><%= t('spotlight.pages.index.feature_pages.home_pages_header') %></h2>
     <div class="card d-flex">
       <div class="card-body d-flex bg-light page main">
         <div class="flex-grow-1 align-self-center">

--- a/app/views/spotlight/feature_pages/_sidebar.html.erb
+++ b/app/views/spotlight/feature_pages/_sidebar.html.erb
@@ -2,7 +2,7 @@
   <ol class="nav sidenav flex-column">
     <% @exhibit.feature_pages.for_locale.published.at_top_level.each do |feature_section| %>
       <li class="<%= 'active' if current_page? [spotlight, @exhibit, feature_section] %>">
-        <%= link_to_unless_current feature_section.title, [spotlight, @exhibit, feature_section] %>
+        <h2 class="h6"><%= link_to_unless_current feature_section.title, [spotlight, @exhibit, feature_section] %></h2>
         <ol class="subsection">
           <% feature_section.child_pages.published.each do |page| %>
             <li class="<%= 'active' if current_page? [spotlight, @exhibit, page] %>"><%= link_to_unless_current page.title, [spotlight, @exhibit, page] %></li>

--- a/app/views/spotlight/metadata_configurations/edit.html.erb
+++ b/app/views/spotlight/metadata_configurations/edit.html.erb
@@ -4,7 +4,7 @@
 
 <%= configuration_page_title %>
 <%= bootstrap_form_for @blacklight_configuration, url: spotlight.exhibit_metadata_configuration_path(@exhibit), layout: :horizontal, label_col: 'col-md-3 col-sm-3', control_col: 'col-md-5 col-sm-5' do |f| %>
-    <h3><%= t(:'.order_header') %></h3>
+    <h2><%= t(:'.order_header') %></h2>
 
     <p class="instructions"><%= t :'.instructions' %></p>
 
@@ -45,7 +45,7 @@
 <% end %>
 
 
-    <h3 class="mt-4"><%= t(:'.exhibit_specific.header') %></h3>
+    <h2 class="mt-4"><%= t(:'.exhibit_specific.header') %></h2>
     <p class="instructions"><%= t(:'.exhibit_specific.instructions') %></p>
 
     <table class="table table-striped" id="exhibit-specific-fields">

--- a/app/views/spotlight/pages/_order_pages.html.erb
+++ b/app/views/spotlight/pages/_order_pages.html.erb
@@ -2,7 +2,7 @@
 <%= bootstrap_form_for @exhibit, url: polymorphic_path([:update_all, @exhibit, page_collection_name]), layout: :horizontal, control_col: 'col-sm-10', html: {:'data-form-observer' => true} do |f| %>
 
     <%= render partial: 'header', locals: {f: f} %>
-    <h3 class="mt-4"><%= t :'.pages_header' %></h3>
+    <h2 class="mt-4"><%= t :'.pages_header' %></h2>
     <p class="instructions"><%= t :'.instructions' %></p>
     <div class="panel-group dd <%= page_collection_name %>_admin" id="nested-pages" data-behavior="nestable" <%= nestable_data_attributes(page_collection_name).html_safe %> >
       <ol class="dd-list">

--- a/app/views/spotlight/search_configurations/_search_fields.html.erb
+++ b/app/views/spotlight/search_configurations/_search_fields.html.erb
@@ -53,7 +53,7 @@
 <% end %>
 
 <% if can? :manage, Spotlight::CustomSearchField.new(exhibit: current_exhibit) %>
-  <h3><%= t(:'.exhibit_specific.header') %></h3>
+  <h2><%= t(:'.exhibit_specific.header') %></h2>
   <p class="instructions"><%= t(:'.exhibit_specific.instructions') %></p>
 
   <table class="table table-striped" id="exhibit-specific-fields">

--- a/app/views/spotlight/searches/index.html.erb
+++ b/app/views/spotlight/searches/index.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <%= curation_page_title %>
-<h3><%= t(:'.categories_header') %></h3>
+<h2><%= t(:'.categories_header') %></h2>
 
 <% if @searches.empty? %>
   <%= t :'.no_saved_searches' %>

--- a/app/views/spotlight/shared/_configuration_sidebar.html.erb
+++ b/app/views/spotlight/shared/_configuration_sidebar.html.erb
@@ -1,4 +1,5 @@
-<h4 class="nav-heading"><%=t(:'spotlight.configuration.sidebar.header') %></h4>
+<h3 class="nav-heading h4"><%=t(:'spotlight.configuration.sidebar.header') %></h3>
+
 <ul class="nav sidenav flex-column">
   <% if can? :update, current_exhibit %>
     <%= nav_link t(:'spotlight.configuration.sidebar.settings'), spotlight.edit_exhibit_path(current_exhibit) %>

--- a/app/views/spotlight/shared/_curation_sidebar.html.erb
+++ b/app/views/spotlight/shared/_curation_sidebar.html.erb
@@ -1,4 +1,4 @@
-<h4 class="nav-heading"><%=t(:'spotlight.curation.sidebar.header') %></h4>
+<h3 class="nav-heading h4"><%=t(:'spotlight.curation.sidebar.header') %></h3>
 
 <ul class="nav sidenav flex-column">
   <%= nav_link t(:'spotlight.curation.sidebar.items'), spotlight.admin_exhibit_catalog_path(current_exhibit) %>

--- a/app/views/spotlight/shared/_exhibit_sidebar.html.erb
+++ b/app/views/spotlight/shared/_exhibit_sidebar.html.erb
@@ -1,3 +1,4 @@
+<h2 class="sr-only"><%= t(:'.header') %></h2>
 <ul class="nav sidenav top-level flex-column">
   <%= nav_link t(:'spotlight.curation.sidebar.dashboard'), spotlight.exhibit_dashboard_path(current_exhibit) %>
   <%= nav_link t(:'spotlight.curation.sidebar.analytics'), spotlight.analytics_exhibit_dashboard_path(current_exhibit) %>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -764,6 +764,8 @@ en:
           other: "%{count} items"
         missing_description_html: "%{link} to add a description."
     shared:
+      exhibit_sidebar:
+        header: Administration menu
       report_a_problem:
         honeypot_field_explanation: Ignore this text box. It is used to detect spammers. If you enter anything into this text box, your message will not be sent.
         title: Contact Us

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -208,8 +208,6 @@ en:
           help: You can select and crop an image to visually represent this exhibit.
     application_name: "%{exhibit} - %{application_name}"
     browse:
-      index:
-        header: Browse Exhibit
       search:
         item_count:
           one: "%{count} item"

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -9,7 +9,7 @@ describe 'Home page', type: :feature, versioning: true do
   it 'exists by default on exhibits' do
     visit spotlight.exhibit_dashboard_path(exhibit)
     click_link 'Feature pages'
-    expect(page).to have_selector 'h3', text: 'Homepage'
+    expect(page).to have_selector 'h2', text: 'Homepage'
     expect(page).to have_selector 'h3.card-title', text: 'Exhibit Home'
   end
 

--- a/spec/features/main_navigation_spec.rb
+++ b/spec/features/main_navigation_spec.rb
@@ -25,7 +25,7 @@ describe 'Main navigation labels are settable', type: :feature do
 
   it 'has the configured about page label in the sidebar' do
     visit spotlight.exhibit_about_page_path(exhibit, about)
-    expect(page).to have_css('#sidebar h4', text: 'New About Label')
+    expect(page).to have_css('#sidebar h2', text: 'New About Label')
   end
 
   it 'has the configured about page label visible in the breadcrumb' do

--- a/spec/helpers/spotlight/masthead_helper_spec.rb
+++ b/spec/helpers/spotlight/masthead_helper_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+describe Spotlight::MastheadHelper, type: :helper do
+  let(:exhibit) { FactoryBot.create(:exhibit) }
+  let(:site) { Spotlight::Site.instance }
+
+  before do
+    allow(helper).to receive(:current_exhibit).and_return(nil)
+    allow(helper).to receive(:current_site).and_return(site)
+  end
+
+  describe '#masthead_heading_content' do
+    context 'when there is a current exhibit' do
+      before { allow(helper).to receive(:current_exhibit).and_return(exhibit) }
+
+      it { expect(helper.masthead_heading_content).to eq exhibit.title }
+    end
+
+    context 'when there is no current exhibit' do
+      it { expect(helper.masthead_heading_content).to eq 'Blacklight' } # the application_name
+    end
+  end
+
+  describe '#masthead_subheading_content' do
+    context 'when there is a current exhibit' do
+      before { allow(helper).to receive(:current_exhibit).and_return(exhibit) }
+
+      context 'when the exhibit has a subtitle' do
+        before { exhibit.subtitle = 'MastheadHelper Spec Exhibit' }
+
+        it { expect(helper.masthead_subheading_content).to eq 'MastheadHelper Spec Exhibit' }
+      end
+
+      context 'when the exhibit does not have a subtitle' do
+        it { expect(helper.masthead_subheading_content).to be_nil }
+      end
+    end
+
+    context 'when there is no current exhibit' do
+      context 'when the site has a subtitle' do
+        before { site.subtitle = "The site's subtitle" }
+
+        it { expect(helper.masthead_subheading_content).to eq "The site's subtitle" }
+      end
+
+      context 'when the site does not have a subtitle' do
+        it { expect(helper.masthead_subheading_content).to be_nil }
+      end
+    end
+  end
+end

--- a/spec/views/shared/_masthead.html.erb_spec.rb
+++ b/spec/views/shared/_masthead.html.erb_spec.rb
@@ -8,6 +8,8 @@ describe 'shared/_masthead', type: :view do
     stub_template 'shared/_exhibit_navbar.html.erb' => 'navbar'
     allow(view).to receive_messages(current_exhibit: exhibit,
                                     current_masthead: masthead,
+                                    masthead_heading_content: exhibit.title,
+                                    masthead_subheading_content: exhibit.subtitle,
                                     resource_masthead?: false)
   end
 
@@ -19,7 +21,7 @@ describe 'shared/_masthead', type: :view do
 
   context 'for an exhibit without a subtitle' do
     before do
-      exhibit.update(subtitle: nil)
+      allow(view).to receive_messages(masthead_subheading_content: nil)
     end
 
     it 'does not include the subtitle' do

--- a/spec/views/spotlight/browse/index.html.erb_spec.rb
+++ b/spec/views/spotlight/browse/index.html.erb_spec.rb
@@ -4,9 +4,11 @@ describe 'spotlight/browse/index', type: :view do
   let(:search) { FactoryBot.create(:search) }
   let(:another_search) { FactoryBot.create(:search) }
 
+  before { allow(view).to receive(:current_exhibit).and_return(search.exhibit) }
+
   it 'has a title' do
     render
-    expect(response).to have_selector 'h1', text: 'Browse Exhibit'
+    expect(response).to have_selector 'h1', text: 'Browse'
   end
 
   it 'renders the collection of searches' do

--- a/spec/views/spotlight/dashboards/_reindexing_activity.html.erb_spec.rb
+++ b/spec/views/spotlight/dashboards/_reindexing_activity.html.erb_spec.rb
@@ -20,7 +20,7 @@ describe 'spotlight/dashboards/_reindexing_activity.html.erb', type: :view do
     end
 
     it 'displays the section header' do
-      expect(rendered).to have_css('h3', text: 'Recent Item Indexing Activity')
+      expect(rendered).to have_css('h2', text: 'Recent Item Indexing Activity')
     end
 
     it 'displays an explanatory message when there are no reindexing attempts in the log' do


### PR DESCRIPTION
This is an attempt to close gaps in the heading structure and ensure that all pages have an appropriate heading.

Closes sul-dlss/exhibits#1601

One area that this doesn't account for is in curator driven pages.  (See the 3rd bullet on sul-dlss/exhibits#1601 and https://github.com/sul-dlss/exhibits/issues/1601#issuecomment-584422430 for relevant discussion) where there is a heading widget that provides an `<h2>` and the widgets themselves have `<h3>` headings.

This doesn't account for all possible scenarios of what curators might want to add to their page (single widget doesn't need a superfluous heading above it, but w/o it there is a heading gap), but is a good step in the right direction.