### PR TITLE
Update the breakpoint sizes that the browse categories …

### DIFF
--- a/app/assets/stylesheets/spotlight/_featured_browse_categories_block.scss
+++ b/app/assets/stylesheets/spotlight/_featured_browse_categories_block.scss
@@ -70,11 +70,11 @@ $aspect-ratio-factor-medium-image: 1; // 1:1 width: height
         width: $no-sidebar-tablet-large-image-width;
         height: $no-sidebar-tablet-large-image-width * $aspect-ratio-factor-large-image;
       }
-      @media (min-width: breakpoint-min("md")) and (max-width: breakpoint-max("lg")) {
+      @media (min-width: breakpoint-min("md")) and (min-width: breakpoint-min("lg")) {
         width: $no-sidebar-desktop-large-image-width;
         height: $no-sidebar-desktop-large-image-width * $aspect-ratio-factor-large-image;
       }
-      @media (min-width: breakpoint-min("lg")) {
+      @media (min-width: breakpoint-min("xl")) {
         width: $no-sidebar-large-desktop-large-image-width;
         height: $no-sidebar-large-desktop-large-image-width * $aspect-ratio-factor-large-image;
       }


### PR DESCRIPTION
…(and other similar) widgets use to determine width.

Closes sul-dlss/exhibits#1686

## Before
![browse-widget-responsive-before](https://user-images.githubusercontent.com/96776/74579929-8aeeb100-4f53-11ea-9c40-365d2f277b76.gif)

## After
![browse-widget-responsive-after](https://user-images.githubusercontent.com/96776/74579933-9510af80-4f53-11ea-8aa0-58741283657c.gif)
