### PR TITLE
Remove the facet terms displayed as a tooltip on the info icon…

### DIFF
--- a/app/models/spotlight/field_metadata.rb
+++ b/app/models/spotlight/field_metadata.rb
@@ -19,8 +19,7 @@ module Spotlight
     def field(key)
       {
         document_count: document_counts.fetch(field_name(key), 0),
-        value_count: terms.fetch(field_name(key), []).length,
-        terms: terms.fetch(field_name(key), [])
+        value_count: terms.fetch(field_name(key), []).length
       }
     end
 

--- a/app/views/spotlight/search_configurations/_facet_metadata.html.erb
+++ b/app/views/spotlight/search_configurations/_facet_metadata.html.erb
@@ -6,9 +6,4 @@
   <% else %>
     <%= content_tag :span, t(:'.value_count', count: metadata[:value_count]) %>
   <% end %>
-  <% if metadata[:terms].any? %>
-    <%= content_tag("span", class: 'btn-with-tooltip', data: {container: 'body', toggle: 'tooltip', placement: 'top', title: metadata[:terms].join(" • ")}) do %>
-      <%= blacklight_icon('info') %>
-    <% end %>
-  <% end %>
 <% end %>

--- a/app/views/spotlight/search_configurations/_facets.html.erb
+++ b/app/views/spotlight/search_configurations/_facets.html.erb
@@ -21,7 +21,7 @@
                   </h3>
                 </div>
                 <div class="d-flex">
-                  <div class="facet-metadata">
+                  <div class="facet-metadata mr-3">
                     <%= render partial: 'facet_metadata', locals: { metadata: metadata } %>
                   </div>
                   <div class="">

--- a/spec/models/spotlight/field_metadata_spec.rb
+++ b/spec/models/spotlight/field_metadata_spec.rb
@@ -48,17 +48,10 @@ describe Spotlight::FieldMetadata do
       expect(subject.field('some_key')[:value_count]).to eq 3
     end
 
-    it 'gets a list of top terms' do
-      expect(subject.field('a')[:terms]).to match_array %w[a b c]
-      expect(subject.field('b')[:terms]).to match_array %w[b]
-      expect(subject.field('some_key')[:terms]).to match_array [7, 8, 9]
-    end
-
     context 'for a missing field' do
       it 'has reasonable default values' do
         expect(subject.field('d')[:document_count]).to eq 0
         expect(subject.field('d')[:value_count]).to eq 0
-        expect(subject.field('d')[:terms]).to be_empty
       end
     end
   end

--- a/spec/views/spotlight/search_configurations/_facet_metadata.html.erb_spec.rb
+++ b/spec/views/spotlight/search_configurations/_facet_metadata.html.erb_spec.rb
@@ -19,7 +19,6 @@ describe 'spotlight/search_configurations/_facet_metadata', type: :view do
     it 'shows the number of unique values' do
       expect(rendered).to have_content '1 item'
       expect(rendered).to have_content '3 unique values'
-      expect(rendered).to have_selector '.btn-with-tooltip'
     end
   end
 


### PR DESCRIPTION
…(Facet config dashboard).

Closes sul-dlss/exhibits#1630

## Before
<img width="846" alt="before" src="https://user-images.githubusercontent.com/96776/74393010-b475d400-4dbd-11ea-84ba-5077de01710c.png">

## After
<img width="844" alt="after" src="https://user-images.githubusercontent.com/96776/74393012-b50e6a80-4dbd-11ea-99da-2bd19c54449b.png">
