### PR TITLE
Enhance visibility of Firefox focus indicator globally

### DIFF
--- a/app/assets/stylesheets/spotlight/_accessibility.scss
+++ b/app/assets/stylesheets/spotlight/_accessibility.scss
@@ -1,0 +1,8 @@
+// Global accessibility overrides
+
+// Increase visibility of Firefox focus indicator
+@-moz-document url-prefix() {
+  &:focus {
+    outline: $input-focus-border-color auto 5px;
+  }
+}

--- a/app/assets/stylesheets/spotlight/_spotlight.scss
+++ b/app/assets/stylesheets/spotlight/_spotlight.scss
@@ -31,6 +31,7 @@
 @import "spotlight/collapse_toggle";
 @import "spotlight/translations";
 @import "spotlight/utilities";
+@import "spotlight/accessibility";
 
 
 


### PR DESCRIPTION
This PR aims to unify the experience of focus styles within Firefox. We do this by overriding the default Firefox focus style so that it matches(ish) the Bootstrap focus style (see work on exhibit cards in #2491). @jvine and I paired on this so this just needs dev review. 

## Before: Firefox default, gray dotted lines
![firefox-default-focus](https://user-images.githubusercontent.com/5402927/75395586-91601f80-58a7-11ea-85c6-239c9306659c.gif)

## After: Bootstrap-esque, solid blue 5px border
![firefox-enhanced-focus](https://user-images.githubusercontent.com/5402927/75395591-93c27980-58a7-11ea-8064-1e9ddfe876f5.gif)