### PR TITLE
Update responsive margin/heights of the browse category image …

### DIFF
--- a/app/assets/stylesheets/spotlight/_browse.scss
+++ b/app/assets/stylesheets/spotlight/_browse.scss
@@ -36,7 +36,7 @@ $image-overlay-max-height: 300px;
   }
 
   .category {
-    margin-bottom: $spacer * 2;
+    margin-bottom: $spacer;
   }
 
   .image-overlay {
@@ -84,19 +84,16 @@ $image-overlay-max-height: 300px;
   }
 
   @media screen and (max-width: breakpoint-max("sm")) {
-    $image-overlay-max-height: 180px;
-    .category {
-      margin: 10px auto;
-    }
-
+    $image-overlay-max-height: 240px;
     .image-overlay {
+      margin: 10px auto;
       max-height: $image-overlay-max-height;
       max-width: 350px;
     }
     .text-overlay .browse-category-title {font-size: $h3-font-size;}
   }
   @media screen and (min-width: breakpoint-min("sm")) and (max-width: breakpoint-max("md")) {
-    $image-overlay-max-height: 180px;
+    $image-overlay-max-height: 240px;
     .image-overlay {max-height: $image-overlay-max-height;}
   }
   @media screen and (min-width: breakpoint-min("md")) and (max-width: breakpoint-max("lg")) {


### PR DESCRIPTION
…overlays on the browse landing page.

Closes #2445 

## Before
![resp-browse-before](https://user-images.githubusercontent.com/96776/74558650-860c0c00-4f17-11ea-9702-5ff72a75302a.gif)

## After
![resp-browse-after](https://user-images.githubusercontent.com/96776/74558632-80162b00-4f17-11ea-846a-62a6cb857fd9.gif)

This also appears to more closely match what is in our current production instance wrt heights and breakpoints.