### PR TITLE
Constrain the uppercase text-transform to the nav in the navbar for …

### DIFF
--- a/app/assets/stylesheets/spotlight/_header.scss
+++ b/app/assets/stylesheets/spotlight/_header.scss
@@ -82,9 +82,13 @@
   .navbar {
     @extend .navbar-dark;
     background-color: $navbar-transparent-page-bg;
-    text-transform: uppercase;
-    .dropdown-menu {
-      text-transform: none;
+
+    .navbar-nav {
+      text-transform: uppercase;
+
+      .dropdown-menu {
+        text-transform: none;
+      }
     }
   }
 


### PR DESCRIPTION
…mastheads w/ images

This allows the Exhibit title in the navbar to retain its case

Closes sul-dlss/exhibits#1680

## Before
<img width="854" alt="navbar-before" src="https://user-images.githubusercontent.com/96776/74575849-68519d80-4f3d-11ea-8287-4917a9aaf0e4.png">

## After
<img width="902" alt="navbar-after" src="https://user-images.githubusercontent.com/96776/74575856-6be52480-4f3d-11ea-8ca0-5c7ca9c02bb1.png">
