### PR TITLE
move blacklight-oembed to gemspec

### DIFF
--- a/blacklight-spotlight.gemspec
+++ b/blacklight-spotlight.gemspec
@@ -25,7 +25,7 @@ these collections.)
   s.add_dependency 'almond-rails', '~> 0.1'
   s.add_dependency 'autoprefixer-rails'
   s.add_dependency 'blacklight', '~> 7.0'
-  # s.add_dependency 'blacklight-oembed', '>= 0.1'
+  s.add_dependency 'blacklight-oembed', '>= 0.3.0'
   s.add_dependency 'bootstrap_form', '~> 4.1'
   s.add_dependency 'breadcrumbs_on_rails', '~> 3.0'
   s.add_dependency 'cancancan'

--- a/lib/generators/spotlight/install_generator.rb
+++ b/lib/generators/spotlight/install_generator.rb
@@ -107,7 +107,6 @@ module Spotlight
     end
 
     def add_oembed
-      gem 'blacklight-oembed', '>= 0.1', github: 'sul-dlss/blacklight-oembed'
       generate 'blacklight_oembed:install'
     end
 


### PR DESCRIPTION
Generating a new app from a template is still throwing errors after GH-2433.

see https://gist.github.com/dunn/e29ee0c32b1f1e03be471386da0b6ed3