### PR TITLE
Use line-clamp to truncate exhibit card content

### DIFF
--- a/app/assets/stylesheets/spotlight/_exhibits_index.scss
+++ b/app/assets/stylesheets/spotlight/_exhibits_index.scss
@@ -1,7 +1,6 @@
 $exhibit-card-overlay-padding: $card-img-overlay-padding / 2 !default;
 $exhibit-card-overlay-opacity: 0.85 !default;
 $exhibit-card-bg: $card-bg !default;
-$exhibit-card-max-height: 255px !default;
 
 .exhibit-card {
   background: $exhibit-card-bg;
@@ -20,7 +19,10 @@ $exhibit-card-max-height: 255px !default;
   }
 
   .card-title {
-    flex: 1;
+    -webkit-box-orient: vertical;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    overflow: hidden;
   }
 
   .card-title .stretched-link {
@@ -54,20 +56,24 @@ $exhibit-card-max-height: 255px !default;
   }
 
   .subtitle {
+    -webkit-box-orient: vertical;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    overflow: hidden;
     text-align: center;
   }
 
   .description {
-    display: flex;
-    flex: 1;
-    flex-direction: column;
+    -webkit-box-orient: vertical;
+    display: -webkit-box;
     font-size: $font-size-sm;
-    overflow-y: hidden;
+    -webkit-line-clamp: 15;
+    overflow: hidden;
   }
 
   &:hover {
     .exhibit-description {
-      max-height: $exhibit-card-max-height;
+      max-height: 450px;
     }
   }
 
@@ -75,7 +81,61 @@ $exhibit-card-max-height: 255px !default;
     outline: auto;
 
     .exhibit-description {
-      max-height: $exhibit-card-max-height;
+      max-height: 450px;
+    }
+  }
+
+  @media (min-width: breakpoint-min("sm")) and (max-width: breakpoint-max("sm")) {
+    &:hover {
+      .exhibit-description {
+        max-height: 215px;
+      }
+    }
+
+    &:focus-within {
+      .exhibit-description {
+        max-height: 215px;
+      }
+    }
+
+    .description {
+      -webkit-line-clamp: 5;
+    }
+
+    .subtitle {
+      -webkit-line-clamp: 2;
+    }
+  }
+
+  @media (min-width: breakpoint-min("md")) and (max-width: breakpoint-max("lg")) {
+    .description {
+      -webkit-line-clamp: 4;
+    }
+
+    .subtitle {
+      -webkit-line-clamp: 2;
+    }
+  }
+
+  @media (min-width: breakpoint-max("lg")) {
+    &:hover {
+      .exhibit-description {
+        max-height: 230px;
+      }
+    }
+
+    &:focus-within {
+      .exhibit-description {
+        max-height: 230px;
+      }
+    }
+
+    .description {
+      -webkit-line-clamp: 6;
+    }
+
+    .subtitle {
+      -webkit-line-clamp: 2;
     }
   }
 }

--- a/app/views/spotlight/exhibits/_exhibit_card.html.erb
+++ b/app/views/spotlight/exhibits/_exhibit_card.html.erb
@@ -13,24 +13,24 @@
       <% end %>
 
       <%= content_tag :h2, class: 'card-title h5 text-center', aria: { describedby: "exhibit-description-#{exhibit.to_param}" } do %>
-        <%= link_to exhibit.title, exhibit, class: 'stretched-link' %>
+        <%= link_to exhibit, class: 'stretched-link' do %>
+          <span><%= exhibit.title %></span>
+        <% end %>
       <% end %>
 
-      <%= content_tag :div, id: "exhibit-description-#{exhibit.to_param}", class: 'card-text exhibit-description' do %>
-        <p class="subtitle">
-          <%= exhibit.subtitle %>
-        </p>
+      <% if exhibit.subtitle || exhibit.description  %>
+        <%= content_tag :div, id: "exhibit-description-#{exhibit.to_param}", class: 'card-text exhibit-description' do %>
+          <% if exhibit.subtitle %>
+            <p class="subtitle">
+              <%= exhibit.subtitle %>
+            </p>
+          <% end %>
 
-        <% if exhibit.description %>
-          <p class="description">
-            <%= truncated_description = exhibit.description.truncate(168, omission: '', separator: ' ') %>
-            <% if exhibit.description.length > 168 %>
-              <%= content_tag(:span,"&hellip;".html_safe, class: "d-none d-sm-inline d-xl-none") %>
-              <span class="d-inline d-sm-none d-xl-inline">
-                <%= exhibit.description.slice(truncated_description.length, exhibit.description.length) %>
-              </span>
-            <% end %>
-          </p>
+          <% if exhibit.description %>
+            <p class="description">
+              <%= exhibit.description %>
+            </p>
+          <% end %>
         <% end %>
       <% end %>
     </div>


### PR DESCRIPTION
(and update subtitle + description heights accordingly)

|         | XS | SM | MD | LG | XL |
|-----|----|-----|----|----|----|
| Title |  3  |  3    |  3   |  3  |  3  |
| Subtitle |  3  |  2    |  2   |  2  |  2  |
| Description |  15  |  5    |  4   |  4  |  6  |
| **Total** |  **21**  | **10**    |  **9**   | **9**  |  **11**  |

## Before
![responsive-truncate-before](https://user-images.githubusercontent.com/96776/75294607-bbe5a600-57dd-11ea-8c0f-c1181bf8166c.gif)

## After
![responsive-truncate-after](https://user-images.githubusercontent.com/96776/75294626-c738d180-57dd-11ea-842d-20a37be035b3.gif)

