### PR TITLE
Update btn links

### DIFF
--- a/app/assets/stylesheets/spotlight/_curation.scss
+++ b/app/assets/stylesheets/spotlight/_curation.scss
@@ -1,6 +1,8 @@
 .page-links a {
   padding-left: 0;
   padding-right: 0;
+  line-height: $btn-line-height;
+  @include font-size($btn-font-size);
 }
 
 .missing-description {

--- a/app/assets/stylesheets/spotlight/_utilities.scss
+++ b/app/assets/stylesheets/spotlight/_utilities.scss
@@ -1,3 +1,7 @@
 .inline-block {
   display: inline-block;
 }
+
+.btn-sizing {
+  @include button-size($btn-padding-y, $btn-padding-x, $btn-font-size, $btn-line-height, $btn-border-radius);
+}

--- a/app/views/spotlight/about_pages/_contact.html.erb
+++ b/app/views/spotlight/about_pages/_contact.html.erb
@@ -9,9 +9,9 @@
         <%= f.hidden_field :weight, data: {property: "weight"} %>
         <%= render partial: "contact_properties", locals: {contact: f.object} %>
       </div>
-      <div class="contact-links">
-        <%= exhibit_edit_link f.object, :class => 'btn btn-link' %> &middot;
-        <%= exhibit_delete_link f.object, :class => 'btn btn-link' %>
+      <div class="contact-links page-links">
+        <%= exhibit_edit_link f.object %> &middot;
+        <%= exhibit_delete_link f.object %>
       </div>
     </div>
   </div>

--- a/app/views/spotlight/admin_users/index.html.erb
+++ b/app/views/spotlight/admin_users/index.html.erb
@@ -28,7 +28,7 @@
           <td>
             <div class="form-actions">
               <div class="primary-actions">
-              <%= cancel_link f.object, '#', class: 'btn btn-link', data: { behavior: 'cancel-edit' } %>
+              <%= cancel_link f.object, '#', class: 'btn-sizing', data: { behavior: 'cancel-edit' } %>
               <%= f.submit t('.save'), class: 'btn btn-primary'%>
               </div>
             </div>

--- a/app/views/spotlight/catalog/_edit_default.html.erb
+++ b/app/views/spotlight/catalog/_edit_default.html.erb
@@ -18,7 +18,7 @@
   <% end %>
   <div class="form-actions">
     <div class="primary-actions">
-      <%= cancel_link document, spotlight.polymorphic_path([current_exhibit, document]), class: 'btn btn-link' %>
+      <%= cancel_link document, spotlight.polymorphic_path([current_exhibit, document]) %>
       <%= f.submit nil, class: 'btn btn-primary' %>
       </div>
   </div>

--- a/app/views/spotlight/catalog/_index_compact_default.html.erb
+++ b/app/views/spotlight/catalog/_index_compact_default.html.erb
@@ -6,8 +6,8 @@
   <%= render_document_partial document, 'admin_index_header', document_counter: document_counter %>
 
   <div class="page-links">
-  <%= view_link document, url_for_document(document), class: 'btn btn-link' %> &middot;
-  <%= exhibit_edit_link document, [:edit, current_exhibit, document], class: 'btn btn-link' %>
+  <%= view_link document, url_for_document(document) %> &middot;
+  <%= exhibit_edit_link document, [:edit, current_exhibit, document] %>
   </div>
 </td>
 

--- a/app/views/spotlight/contacts/_form.html.erb
+++ b/app/views/spotlight/contacts/_form.html.erb
@@ -25,7 +25,7 @@
   <% end %>
 
   <div class="form-group primary-actions">
-    <%= cancel_link @contact, exhibit_about_pages_path(@contact.exhibit), class: "btn btn-link" %>
+    <%= cancel_link @contact, exhibit_about_pages_path(@contact.exhibit) %>
     <%= f.submit nil, class: 'btn btn-primary' %>
   </div>
 <% end %>

--- a/app/views/spotlight/custom_fields/_form.html.erb
+++ b/app/views/spotlight/custom_fields/_form.html.erb
@@ -15,7 +15,7 @@
 
   <div class="form-actions">
     <div class="primary-actions">
-      <%= link_to t(:"cancel"), edit_exhibit_metadata_configuration_path(current_exhibit), class: "btn btn-link" %>
+      <%= link_to t(:"cancel"), edit_exhibit_metadata_configuration_path(current_exhibit) %>
       <%= f.submit nil, class: 'btn btn-primary' %>
     </div>
   </div>

--- a/app/views/spotlight/custom_search_fields/_form.html.erb
+++ b/app/views/spotlight/custom_search_fields/_form.html.erb
@@ -6,7 +6,7 @@
 
   <div class="form-actions">
     <div class="primary-actions">
-      <%= link_to t(:"cancel"), edit_exhibit_search_configuration_path(current_exhibit), class: "btn btn-link" %>
+      <%= link_to t(:"cancel"), edit_exhibit_search_configuration_path(current_exhibit) %>
       <%= f.submit nil, class: 'btn btn-primary' %>
     </div>
   </div>

--- a/app/views/spotlight/dashboards/_page.html.erb
+++ b/app/views/spotlight/dashboards/_page.html.erb
@@ -3,11 +3,11 @@
     <h4 class="h5 mb-0"><%= page.title %></h4>
     <div class="page-links pt-0">
       <% if page.is_a?(Spotlight::HomePage) %>
-          <%= link_to action_default_value(page, :view), current_exhibit, :class => 'btn btn-link' %> &middot;
-          <%= exhibit_edit_link page, edit_exhibit_home_page_path(page.exhibit), :class => 'btn btn-link', data: { turbolinks: false } %>
+          <%= link_to action_default_value(page, :view), current_exhibit %> &middot;
+          <%= exhibit_edit_link page, edit_exhibit_home_page_path(page.exhibit), data: { turbolinks: false } %>
       <% else %>
-        <%= exhibit_view_link page, :class => 'btn btn-link' %> &middot;
-        <%= exhibit_edit_link page, :class => 'btn btn-link', data: { turbolinks: false } %>
+        <%= exhibit_view_link page %> &middot;
+        <%= exhibit_edit_link page, data: { turbolinks: false } %>
       <% end %>
     </div>
   </td>

--- a/app/views/spotlight/feature_pages/_header.html.erb
+++ b/app/views/spotlight/feature_pages/_header.html.erb
@@ -12,8 +12,8 @@
           </h3>
         </div>
         <div class="page-links">
-          <%= exhibit_view_link page, exhibit_root_path(page.exhibit), class: 'btn btn-link' %> &middot;
-          <%= exhibit_edit_link page, edit_exhibit_home_page_path(page.exhibit), class: 'btn btn-link', data: { turbolinks: false } %>
+          <%= exhibit_view_link page, exhibit_root_path(page.exhibit) %> &middot;
+          <%= exhibit_edit_link page, edit_exhibit_home_page_path(page.exhibit), data: { turbolinks: false } %>
         </div>
       </div>
     </div>

--- a/app/views/spotlight/metadata_configurations/edit.html.erb
+++ b/app/views/spotlight/metadata_configurations/edit.html.erb
@@ -55,8 +55,8 @@
             <td>
               <div class="field-label"><%= field.label %></div>
               <div class="actions">
-                <%= exhibit_edit_link field, class: 'btn btn-link' %> &middot;
-                <%= exhibit_delete_link field, class: 'btn btn-link' %>
+                <%= exhibit_edit_link field %> &middot;
+                <%= exhibit_delete_link field %>
               </div>
             </td>
             <td class="field-description">

--- a/app/views/spotlight/pages/_form.html.erb
+++ b/app/views/spotlight/pages/_form.html.erb
@@ -61,7 +61,7 @@
 
   <div class="form-actions">
     <div class="primary-actions">
-      <%= link_to(t('cancel'), :back, class: "btn btn-link", data: (@page.lock && @page.lock.current_session? ? { lock: url_for([spotlight, @page.exhibit, @page.lock]) } : {})) %>
+      <%= link_to(t('cancel'), :back, data: (@page.lock && @page.lock.current_session? ? { lock: url_for([spotlight, @page.exhibit, @page.lock]) } : {})) %>
       <%= f.submit class: 'btn btn-primary' %>
     </div>
   </div>

--- a/app/views/spotlight/pages/_page.html.erb
+++ b/app/views/spotlight/pages/_page.html.erb
@@ -18,9 +18,9 @@
       </div>
 
       <div class="page-links">
-        <%= exhibit_view_link page, :class => 'btn btn-link' %> &middot;
-        <%= exhibit_edit_link page, :class => 'btn btn-link', data: { turbolinks: false } %> &middot;
-        <%= exhibit_delete_link page, :class => 'btn btn-link' %>
+        <%= exhibit_view_link page %> &middot;
+        <%= exhibit_edit_link page, data: { turbolinks: false } %> &middot;
+        <%= exhibit_delete_link page %>
       </div>
       <%- if page.feature_page? -%>
         <%= f.hidden_field :parent_page_id, data: {property: "parent_page"} %>

--- a/app/views/spotlight/roles/index.html.erb
+++ b/app/views/spotlight/roles/index.html.erb
@@ -18,7 +18,7 @@
           <td></td>
           <td colspan=2>
             <div class="form-actions d-flex justify-content-end">
-              <%= cancel_link r.object, '#', class: 'btn btn-link', data: {behavior: 'cancel-edit' } %>
+              <%= cancel_link r.object, '#', class: 'btn-sizing', data: {behavior: 'cancel-edit' } %>
               <%=f.submit nil, class: 'btn btn-primary'%>
             </div>
           </td>
@@ -43,7 +43,7 @@
           </td>
           <td colspan=2>
             <div class="form-actions d-flex justify-content-end">
-              <%= cancel_link r.object, '#', class: 'btn btn-link', data: {behavior: 'cancel-edit' } %>
+              <%= cancel_link r.object, '#', class: 'btn-sizing', data: {behavior: 'cancel-edit' } %>
               <%=f.submit nil, class: 'btn btn-primary'%>
             </div>
           </td>

--- a/app/views/spotlight/search_configurations/_facets.html.erb
+++ b/app/views/spotlight/search_configurations/_facets.html.erb
@@ -25,9 +25,9 @@
                     <%= render partial: 'facet_metadata', locals: { metadata: metadata } %>
                   </div>
                   <div class="">
-                    <a class="btn btn-link collapse-toggle collapsed" role="button" data-toggle="collapse" href="#<%= key.parameterize %>_facet_options" aria-expanded="false" aria-controls="<%= key.parameterize %>_facet_options">
+                    <button class="btn btn-link collapse-toggle collapsed" type="button" data-toggle="collapse" data-target="#<%= key.parameterize %>_facet_options" aria-expanded="false" aria-controls="<%= key.parameterize %>_facet_options">
                       Options
-                    </a>
+                    </button>
                     <span class="collapse-chevron">❯</span>
                   </div>
                 </div>

--- a/app/views/spotlight/search_configurations/_search_fields.html.erb
+++ b/app/views/spotlight/search_configurations/_search_fields.html.erb
@@ -63,8 +63,8 @@
           <td>
             <div class="field-label"><%= field.label %></div>
             <div class="actions">
-              <%= exhibit_edit_link field, class: 'btn btn-link' %> &middot;
-              <%= exhibit_delete_link field, class: 'btn btn-link' %>
+              <%= exhibit_edit_link field %> &middot;
+              <%= exhibit_delete_link field %>
             </div>
           </td>
           <td class="field-description">

--- a/app/views/spotlight/searches/_form.html.erb
+++ b/app/views/spotlight/searches/_form.html.erb
@@ -68,7 +68,7 @@
 
   <div class="form-actions">
     <div class="primary-actions">
-      <%= cancel_link @search,exhibit_searches_path(@exhibit), class: 'btn btn-link' %>
+      <%= cancel_link @search,exhibit_searches_path(@exhibit), class: 'btn-sizing' %>
       <%= f.submit nil, class: 'btn btn-primary' %>
     </div>
   </div>

--- a/app/views/spotlight/shared/_report_a_problem.html.erb
+++ b/app/views/spotlight/shared/_report_a_problem.html.erb
@@ -14,7 +14,7 @@
       <%= f.hidden_field :current_url %>
       <div class="form-actions">
         <div class="primary-actions">
-        <%= link_to t(:'helpers.action.cancel'), '#', class: 'btn btn-link', data: { 'behavior' => 'cancel-link' } %>
+        <%= link_to t(:'helpers.action.cancel'), '#', class: 'btn-sizing', data: { 'behavior' => 'cancel-link' } %>
         <%= f.submit nil, class: 'btn btn-primary' %>
         </div>
       </div>

--- a/spec/features/javascript/search_config_admin_spec.rb
+++ b/spec/features/javascript/search_config_admin_spec.rb
@@ -74,7 +74,7 @@ describe 'Search Configuration Administration', js: true do
       click_link 'Facets'
 
       within '.facet-config-genre_ssim' do
-        click_link 'Options'
+        click_button 'Options'
         expect(find(:css, '#blacklight_configuration_facet_fields_genre_ssim_sort_count')).to be_checked
 
         choose 'Value'


### PR DESCRIPTION
Aims to fix https://github.com/sul-dlss/exhibits/issues/1628

We used `.btn .btn-links` in many places, just to size links similarly to buttons. While this is all and good, it prevented default accessibility technology. This PR removes the proliferation of that pattern in favor of using it on actual `<button>` elements as intended while retaining the ability to have a `btn`like size.

I want to verify this w/ @jvine and @ggeisler before shipping.