### PR TITLE
Change site admin page headers and add breadcrumbs

### DIFF
--- a/app/controllers/spotlight/admin_users_controller.rb
+++ b/app/controllers/spotlight/admin_users_controller.rb
@@ -10,7 +10,10 @@ module Spotlight
 
     load_and_authorize_resource :site, class: 'Spotlight::Site'
 
-    def index; end
+    def index
+      add_breadcrumb t(:'spotlight.sites.home'), root_url
+      add_breadcrumb t(:'spotlight.admin_users.index.page_title')
+    end
 
     def create
       if update_roles

--- a/app/controllers/spotlight/exhibits_controller.rb
+++ b/app/controllers/spotlight/exhibits_controller.rb
@@ -22,6 +22,8 @@ module Spotlight
 
     def new
       build_initial_exhibit_contact_emails
+      add_breadcrumb t(:'spotlight.sites.home'), root_url
+      add_breadcrumb t(:'spotlight.exhibits.new.page_title')
     end
 
     def process_import

--- a/app/controllers/spotlight/sites_controller.rb
+++ b/app/controllers/spotlight/sites_controller.rb
@@ -8,9 +8,15 @@ module Spotlight
     before_action :load_site
     load_and_authorize_resource
 
-    def edit; end
+    def edit
+      add_breadcrumb t(:'spotlight.sites.home'), root_url
+      add_breadcrumb t(:'spotlight.sites.edit.page_title')
+    end
 
-    def edit_exhibits; end
+    def edit_exhibits
+      add_breadcrumb t(:'spotlight.sites.home'), root_url
+      add_breadcrumb t(:'spotlight.sites.edit_exhibits.page_title')
+    end
 
     def update
       if @site.update(site_params)

--- a/app/helpers/spotlight/title_helper.rb
+++ b/app/helpers/spotlight/title_helper.rb
@@ -13,8 +13,18 @@ module Spotlight
     end
 
     def page_title(section, title = nil)
-      set_html_page_title(t(:'spotlight.html_admin_title', section: section, title: title || t(:'.title', default: :'.header')))
-      content_tag(:h1, safe_join([section, content_tag(:small, title || t(:'.header'))], "\n"), class: 'page-header')
+      title ||= t(:'.header', default: '').presence
+
+      head_content = t(:'spotlight.html_admin_title', section: section, title: title) if section && title
+      head_content ||= section || title
+      set_html_page_title(head_content)
+
+      html_content = safe_join([
+        (section if section.present?),
+        (content_tag(:small, title) if title.present?)
+      ].compact, "\n")
+
+      content_tag(:h1, html_content, class: 'page-header')
     end
 
     # rubocop:disable Naming/AccessorMethodName

--- a/app/views/shared/_site_sidebar.html.erb
+++ b/app/views/shared/_site_sidebar.html.erb
@@ -14,6 +14,6 @@
 </ul>
 
 <ul class="nav sidenav nav-pills nav-stacked">
-  <li class="nav-item"><%= link_to t(:'spotlight.sites.new.page_title'), spotlight.new_exhibit_path, class: 'btn btn-outline-secondary btn-nav', role: 'button' if can? :create, Spotlight::Exhibit %></li>
+  <li class="nav-item"><%= link_to t(:'spotlight.exhibits.new.page_title'), spotlight.new_exhibit_path, class: 'btn btn-outline-secondary btn-nav', role: 'button' if can? :create, Spotlight::Exhibit %></li>
 </ul>
 <% end %>

--- a/app/views/spotlight/admin_users/index.html.erb
+++ b/app/views/spotlight/admin_users/index.html.erb
@@ -1,4 +1,4 @@
-<%= page_title(t('.section'), t('.page_title')) %>
+<%= page_title(t('.page_title')) %>
 <%= bootstrap_form_for Spotlight::Engine.user_class.new, html: { class: 'admin-users' }, url: spotlight.admin_users_path do |f| %>
   <div class="mb-4">
     <h3 class="instructions"><%= t :'.instructions' %></h3>

--- a/app/views/spotlight/exhibits/new.html.erb
+++ b/app/views/spotlight/exhibits/new.html.erb
@@ -1,4 +1,4 @@
-<%= page_title t(:'spotlight.sites.new.section') %>
+<%= page_title t(:'.page_title') %>
 <%= render 'new_exhibit_form' %>
 
 <% content_for(:sidebar_position) { 'order-last' } %>

--- a/app/views/spotlight/sites/edit.html.erb
+++ b/app/views/spotlight/sites/edit.html.erb
@@ -1,4 +1,4 @@
-<%= page_title(t('.section'), t('.page_title')) %>
+<%= page_title(t('.page_title')) %>
 <div role="tabpanel">
   <%= bootstrap_form_for @site, url: spotlight.site_path, layout: :horizontal, label_col: 'col-md-2', control_col: 'col-md-10' do |f| %>
     <ul class="nav nav-tabs" role="tablist">

--- a/app/views/spotlight/sites/edit_exhibits.html.erb
+++ b/app/views/spotlight/sites/edit_exhibits.html.erb
@@ -1,4 +1,4 @@
-<%= page_title(t('.section'), t('.page_title')) %>
+<%= page_title(t('.page_title')) %>
 <%= bootstrap_form_for @site, url: spotlight.site_path, layout: :horizontal, label_col: 'col-md-2', control_col: 'col-md-10' do |f| %>
   <p class="instructions"><%= t :'.instructions' %></p>
   <table class="table table-striped dd-table">

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -187,7 +187,6 @@ en:
         page_title: Manage users
         pending: pending
         save: Add role
-        section: Manage exhibits
         update: Make user an administrator
     appearances:
       edit:
@@ -423,7 +422,7 @@ en:
           language: Language
           public: Public
       new:
-        header: Create a new exhibit
+        page_title: Create a new exhibit
       new_exhibit_form:
         fields:
           slug:
@@ -787,7 +786,6 @@ en:
         basic_settings:
           heading: Title
         page_title: Customize appearance
-        section: Manage exhibits
         site_masthead:
           heading: Site masthead
           help: |
@@ -796,13 +794,10 @@ en:
       edit_exhibits:
         instructions: Drag and drop the exhibits below to specify the order in which they are displayed on the exhibits homepage.
         page_title: Order exhibits
-        section: Manage exhibits
       exhibit:
         published: Published
         unpublished: Unpublished
-      new:
-        page_title: Create a new exhibit
-        section: Manage exhibits
+      home: Exhibits
     tags:
       index:
         actions: Actions

--- a/spec/features/create_exhibit_spec.rb
+++ b/spec/features/create_exhibit_spec.rb
@@ -13,8 +13,7 @@ describe 'Create a new exhibit', type: :feature do
     within '.dropdown-menu' do
       click_link 'Create new exhibit'
     end
-    expect(page).to have_selector 'h1', text: 'Manage exhibits'
-    expect(page).to have_selector 'h1 small', text: 'Create a new exhibit'
+    expect(page).to have_selector 'h1', text: 'Create a new exhibit'
   end
 
   it 'allows admins to create a new exhibit' do

--- a/spec/helpers/spotlight/title_helper_spec.rb
+++ b/spec/helpers/spotlight/title_helper_spec.rb
@@ -17,6 +17,19 @@ describe Spotlight::TitleHelper, type: :helper do
       expect(title).to have_selector 'h1', text: 'Section'
       expect(title).to have_selector 'h1 small', text: 'Title'
     end
+
+    it 'renders just the section title if that was all that was provided' do
+      allow(helper).to receive(:t).and_call_original
+      allow(helper).to receive(:t).with(:'.header', default: '').and_return('')
+
+      title = helper.page_title('Section')
+
+      expect(title).to have_selector 'h1', text: 'Section'
+      expect(title).not_to have_selector 'h1 small'
+
+      title = helper.instance_variable_get(:@page_title)
+      expect(title).to eq 'Section | Application'
+    end
   end
 
   describe '#set_html_page_title' do


### PR DESCRIPTION
Fixes https://github.com/sul-dlss/exhibits/issues/1584

<img width="380" alt="Screen Shot 2020-03-04 at 07 27 54" src="https://user-images.githubusercontent.com/111218/75894835-abd75300-5de9-11ea-9a05-ce75d052271f.png">
<img width="366" alt="Screen Shot 2020-03-04 at 07 28 00" src="https://user-images.githubusercontent.com/111218/75894839-b0037080-5de9-11ea-9f93-ad9b13dfbf4e.png">
<img width="374" alt="Screen Shot 2020-03-04 at 07 28 06" src="https://user-images.githubusercontent.com/111218/75894854-b396f780-5de9-11ea-81ea-5bdc7897c9e6.png">
<img width="412" alt="Screen Shot 2020-03-04 at 07 32 51" src="https://user-images.githubusercontent.com/111218/75895347-5d768400-5dea-11ea-891a-936e13a5560d.png">

