### PR TITLE
Remove superfluous col-md-12 divs when viewing a browse category.

### DIFF
--- a/app/views/spotlight/browse/show.html.erb
+++ b/app/views/spotlight/browse/show.html.erb
@@ -1,30 +1,27 @@
 <% set_html_page_title @search.title %>
 <% render partial: 'tophat' %>
-<div class="col-md-12">
-  <%= exhibit_edit_link @search, class: 'edit-button float-right btn btn-primary' if can? :edit, @search %>
-  <% if resource_masthead? %>
-    <% content_for :masthead do %>
-      <%= render 'search_title', search: @search %>
-    <% end %>
-  <% else %>
-    <h1><%= render 'search_title', search: @search %></h1>
-  <% end %>
-  <% if @search.long_description.present? %>
-    <div class="long-description-text <%= 'very-long-description-text' if @search.long_description.length > 600 %>">
-      <%= render_markdown @search.long_description %>
-    </div>
-  <% end %>
-</div>
 
-<div class="col-md-12">
-  <%= render 'sort_and_per_page' %>
-  <% if @search.search_box? %>
-    <%= render partial: 'search_box', locals: {search: @search} %>
+<%= exhibit_edit_link @search, class: 'edit-button float-right btn btn-primary' if can? :edit, @search %>
+<% if resource_masthead? %>
+  <% content_for :masthead do %>
+    <%= render 'search_title', search: @search %>
   <% end %>
-  <% if @search.default_index_view_type && params[:view].blank? %>
-    <%= render_document_index_with_view(@search.default_index_view_type, @document_list) %>
-  <% else %>
-    <%= render_document_index(@document_list) %>
-  <% end %>
-  <%= render 'results_pagination' %>
-</div>
+<% else %>
+  <h1><%= render 'search_title', search: @search %></h1>
+<% end %>
+<% if @search.long_description.present? %>
+  <div class="long-description-text <%= 'very-long-description-text' if @search.long_description.length > 600 %>">
+    <%= render_markdown @search.long_description %>
+  </div>
+<% end %>
+
+<%= render 'sort_and_per_page' %>
+<% if @search.search_box? %>
+  <%= render partial: 'search_box', locals: {search: @search} %>
+<% end %>
+<% if @search.default_index_view_type && params[:view].blank? %>
+  <%= render_document_index_with_view(@search.default_index_view_type, @document_list) %>
+<% else %>
+  <%= render_document_index(@document_list) %>
+<% end %>
+<%= render 'results_pagination' %>


### PR DESCRIPTION
Closes sul-dlss/exhibits#1677

## Before
<img width="865" alt="browse-before" src="https://user-images.githubusercontent.com/96776/74577039-44448b00-4f42-11ea-8004-a8937b70118e.png">


## After
<img width="875" alt="browse-after" src="https://user-images.githubusercontent.com/96776/74577043-46a6e500-4f42-11ea-929b-0a4fb8ca7386.png">

