### PR TITLE
Add margin for zipr button fixes #2430

### DIFF
--- a/app/assets/stylesheets/spotlight/_pages.scss
+++ b/app/assets/stylesheets/spotlight/_pages.scss
@@ -267,4 +267,5 @@
 
 .zpr-link {
   @extend .btn-sm;
+  margin-top: $spacer * .75;
 }


### PR DESCRIPTION
Adds the requested 0.75rem margin.

![Screen Shot 2020-02-11 at 4 05 19 PM](https://user-images.githubusercontent.com/1656824/74287940-6a6eee80-4ce8-11ea-8bd0-25dd55893e88.png)
