### PR TITLE
Ensure that breadcrumbs are available without show search session

### DIFF
--- a/app/controllers/spotlight/catalog_controller.rb
+++ b/app/controllers/spotlight/catalog_controller.rb
@@ -206,11 +206,11 @@ module Spotlight
 
     # rubocop:disable Metrics/AbcSize
     def add_document_breadcrumbs(document)
-      if current_browse_category
+      if current_page_context && current_page_context.title.present? && !current_page_context.is_a?(Spotlight::HomePage)
+        add_breadcrumb current_page_context.title, [current_page_context.exhibit, current_page_context]
+      elsif current_browse_category
         add_breadcrumb current_browse_category.exhibit.main_navigations.browse.label_or_default, exhibit_browse_index_path(current_browse_category.exhibit)
         add_breadcrumb current_browse_category.title, exhibit_browse_path(current_browse_category.exhibit, current_browse_category)
-      elsif current_page_context && current_page_context.title.present? && !current_page_context.is_a?(Spotlight::HomePage)
-        add_breadcrumb current_page_context.title, [current_page_context.exhibit, current_page_context]
       elsif current_search_session
         add_breadcrumb t(:'spotlight.catalog.breadcrumb.index'), search_action_url(current_search_session.query_params)
       end

--- a/app/controllers/spotlight/catalog_controller.rb
+++ b/app/controllers/spotlight/catalog_controller.rb
@@ -141,7 +141,7 @@ module Spotlight
     def setup_next_and_previous_documents
       if current_search_session_from_browse_category?
         setup_next_and_previous_documents_from_browse_category if current_browse_category
-      elsif current_search_session_from_page? || current_search_session_from_home_page?
+      elsif current_page_from_page?
         # TODO: figure out how to construct previous/next documents
       else
         super

--- a/spec/controllers/spotlight/catalog_controller_spec.rb
+++ b/spec/controllers/spotlight/catalog_controller_spec.rb
@@ -57,6 +57,17 @@ describe Spotlight::CatalogController, type: :controller do
         expect(response).to be_successful
       end
 
+      it 'shows the item with breadcrumbs to the feature page without a showpage search session' do
+        feature_page = FactoryBot.create(:feature_page, exhibit: exhibit)
+        allow(controller).to receive_messages(page_referrer: { action: 'show', controller: 'feature_pages', id: feature_page.id })
+
+        expect(controller).to receive(:add_breadcrumb).with('Home', exhibit_path(exhibit, q: ''))
+        expect(controller).to receive(:add_breadcrumb).with(feature_page.title, [exhibit, feature_page])
+        expect(controller).to receive(:add_breadcrumb).with('L&#39;AMERIQUE', exhibit_solr_document_path(exhibit, document))
+        get :show, params: { exhibit_id: exhibit, id: 'dq287tq6352' }
+        expect(response).to be_successful
+      end
+
       it 'shows the item with breadcrumbs from the home page' do
         home_page = FactoryBot.create(:home_page)
         allow(controller).to receive_messages(current_page_context: home_page)


### PR DESCRIPTION
I'm not sure if this is the correct way or not to handle this issue. But it seems previously for show actions, a search session was activated for that. But maybe that isn't happening anymore?

This is a work around, which aims to fix https://github.com/sul-dlss/exhibits/issues/1749 but might not be the correct way to do this. 

Is there somewhere we just are not creating search sessions for show page access anymore?

## Update 

This PR now does two things

1. Uses page referrers (or at least tries to) to determine where the heck we are linking from
1. Adds the page logic to preference the browse category logic since those search sessions can linger

## Update 2

Is this all not working because for some reason this isn't executing? 

https://github.com/projectblacklight/spotlight/blob/8eec0de68b8861c5847a4b3fb31a0a126e142bb7/app/controllers/spotlight/pages_controller.rb#L142-L146