### PR TITLE
Move some of our BS form overrides to be applied to forms regardless …

### DIFF
--- a/app/assets/stylesheets/spotlight/_bootstrap_overrides.scss
+++ b/app/assets/stylesheets/spotlight/_bootstrap_overrides.scss
@@ -80,21 +80,22 @@ h1,h2,h3,h4,h5,h6 {
   }
 }
 
-.tab-pane {
-  fieldset {
-    margin-bottom: $spacer * 2;
-    margin-top: $spacer * 1;
-  }
-  legend {
-    margin-bottom: $spacer;
-  }
-  small.form-text {
-    margin-bottom: $spacer;
-    margin-top: $spacer * 0.3125;
-  }
-  div.form-check + input[type="file"] {
-    margin-top: $spacer;
-  }
+fieldset {
+  margin-bottom: $spacer * 2;
+  margin-top: $spacer * 1;
+}
+
+legend {
+  margin-bottom: $spacer;
+}
+
+small.form-text {
+  margin-bottom: $spacer;
+  margin-top: $spacer * 0.3125;
+}
+
+div.form-check + input[type="file"] {
+  margin-top: $spacer;
 }
 
 @media (max-width: breakpoint-max("md")) {


### PR DESCRIPTION
…if they are in a tab-pane or not.

Closes #2447 

## Before
<img width="643" alt="contact-form-before" src="https://user-images.githubusercontent.com/96776/74560343-37f90780-4f1b-11ea-96ce-e277ac7f7fdd.png">

## After
<img width="684" alt="contact-form-after" src="https://user-images.githubusercontent.com/96776/74560347-3af3f800-4f1b-11ea-8bf8-9959868821fe.png">