### PR TITLE
Update bootstrap display utility classes for exhibit description …

### DIFF
--- a/app/views/spotlight/exhibits/_exhibit_card_back.html.erb
+++ b/app/views/spotlight/exhibits/_exhibit_card_back.html.erb
@@ -11,8 +11,8 @@
     <p class="description">
       <%= truncated_description = exhibit.description.truncate(168, omission: '', separator: ' ') %>
       <% if exhibit.description.length > 168 %>
-        <%= content_tag(:span,"&hellip;".html_safe, class: "d-sm-block d-md-block") %>
-        <span class="d-sm-none d-md-none">
+        <%= content_tag(:span,"&hellip;".html_safe, class: "d-none d-sm-inline d-xl-none") %>
+        <span class="d-inline d-sm-none d-xl-inline">
           <%= exhibit.description.slice(truncated_description.length, exhibit.description.length) %>
         </span>
       <% end %>


### PR DESCRIPTION
…truncation.

This technically closes #2443 (I think) and is based on some work that I done looking into it (and gets in more in-line w/ the previous behavior I believe), but not sure if this work will ultimately be done away with for other home-page design considerations. 🤷‍♂️

<img width="487" alt="xs" src="https://user-images.githubusercontent.com/96776/74567940-c2e1fe00-4f2b-11ea-870a-009cd2bb0536.png">
<img width="498" alt="sm" src="https://user-images.githubusercontent.com/96776/74568817-b9599580-4f2d-11ea-99db-d9b6e35cc452.png">
<img width="464" alt="md" src="https://user-images.githubusercontent.com/96776/74567945-c5dcee80-4f2b-11ea-9558-a2c1d8dedea8.png">
<img width="556" alt="lg" src="https://user-images.githubusercontent.com/96776/74567946-c6758500-4f2b-11ea-8bd0-8d2aee662b07.png">
<img width="537" alt="xl" src="https://user-images.githubusercontent.com/96776/74567947-c6758500-4f2b-11ea-98ce-c7d16fce6911.png">
