### PR TITLE
Revise exhibit card focus styles

### DIFF
--- a/app/assets/stylesheets/spotlight/_exhibits_index.scss
+++ b/app/assets/stylesheets/spotlight/_exhibits_index.scss
@@ -72,7 +72,13 @@ $exhibit-card-max-height: 255px !default;
   }
 
   &:focus-within {
-    outline: auto;
+    // Use Bootstrap focus style
+    outline: $input-focus-border-color auto 5px;
+
+    // Use WebKit focus styles if available
+    @supports (-webkit-appearance:none) {
+      outline-color: -webkit-focus-ring-color;
+    }
 
     .exhibit-description {
       max-height: $exhibit-card-max-height;


### PR DESCRIPTION
Part of sul-dlss/exhibits#1727
@jvine @ggeisler 

**There are two aims in this PR:**
- make focus styles for exhibit cards more consistent within the same browser (i.e. `outline:auto` is not used for `:focus` in WebKit browsers) 
- enhance native focus on exhibit cards where it is currently insufficient (i.e. Firefox) 

**How do we do this?** 
- unify styles where WebKit is available (i.e. Chrome, Safari) 
- default to Bootstrap focus styles where it's not available (i.e. Firefox)

**Out of scope:** 
- unifying focus styles across Spotlight (some work on this sul-dlss/exhibits#1745)

In the screenshots below I've artificially focused on both exhibit cards and tabs to contrast the exhibit card enhancements with the browser focus styles.

## Chrome
### Before (`outline:auto`)
![chrome focus doesn't match](https://user-images.githubusercontent.com/5402927/75299136-1fc19c00-57e9-11ea-8d8a-4268363cecb4.png)

### After (`-webkit-focus-ring-color`)
![chrome focus matches!](https://user-images.githubusercontent.com/5402927/75298900-8abea300-57e8-11ea-8e41-1e532bfba9f9.png)

## Safari (unchanged) 
![safari focused card](https://user-images.githubusercontent.com/5402927/75298898-8a260c80-57e8-11ea-8fc7-2402d880807a.png)
## Firefox
### Before (`outline:auto`)
![firefox focus doesn't match](https://user-images.githubusercontent.com/5402927/75299137-205a3280-57e9-11ea-9d75-bb7f0a81b4d8.png)

### After (Bootstrap focus color)
![firefox focus enhanced](https://user-images.githubusercontent.com/5402927/75298901-8abea300-57e8-11ea-9201-3bfbc7a73c33.png)