### PR TITLE
Use floats on widget content columns so that the text columns wrap …

### DIFF
--- a/app/assets/stylesheets/spotlight/_pages.scss
+++ b/app/assets/stylesheets/spotlight/_pages.scss
@@ -102,9 +102,6 @@
 }
 
 .item-grid-block {
-  margin-left: -($grid-gutter-width / 2);
-  margin-right: -($grid-gutter-width / 2);
-
   h3 { margin-top: 0; }
 
   .text-col {

--- a/app/views/spotlight/sir_trevor/blocks/_oembed_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_oembed_block.html.erb
@@ -1,10 +1,10 @@
-<div class="content-block item-text row <%= 'flex-row-reverse' if oembed_block.content_align == 'right' %>">
-  <div class="<%= 'col-md-6' if oembed_block.text? %> col-12 oembed-block">
+<div class="content-block item-text row d-block">
+  <div class="<%= 'col-md-6' if oembed_block.text? %> col-12 <%= oembed_block.content_align == 'right' ? 'float-right' : 'float-left' %> oembed-block">
     <%= render_oembed_tag oembed_block.url %>
   </div>
 
   <% if oembed_block.text? %>
-    <div class="text-col col-md-6">
+    <div class="text-col col-md-6 mw-100">
       <% unless oembed_block.title.blank? %>
         <h3><%= oembed_block.title %></h3>
       <% end %>

--- a/app/views/spotlight/sir_trevor/blocks/_solr_documents_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_solr_documents_block.html.erb
@@ -1,9 +1,9 @@
 <% solr_documents_block.with_solr_helper(self) %>
 
-<div class="content-block items-block row <%= 'flex-row-reverse' if solr_documents_block.content_align == 'right' %>">
+<div class="content-block items-block row d-block">
   <% if solr_documents_block.documents? %>
 
-    <div class="items-col spotlight-flexbox <%= solr_documents_block.text? ? "col-md-6" : "col-md-12" %> ">
+    <div class="items-col spotlight-flexbox <%= solr_documents_block.text? ? "col-md-6" : "col-md-12" %> <%= solr_documents_block.content_align == 'right' ? 'float-right' : 'float-left' %>">
       <% solr_documents_block.each_document do |block_options, document| %>
         <% doc_presenter = index_presenter(document) %>
         <div class="box" data-id="<%= document.id %>">
@@ -35,7 +35,7 @@
   <% end %>
 
   <% if solr_documents_block.text? %>
-    <div class="text-col col-md-6">
+    <div class="text-col col-md-6 mw-100">
       <% unless solr_documents_block.title.blank? %>
         <h3><%= solr_documents_block.title %></h3>
       <% end %>

--- a/app/views/spotlight/sir_trevor/blocks/_solr_documents_embed_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_solr_documents_embed_block.html.erb
@@ -1,12 +1,12 @@
 <% solr_documents_embed_block.with_solr_helper(self) %>
 
-<div class="content-block items-block row <%= 'flex-row-reverse' if solr_documents_embed_block.content_align == 'right' %>">
+<div class="content-block items-block row d-block">
 
   <% if solr_documents_embed_block.documents? %>
-    <div class="items-col <%= solr_documents_embed_block.text? ? "col-md-6" : "col-md-12" %> ">
+    <div class="items-col <%= solr_documents_embed_block.text? ? "col-md-6" : "col-md-12" %> <%= solr_documents_embed_block.content_align == 'right' ? 'float-right' : 'float-left' %>">
       <% unless solr_documents_embed_block.text? %>
         <% unless solr_documents_embed_block.title.blank? %>
-        
+
           <h3><%= solr_documents_embed_block.title %></h3>
         <% end %>
       <% end %>
@@ -21,7 +21,7 @@
   <% end %>
 
   <% if solr_documents_embed_block.text? %>
-    <div class="text-col col-md-6">
+    <div class="text-col col-md-6 mw-100">
       <% unless solr_documents_embed_block.title.blank? %>
         <h3><%= solr_documents_embed_block.title %></h3>
       <% end %>

--- a/app/views/spotlight/sir_trevor/blocks/_solr_documents_grid_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_solr_documents_grid_block.html.erb
@@ -1,5 +1,5 @@
 <% solr_documents_grid_block.with_solr_helper(self) %>
-<div class="content-block item-grid-block">
+<div class="content-block item-grid-block row d-block">
   <div class="items-col align-content-start justify-content-between flex-wrap <%= solr_documents_grid_block.text? ? 'col-md-9' : 'col-md-12' %> <%= solr_documents_grid_block.content_align == 'right' ? 'float-right' : 'float-left' %>">
     <% if solr_documents_grid_block.documents? %>
         <% solr_documents_grid_block.each_document.each_with_index do |(block_options, document), index| %>

--- a/app/views/spotlight/sir_trevor/blocks/_uploaded_items_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_uploaded_items_block.html.erb
@@ -1,5 +1,5 @@
-<div class="content-block item-text row <%= 'flex-row-reverse' if uploaded_items_block.content_align == 'right' %>">
-  <div class="items-col spotlight-flexbox <%= 'col-md-6' if uploaded_items_block.text? %> col-12 uploaded-items-block">
+<div class="content-block item-text row d-block">
+  <div class="items-col spotlight-flexbox <%= 'col-md-6' if uploaded_items_block.text? %> col-12 <%= uploaded_items_block.content_align == 'right'  ? 'float-right' : 'float-left'  %> uploaded-items-block">
     <% if uploaded_items_block.files.present? %>
       <% uploaded_items_block.files.each do |file| %>
         <div class="box" data-id="<%= file[:id] %>">
@@ -17,7 +17,7 @@
   </div>
 
   <% if uploaded_items_block.text? %>
-    <div class="text-col col-md-6">
+    <div class="text-col col-md-6 mw-100">
       <%= content_tag(:h3, uploaded_items_block.title) if uploaded_items_block.title.present? %>
       <%= sir_trevor_markdown uploaded_items_block.text %>
     </div>


### PR DESCRIPTION
…around the content (even in flexbox land).

Closes #2428 

This follows the same pattern done in #2404 (and updates that to remove some custom css that can be handled via utility classes)