### PR TITLE
Use a more  targeted opacity override; part of #2427

### DIFF
--- a/app/assets/stylesheets/spotlight/_bootstrap_overrides.scss
+++ b/app/assets/stylesheets/spotlight/_bootstrap_overrides.scss
@@ -103,7 +103,3 @@ div.form-check + input[type="file"] {
     padding-left: 0;
   }
 }
-
-.carousel-block .carousel-indicators li {
-  opacity: 1;
-}

--- a/app/assets/stylesheets/spotlight/_slideshow_block.scss
+++ b/app/assets/stylesheets/spotlight/_slideshow_block.scss
@@ -70,6 +70,7 @@
       margin: 0;
       border: none;
       border-radius: 0;
+      opacity: 1;
 
       @extend .list-group-item;
     }


### PR DESCRIPTION
The current override also hits the actual carousel block, e.g.:

<img width="411" alt="Screen Shot 2020-02-14 at 13 33 21" src="https://user-images.githubusercontent.com/111218/74569164-9380c080-4f2e-11ea-97bc-4ea3063b41d2.png">
