### PR TITLE
Tighten up spacing overrides we have on the about page sidebar elements.

### DIFF
--- a/app/assets/stylesheets/spotlight/_pages.scss
+++ b/app/assets/stylesheets/spotlight/_pages.scss
@@ -64,8 +64,8 @@
 
   ol.contacts {
     li {
-      margin-bottom: 2 * $spacer;
-      margin-top: $spacer * 0.5;
+      margin-bottom: $spacer * .5;
+      margin-top: $spacer * .5;
       word-break: break-word;
       .name {
         font-weight: bold;
@@ -76,7 +76,7 @@
   ol.sidenav {
     li {
       color: $gray-900;
-      margin-top: $spacer;
+      margin-top: $spacer * .25;
     }
 
     ol.subsection {


### PR DESCRIPTION
Connected to sul-dlss/exhibits#1653 


## Before
<img width="441" alt="about-before" src="https://user-images.githubusercontent.com/96776/74761969-d04ffe80-5231-11ea-824a-25a08219a902.png">

## After
<img width="369" alt="about-after" src="https://user-images.githubusercontent.com/96776/74761971-d0e89500-5231-11ea-9480-bd0e8da935b4.png">
