### PR TITLE
Wrap browse category titles in a span

### DIFF
--- a/app/views/spotlight/browse/_search.html.erb
+++ b/app/views/spotlight/browse/_search.html.erb
@@ -5,8 +5,8 @@
         <%= image_tag(search.thumbnail_image_url || 'spotlight/default_browse_thumbnail.jpg', class: 'img-responsive', alt: '') %>
         <div class="text-overlay">
            <h2 class="browse-category-title">
-             <%= search.title%>
-             <small><%= t :'spotlight.browse.search.item_count', count: search.count %></small>
+             <span class="title"><%= search.title%></span>
+             <small class="item-count"><%= t :'spotlight.browse.search.item_count', count: search.count %></small>
            </h2>
          </div>
       </div>

--- a/app/views/spotlight/browse/_search_title.html.erb
+++ b/app/views/spotlight/browse/_search_title.html.erb
@@ -1,2 +1,2 @@
-<%= search.title %>
+<span class="title"><%= search.title %></span>
 <small class="item-count"><%= t :'spotlight.browse.search.item_count', count: params[:browse_q] ? parent_search_count: search.count %></small>


### PR DESCRIPTION
This allows downstream applications to make more targeted overrides (like e.g. https://github.com/sul-dlss/dlme/issues/834)