### PR TITLE
Fix generator helper injection

### DIFF
--- a/lib/generators/spotlight/install_generator.rb
+++ b/lib/generators/spotlight/install_generator.rb
@@ -64,7 +64,9 @@ module Spotlight
 
     def add_helper
       copy_file 'spotlight_helper.rb', 'app/helpers/spotlight_helper.rb'
-      inject_into_class 'app/helpers/application_helper.rb', ApplicationHelper, '  include SpotlightHelper'
+      inject_into_file 'app/helpers/application_helper.rb', after: 'module ApplicationHelper' do
+        "\n  include SpotlightHelper"
+      end
     end
 
     def add_model_mixin


### PR DESCRIPTION
 `insert_into_class` apparently now requires a class, not a module, and complains about it when you use the generator.