### PR TITLE
Add a row class to the sort fields translation page.

### DIFF
--- a/app/views/spotlight/translations/_search_fields.html.erb
+++ b/app/views/spotlight/translations/_search_fields.html.erb
@@ -74,7 +74,7 @@
         <%= f.fields_for :translations, translation do |translation_fields| %>
           <%= translation_fields.hidden_field :key %>
           <%= translation_fields.hidden_field :locale %>
-          <div data-translation-progress-item='true' class='form-group translation-form'>
+          <div data-translation-progress-item='true' class='row form-group translation-form'>
             <%= translation_fields.label :value, t("spotlight.search.fields.sort.#{key}", locale: I18n.default_locale), class: 'col-form-label col-12 col-sm-2' %>
             <div class='col-11 col-sm-9 card card-body panel-translation'>
               <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>


### PR DESCRIPTION
Closes #2448 

## Before
<img width="777" alt="sort-fields-before" src="https://user-images.githubusercontent.com/96776/74565464-1d785b80-4f26-11ea-844a-7066ad915d2b.png">

## After
<img width="771" alt="sort-fields-after" src="https://user-images.githubusercontent.com/96776/74565466-1f421f00-4f26-11ea-96d5-61ccb2991909.png">
