### PR TITLE
add blacklight-oembed as a direct dependency of spotlight 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,3 @@ cache:
   ##
   # Caching bundler here in a hope to reduce Travis test time
   bundler: true
-  ##
-  # We don't really know how this will work, but lets see.
-  directories:
-    - .internal_test_app

--- a/blacklight-spotlight.gemspec
+++ b/blacklight-spotlight.gemspec
@@ -25,7 +25,7 @@ these collections.)
   s.add_dependency 'almond-rails', '~> 0.1'
   s.add_dependency 'autoprefixer-rails'
   s.add_dependency 'blacklight', '~> 7.0'
-  # s.add_dependency 'blacklight-oembed', '>= 0.1'
+  s.add_dependency 'blacklight-oembed', '>= 0.3.0'
   s.add_dependency 'bootstrap_form', '~> 4.1'
   s.add_dependency 'breadcrumbs_on_rails', '~> 3.0'
   s.add_dependency 'cancancan'

--- a/lib/generators/spotlight/install_generator.rb
+++ b/lib/generators/spotlight/install_generator.rb
@@ -107,7 +107,7 @@ module Spotlight
     end
 
     def add_oembed
-      gem 'blacklight-oembed', '>= 0.1', github: 'sul-dlss/blacklight-oembed'
+      gem 'blacklight-oembed', '>= 0.3.0'
       generate 'blacklight_oembed:install'
     end
 

--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -7,6 +7,7 @@ require 'devise'
 require 'devise_invitable'
 
 require 'blacklight'
+require 'blacklight/oembed'
 require 'autoprefixer-rails'
 require 'friendly_id'
 require 'tophat'


### PR DESCRIPTION
it needs to be a dependency of spotlight itself to avoid loading errors during
generation (https://gist.github.com/dunn/e29ee0c32b1f1e03be471386da0b6ed3) and
it needs to be a dependency of the generated application so that its assets are
available to sprockets; otherwise we get

```
ActionView::Template::Error (couldn't find file 'blacklight_gallery/default' with type 'application/javascript'
```