### PR TITLE
Fix sir trevor button styling that was broken

### DIFF
--- a/app/assets/stylesheets/spotlight/_sir-trevor_overrides.scss
+++ b/app/assets/stylesheets/spotlight/_sir-trevor_overrides.scss
@@ -76,10 +76,9 @@
 .st-block-controls__button {
   @extend .btn;
   @extend .btn-secondary;
+  @extend .btn-outline-secondary;
 
-  background-color: theme-colors("secondary");
   border: 1px solid $gray-700;
-  color: theme-colors("light");
 
   .st-icon {
     margin-left: auto;

--- a/vendor/assets/stylesheets/sir-trevor/block-controls.scss
+++ b/vendor/assets/stylesheets/sir-trevor/block-controls.scss
@@ -32,7 +32,3 @@
   width: 42px;
   height: 42px;
 }
-
-.st-block-controls__button:hover {
-  color: $accent-color;
-}


### PR DESCRIPTION
I noticed this on a clean generated app while working on something else.

## Before
![Screen Shot 2020-02-13 at 7 30 09 AM](https://user-images.githubusercontent.com/1656824/74444899-bf1e8080-4e32-11ea-9e49-c98ff035861f.png)

## After
![Screen Shot 2020-02-13 at 7 29 55 AM](https://user-images.githubusercontent.com/1656824/74444903-bfb71700-4e32-11ea-8f5c-6317cb979be4.png)
