### PR TITLE
Update exhibit card detail to use flexbox

### DIFF
--- a/app/assets/stylesheets/spotlight/_exhibits_index.scss
+++ b/app/assets/stylesheets/spotlight/_exhibits_index.scss
@@ -5,6 +5,7 @@ $exhibit-card-max-height: 255px !default;
 
 .exhibit-card {
   background: $exhibit-card-bg;
+  overflow-y: hidden;
   padding-bottom: 3rem;
 
   .unpublished {
@@ -16,6 +17,10 @@ $exhibit-card-max-height: 255px !default;
     left: 0;
     right: 0;
     width: 15ch;
+  }
+
+  .card-title {
+    flex: 1;
   }
 
   .card-title .stretched-link {
@@ -32,11 +37,16 @@ $exhibit-card-max-height: 255px !default;
     background: rgba($exhibit-card-bg, $exhibit-card-overlay-opacity);
     border-bottom-left-radius: calc(0.25rem - 1px);
     border-bottom-right-radius: calc(0.25rem - 1px);
+    display: flex;
+    flex-direction: column;
     padding: $exhibit-card-overlay-padding;
     top: inherit;
+    max-height: 100%;
   }
 
   .exhibit-description {
+    display: flex;
+    flex-direction: column;
     max-height: 0;
     outline: none;
     overflow-y: hidden;
@@ -48,7 +58,11 @@ $exhibit-card-max-height: 255px !default;
   }
 
   .description {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
     font-size: $font-size-sm;
+    overflow-y: hidden;
   }
 
   &:hover {


### PR DESCRIPTION
Pointing  at exhibits:

<img width="346" alt="Screen Shot 2020-02-21 at 07 55 09" src="https://user-images.githubusercontent.com/111218/75069982-32656980-54a7-11ea-933e-8f55bf82d146.png">

This isn't a major functional change, but it makes some of the margins and paddings make a little more logical sense.