### PR TITLE
Remove extra left padding from sidebar nav elements

### DIFF
--- a/app/assets/stylesheets/spotlight/_bootstrap_overrides.scss
+++ b/app/assets/stylesheets/spotlight/_bootstrap_overrides.scss
@@ -32,14 +32,13 @@
 
     padding-bottom: 0.25rem;
     margin-bottom: 0.25rem;
-    margin-left: 0.5rem;
     padding-left: 0;
     padding-top: 0;
   }
 
   .nav-link {
     padding: 0rem 1rem;
-    padding-left: 0.5rem;
+    padding-left: 0px;
   }
 
   .nav-link.active {


### PR DESCRIPTION
![Screen Shot 2020-02-13 at 14 25 13](https://user-images.githubusercontent.com/111218/74484038-acc13880-4e6c-11ea-8885-49d4f5a62e40.png)

![Screen Shot 2020-02-13 at 14 25 43](https://user-images.githubusercontent.com/111218/74484061-bcd91800-4e6c-11ea-9612-5f9df562107f.png)

This gets everything to line up against the edge  of the sidebar consistently