### PR TITLE
Fixes #2419 Add width-100 to support Chrome width expansion

### DIFF
--- a/app/views/spotlight/about_pages/_contact_properties.html.erb
+++ b/app/views/spotlight/about_pages/_contact_properties.html.erb
@@ -1,4 +1,4 @@
-<div class="d-flex">
+<div class="d-flex w-100">
   <%= image_tag contact.avatar.iiif_url, class: 'contact-photo', alt: '' if contact.avatar && contact.avatar.iiif_url.present? %>
   <div>
     <div itemprop="name" class="name"><%= contact.name %></div>


### PR DESCRIPTION
This bug was not present in Firefox.

## After (Chrome)
![Screen Shot 2020-02-11 at 1 53 59 PM](https://user-images.githubusercontent.com/1656824/74278228-1fe47680-4cd6-11ea-9bed-d1b562c537c4.png)

## Before (Chrome)
![Screen Shot 2020-02-11 at 1 53 50 PM](https://user-images.githubusercontent.com/1656824/74278232-207d0d00-4cd6-11ea-88ee-f8a429d61ee0.png)
