### PR TITLE
Update styling on site-wide user admin dashboard

### DIFF
--- a/app/views/spotlight/admin_users/index.html.erb
+++ b/app/views/spotlight/admin_users/index.html.erb
@@ -5,7 +5,7 @@
     <table class="table table-striped">
       <thead>
         <tr>
-          <th><%= Spotlight::Engine.user_class.human_attribute_name(:email)  %></th>
+          <th colspan="2"><%= Spotlight::Engine.user_class.human_attribute_name(:email)  %></th>
         </tr>
       </thead>
       <tbody class="table">

--- a/app/views/spotlight/admin_users/index.html.erb
+++ b/app/views/spotlight/admin_users/index.html.erb
@@ -16,7 +16,7 @@
               <span class='badge badge-warning pending-label'><%= t('.pending') %></span>
             </td>
             <td>
-              <%= link_to(t('.destroy'), admin_user_path(user), method: :delete, class: 'btn btn-danger float-right') unless user == current_user %>
+              <%= link_to(t('.destroy'), admin_user_path(user), method: :delete, class: 'btn btn-sm btn-danger float-right') unless user == current_user %>
             </td>
           </tr>
         <% end %>
@@ -81,9 +81,9 @@
             </td>
             <td class="text-right">
               <% if user.superadmin? %>
-                <%= link_to(t('.destroy'), admin_user_path(user), method: :delete, class: 'btn btn-danger') unless user == current_user %>
+                <%= link_to(t('.destroy'), admin_user_path(user), method: :delete, class: 'btn btn-sm btn-danger') unless user == current_user %>
               <% else %>
-                <%= link_to(t('.update'), admin_user_path(user), method: :patch, class: 'btn btn-default') %>
+                <%= link_to(t('.update'), admin_user_path(user), method: :patch, class: 'btn btn-sm btn-secondary') %>
               <% end %>
             </td>
           </tr>

--- a/app/views/spotlight/admin_users/index.html.erb
+++ b/app/views/spotlight/admin_users/index.html.erb
@@ -1,90 +1,96 @@
 <%= page_title(t('.section'), t('.page_title')) %>
 <%= bootstrap_form_for Spotlight::Engine.user_class.new, html: { class: 'admin-users' }, url: spotlight.admin_users_path do |f| %>
-  <h3 class="instructions"><%= t :'.instructions' %></h3>
-  <table class="table table-striped">
-    <thead>
-      <tr>
-        <th><%= Spotlight::Engine.user_class.human_attribute_name(:email)  %></th>
-      </tr>
-    </thead>
-    <tbody class="table">
-      <% @site.roles.map(&:user).each do |user| %>
+  <div class="mb-4">
+    <h3 class="instructions"><%= t :'.instructions' %></h3>
+    <table class="table table-striped">
+      <thead>
         <tr>
-          <td class="<%= 'invite-pending' if user.invite_pending? %>">
-            <%= user.email %>
-            <span class='badge badge-warning pending-label'><%= t('.pending') %></span>
+          <th><%= Spotlight::Engine.user_class.human_attribute_name(:email)  %></th>
+        </tr>
+      </thead>
+      <tbody class="table">
+        <% @site.roles.map(&:user).each do |user| %>
+          <tr>
+            <td class="<%= 'invite-pending' if user.invite_pending? %>">
+              <%= user.email %>
+              <span class='badge badge-warning pending-label'><%= t('.pending') %></span>
+            </td>
+            <td>
+              <%= link_to(t('.destroy'), admin_user_path(user), method: :delete, class: 'btn btn-danger float-right') unless user == current_user %>
+            </td>
+          </tr>
+        <% end %>
+        <tr data-edit-for='new'>
+          <td>
+            <%= f.email_field :email, hide_label: true %>
+            <span data-user-role='admin'></span>
           </td>
           <td>
-            <%= link_to(t('.destroy'), admin_user_path(user), method: :delete, class: 'btn btn-danger float-right') unless user == current_user %>
-          </td>
-        </tr>
-      <% end %>
-      <tr data-edit-for='new'>
-        <td>
-          <%= f.email_field :email, hide_label: true %>
-          <span data-user-role='admin'></span>
-        </td>
-        <td>
-          <div class="form-actions">
-            <div class="primary-actions">
-            <%= cancel_link f.object, '#', class: 'btn btn-link', data: { behavior: 'cancel-edit' } %>
-            <%= f.submit t('.save'), class: 'btn btn-primary'%>
+            <div class="form-actions">
+              <div class="primary-actions">
+              <%= cancel_link f.object, '#', class: 'btn btn-link', data: { behavior: 'cancel-edit' } %>
+              <%= f.submit t('.save'), class: 'btn btn-primary'%>
+              </div>
             </div>
-          </div>
-        </td>
-      </tr>
-      <tr data-edit-for='new'>
-        <td colspan='2'>
-        </td>
-      </tr>
-    </tbody>
-  </table>
-
-  <div class="form-actions">
-    <div class="primary-actions">
-      <%= link_to(t('.create'), 'javascript:;', class: 'btn btn-secondary', data: { behavior: 'new-user' }) %>
-    </div>
-  </div>
-
-  <h3 class="instructions"><%= t :'.admins_curators' %></h3>
-  <div id="admins_curators" class="card card-body bg-light">
-    <div class='btn-toolbar float-right'>
-      <button class="btn btn-sm btn-secondary copy-email-addresses" data-clipboard-target="#admins_curators">
-          <%= t('.copy') %>
-      </button>
-    </div>
-    <%= Spotlight::Engine.user_class.with_roles.pluck(:email).sort.join(', ') %>
-  </div>
-
-  <h3 class="instructions"><%= t :'.all_users' %></h3>
-  <table class="table table-striped ">
-    <thead>
-      <tr>
-        <th><%= Spotlight::Engine.user_class.human_attribute_name(:email)  %></th>
-        <th><%= Spotlight::Engine.user_class.human_attribute_name(:role)  %></th>
-      </tr>
-    </thead>
-    <tbody class="table">
-      <% @users.each do |user| %>
-        <tr>
-          <td class="<%= 'invite-pending' if user.invite_pending? %>">
-            <%= user.email %>
-            <span class='badge badge-warning pending-label'><%= t('.pending') %></span>
-          </td>
-          <td class="role">
-            <%= user.roles.map { |r| r.role.titleize }.uniq.join(", ") %>
-          </td>
-          <td class="text-right">
-            <% if user.superadmin? %>
-              <%= link_to(t('.destroy'), admin_user_path(user), method: :delete, class: 'btn btn-danger') unless user == current_user %>
-            <% else %>
-              <%= link_to(t('.update'), admin_user_path(user), method: :patch, class: 'btn btn-default') %>
-            <% end %>
           </td>
         </tr>
-      <% end %>
-    </tbody>
-  </table>
+        <tr data-edit-for='new'>
+          <td colspan='2'>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="form-actions">
+      <div class="primary-actions">
+        <%= link_to(t('.create'), 'javascript:;', class: 'btn btn-secondary', data: { behavior: 'new-user' }) %>
+      </div>
+    </div>
+  </div>
+
+  <div class="mb-4">
+    <h3 class="instructions"><%= t :'.admins_curators' %></h3>
+    <div id="admins_curators" class="card card-body bg-light">
+      <div class='btn-toolbar float-right'>
+        <button class="btn btn-sm btn-secondary copy-email-addresses" data-clipboard-target="#admins_curators">
+            <%= t('.copy') %>
+        </button>
+      </div>
+      <%= Spotlight::Engine.user_class.with_roles.pluck(:email).sort.join(', ') %>
+    </div>
+  </div>
+
+  <div class="mb-4">
+    <h3 class="instructions"><%= t :'.all_users' %></h3>
+    <table class="table table-striped ">
+      <thead>
+        <tr>
+          <th><%= Spotlight::Engine.user_class.human_attribute_name(:email)  %></th>
+          <th><%= Spotlight::Engine.user_class.human_attribute_name(:role)  %></th>
+        </tr>
+      </thead>
+      <tbody class="table">
+        <% @users.each do |user| %>
+          <tr>
+            <td class="<%= 'invite-pending' if user.invite_pending? %>">
+              <%= user.email %>
+              <span class='badge badge-warning pending-label'><%= t('.pending') %></span>
+            </td>
+            <td class="role">
+              <%= user.roles.map { |r| r.role.titleize }.uniq.join(", ") %>
+            </td>
+            <td class="text-right">
+              <% if user.superadmin? %>
+                <%= link_to(t('.destroy'), admin_user_path(user), method: :delete, class: 'btn btn-danger') unless user == current_user %>
+              <% else %>
+                <%= link_to(t('.update'), admin_user_path(user), method: :patch, class: 'btn btn-default') %>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
 <% end %>
 
 <% content_for(:sidebar_position) { 'order-last' } %>


### PR DESCRIPTION
Closes #2444 

## Before
<img width="760" alt="admin-users-before" src="https://user-images.githubusercontent.com/96776/74564638-60393400-4f24-11ea-9db2-4af98291b829.png">

## After 
<img width="791" alt="admin-users-after" src="https://user-images.githubusercontent.com/96776/74564640-60d1ca80-4f24-11ea-8c2b-3f02286571c1.png">
