### PR TITLE
Add bottom margin to sidebar sections with child pages

### DIFF
--- a/app/assets/stylesheets/spotlight/_pages.scss
+++ b/app/assets/stylesheets/spotlight/_pages.scss
@@ -80,6 +80,7 @@
     }
 
     ol.subsection {
+      margin-bottom: $spacer;
       padding-left: 0;
       li {
         list-style: square;


### PR DESCRIPTION
The sidebar section of feature pages looks fine when there are no child pages, but when there are child pages, the parent feature page list item is too closely vertically to the previous child page list item:

<img width="657" alt="Screen Shot 2020-02-27 at 2 06 49 PM" src="https://user-images.githubusercontent.com/101482/75493813-fedb8100-5977-11ea-8a7e-dc9927947f15.png">

This PR adds some bottom margin to the nested child page list to fix that:

<img width="582" alt="Screen Shot 2020-02-27 at 3 42 22 PM" src="https://user-images.githubusercontent.com/101482/75493860-19155f00-5978-11ea-99cc-067d31eb6efc.png">

This only affects the feature page sidebar, since we don't have child pages elsewhere.

One minor negative ramification of this is I couldn't avoid adding the new bottom margin to the the parent list item when there are no child pages because of the way the sidebar is rendered (it outputs a `ol.subsection` even when there are no child pages to put in it). I'm going to file a separate ticket for that in case anyone wants to figure out how to omit that element when we don't need it. In the meantime it's not too big of a deal; the amount of bottom margin added is not too noticeable:

<img width="582" alt="Screen Shot 2020-02-27 at 3 41 52 PM" src="https://user-images.githubusercontent.com/101482/75494242-02233c80-5979-11ea-85b1-6b3a14b11cfb.png">
