### PR TITLE
Add a wrapper around the Title/Subtitle and apply stying from the...

### DIFF
--- a/app/assets/stylesheets/spotlight/_header.scss
+++ b/app/assets/stylesheets/spotlight/_header.scss
@@ -20,8 +20,12 @@
 
 
   .site-title {
-    margin-top: $padding-large-vertical;
-    padding-bottom: $padding-base-vertical / 2;
+    margin-bottom: 0;
+  }
+
+  .site-title-wrapper {
+    margin-top: $spacer * 1.25;
+    padding-bottom: $spacer * 0.75;
     position: relative;
     white-space: nowrap;
   }

--- a/app/views/shared/_masthead.html.erb
+++ b/app/views/shared/_masthead.html.erb
@@ -13,18 +13,20 @@
   <%= render 'shared/exhibit_navbar' if current_exhibit && resource_masthead? %>
 
   <div class="container site-title-container">
-    <% if content_for? :masthead %>
-      <h1 class="site-title h2">
-        <%= content_for :masthead %>
-      </h1>
-    <% else %>
-      <h1 class="site-title h2">
-        <%= masthead_heading_content %>
-      </h1>
-      <% if masthead_subheading_content %>
-        <small><%= masthead_subheading_content %></small>
+    <div class="site-title-wrapper">
+      <% if content_for? :masthead %>
+        <h1 class="site-title h2">
+          <%= content_for :masthead %>
+        </h1>
+      <% else %>
+        <h1 class="site-title h2">
+          <%= masthead_heading_content %>
+        </h1>
+        <% if masthead_subheading_content %>
+          <small><%= masthead_subheading_content %></small>
+        <% end %>
       <% end %>
-    <% end %>
+    </div>
   </div>
 
   <%= render 'shared/exhibit_navbar' if current_exhibit && !resource_masthead? %>


### PR DESCRIPTION
...site-title to that.

The spacing and positioning needs to be on an element that contains both the title and subtitle.


(Before this change, subtitles would not show up when an exhibit had a masthead image applied)