### PR TITLE
Remove duplicate import of blacklight-gallery

### DIFF
--- a/app/assets/stylesheets/spotlight/_spotlight.scss
+++ b/app/assets/stylesheets/spotlight/_spotlight.scss
@@ -5,7 +5,6 @@
 @import "spotlight/sir-trevor_overrides";
 @import "spotlight/attachments";
 @import "spotlight/pages";
-@import 'blacklight_gallery/default';
 @import "spotlight/browse";
 @import "spotlight/header";
 @import "spotlight/footer";


### PR DESCRIPTION
This was causing duplication of blacklight-gallery and bootstrap styles
in downstream applications. Blacklight-gallery generates itself into an
application and consumers can choose how it should import things.