### PR TITLE
Explicitly size the contact-photo image.

### DIFF
--- a/app/assets/stylesheets/spotlight/_pages.scss
+++ b/app/assets/stylesheets/spotlight/_pages.scss
@@ -98,9 +98,10 @@
 .contact-photo {
   border: 1px solid #ccc;
   border-radius: $border-radius;
+  height: 70px;
   margin-right: 15px;
   margin-top: 3px;
-  max-height: 70px;
+  width: 70px;
 }
 
 // Indent contact fields so they align evenly, only when there is a contact photo


### PR DESCRIPTION
Firefox's flex implementation appears to resize the image in odd ways otherwise

Closes sul-dlss/exhibits#1800

_Screenshots in Firefox_

## Before
<img width="242" alt="contact-before" src="https://user-images.githubusercontent.com/96776/75593152-3fe79a00-5a39-11ea-863a-34a9b6d7bcd8.png">

## After
<img width="254" alt="contact-after" src="https://user-images.githubusercontent.com/96776/75593156-4249f400-5a39-11ea-8af4-3a4535cd7bd7.png">
