### PR TITLE
YML import/export for Curator UI translations

### DIFF
--- a/app/views/spotlight/translations/_browse_categories.html.erb
+++ b/app/views/spotlight/translations/_browse_categories.html.erb
@@ -6,12 +6,12 @@
     <div class="row">
       <div class="col-4 text-right">
         <span class="browse-translations-header">
-          <%= t :'spotlight.exhibits.translations.browse_categories.default_language_column_label' %>
+          <%= t :'.default_language_column_label' %>
         </span>
       </div>
       <div class="col-7">
         <span class="browse-translations-header">
-          <%= t :'spotlight.exhibits.translations.browse_categories.translation_column_label', language: t("locales.#{@language}")  %>
+          <%= t :'.translation_column_label', language: t("locales.#{@language}")  %>
         </span>
       </div>
     </div>
@@ -60,7 +60,7 @@
         <div class="col-7 offset-4">
           <%= f.fields_for :translations, description_translation do |translation_fields| %>
             <%= button_tag 'type' => 'button', class: 'btn btn-text collapse-toggle collapsed translation-description-toggle', 'data-toggle': 'collapse', 'data-target': "#browse_category_description_#{search.id}", 'aria-expanded': 'false', 'aria-controls': "#browse_category_description_#{search.id}" do %>
-              <%= translation_fields.label :value, t(:'spotlight.exhibits.translations.browse_categories.description_label') %>
+              <%= translation_fields.label :value, t(:'.description_label') %>
             <% end %>
             <span class="collapse-chevron">❯</span>
 

--- a/app/views/spotlight/translations/_general.html.erb
+++ b/app/views/spotlight/translations/_general.html.erb
@@ -5,7 +5,7 @@
 
     <div class='translation-basic-settings'>
       <h2 class='translation-subheading'>
-        <%= t('spotlight.exhibits.translations.general.basic_settings.label') %>
+        <%= t('.basic_settings.label') %>
       </h2>
 
       <% translation = Translation.find_or_initialize_by(exhibit: current_exhibit, key: "#{current_exhibit.slug}.title", locale: @language) %>
@@ -13,7 +13,7 @@
         <%= translation_fields.hidden_field :key %>
         <%= translation_fields.hidden_field :locale %>
         <div data-translation-progress-item='true' class='row form-group translation-form translation-basic-settings-title'>
-          <%= translation_fields.label :value, t('spotlight.exhibits.translations.general.basic_settings.title'), class: 'col-form-label col-12 col-sm-2' %>
+          <%= translation_fields.label :value, t('.basic_settings.title'), class: 'col-form-label col-12 col-sm-2' %>
           <div class='col-11 col-sm-9 card card-body panel-translation'>
             <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
             <small class="form-text text-muted">
@@ -34,7 +34,7 @@
         <%= translation_fields.hidden_field :key %>
         <%= translation_fields.hidden_field :locale %>
         <div data-translation-progress-item='true' class='row form-group translation-form translation-basic-settings-subtitle'>
-          <%= translation_fields.label :value, t('spotlight.exhibits.translations.general.basic_settings.subtitle'), class: 'col-form-label col-12 col-sm-2' %>
+          <%= translation_fields.label :value, t('.basic_settings.subtitle'), class: 'col-form-label col-12 col-sm-2' %>
           <div class='col-11 col-sm-9 card card-body panel-translation'>
             <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
             <small class="form-text text-muted">
@@ -55,7 +55,7 @@
         <%= translation_fields.hidden_field :key %>
         <%= translation_fields.hidden_field :locale %>
         <div data-translation-progress-item='true' class='row form-group translation-form translation-basic-settings-description'>
-          <%= translation_fields.label :value, t('spotlight.exhibits.translations.general.basic_settings.description'), class: 'col-form-label col-12 col-sm-2' %>
+          <%= translation_fields.label :value, t('.basic_settings.description'), class: 'col-form-label col-12 col-sm-2' %>
           <div class='col-11 col-sm-9 card card-body panel-translation'>
             <%= translation_fields.text_area_without_bootstrap :value, class: 'form-control' %>
             <small class="form-text text-muted">
@@ -74,7 +74,7 @@
     </div>
     <div class='translation-main-menu'>
       <h2 class='translation-subheading'>
-        <%= t('spotlight.exhibits.translations.general.main_menu.label') %>
+        <%= t('.main_menu.label') %>
       </h2>
 
       <% translation = Translation.find_or_initialize_by(exhibit: current_exhibit, key: "spotlight.curation.nav.home", locale: @language) %>
@@ -82,7 +82,7 @@
         <%= translation_fields.hidden_field :key %>
         <%= translation_fields.hidden_field :locale %>
         <div data-translation-progress-item='true' class='row form-group translation-form translation-main-menu-home'>
-          <%= translation_fields.label :value, t('spotlight.exhibits.translations.general.main_menu.home'), class: 'col-form-label col-12 col-sm-2' %>
+          <%= translation_fields.label :value, t('.main_menu.home'), class: 'col-form-label col-12 col-sm-2' %>
           <div class='col-11 col-sm-9 card card-body panel-translation'>
             <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
             <small class="form-text text-muted">
@@ -105,7 +105,7 @@
           <%= translation_fields.hidden_field :key %>
           <%= translation_fields.hidden_field :locale %>
           <div data-translation-progress-item='true' class='row form-group translation-form translation-main-menu-<%= navigation.nav_type %>'>
-            <%= translation_fields.label :value, t("spotlight.exhibits.translations.general.main_menu.#{navigation.nav_type}", default: navigation.default_label), class: 'col-form-label col-12 col-sm-2' %>
+            <%= translation_fields.label :value, t(".main_menu.#{navigation.nav_type}", default: navigation.default_label), class: 'col-form-label col-12 col-sm-2' %>
             <div class='col-11 col-sm-9 card card-body panel-translation'>
               <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
               <small class="form-text text-muted">

--- a/app/views/spotlight/translations/_import.html.erb
+++ b/app/views/spotlight/translations/_import.html.erb
@@ -1,0 +1,23 @@
+<% if can? :import_translations, Spotlight::Exhibit %>
+  <div class="row col-md-12 mb-4">
+    <h2><%= t(:'.header') %></h2>
+    <p class="instructions"><%= t(:'.description') %></p>
+
+    <%= bootstrap_form_for current_exhibit, url: spotlight.import_exhibit_translations_path(current_exhibit), html: { class: 'row col-md-12 clearfix mb-3', multipart: true } do |f| %>
+      <%= f.label :value, t(".import_label"), class: 'col-form-label col-12 col-sm-3 text-right' %>
+
+      <div class="input-group col px-0">
+        <%= file_field_tag :file, class: 'form-control' %>
+        <%= hidden_field_tag :tab, 'import' %>
+        <div class="input-group-append">
+          <%= f.submit t(:'.import_submit'), class: 'btn btn-primary' %>
+        </div>
+      </div>
+    <% end %>
+    <div class="row col-md-12">
+      <%= content_tag :span, t(".export_label"), class: 'col-form-label col-12 col-sm-3 text-right' %>
+
+      <%= link_to t(:'.export_submit'), spotlight.exhibit_translations_path(current_exhibit, format: "yaml"), class: 'btn btn-primary' %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/spotlight/translations/_metadata.html.erb
+++ b/app/views/spotlight/translations/_metadata.html.erb
@@ -32,7 +32,7 @@
     <% if current_exhibit.custom_fields.any? %>
       <div class='translation-exhibit-specific-fields'>
         <h2 class='translation-subheading'>
-          <%= t('spotlight.exhibits.translations.metadata.exhibit_specific_fields.label') %>
+          <%= t('.exhibit_specific_fields.label') %>
         </h2>
 
         <% current_exhibit.custom_fields.each do |custom_field| %>

--- a/app/views/spotlight/translations/_page.html.erb
+++ b/app/views/spotlight/translations/_page.html.erb
@@ -22,8 +22,8 @@
       </p>
     <% else %>
       <span class="new-translated-page">
-        <%= t('spotlight.exhibits.translations.pages.no_translated_page') %>
-        <%= link_to(t('spotlight.exhibits.translations.pages.new'), polymorphic_path([:clone, current_exhibit, page], language: @language)) %>
+        <%= t('.no_translated_page') %>
+        <%= link_to(t('.new'), polymorphic_path([:clone, current_exhibit, page], language: @language)) %>
       <span>
     <% end %>
   </td>
@@ -36,11 +36,11 @@
   </td>
   <td class="text-center">
     <% if translated_page %>
-      <%= link_to(t('spotlight.exhibits.translations.pages.edit'), polymorphic_path([:edit, current_exhibit, translated_page], locale: @language)) %> &middot;
-      <%= link_to(t('spotlight.exhibits.translations.pages.recreate'), polymorphic_path([:clone, current_exhibit, page], language: @language), data: { confirm: t('spotlight.exhibits.translations.pages.recreate_are_you_sure') }) %>
+      <%= link_to(t('.edit'), polymorphic_path([:edit, current_exhibit, translated_page], locale: @language)) %> &middot;
+      <%= link_to(t('.recreate'), polymorphic_path([:clone, current_exhibit, page], language: @language), data: { confirm: t('.recreate_are_you_sure') }) %>
       <% if page.feature_page? || page.about_page? %>
         &middot;
-        <%= link_to(t('spotlight.exhibits.translations.pages.destroy'), polymorphic_path([current_exhibit, translated_page], locale: @language), method: :delete, data: { confirm: t('spotlight.exhibits.translations.pages.destroy_are_you_sure') }) %>
+        <%= link_to(t('.destroy'), polymorphic_path([current_exhibit, translated_page], locale: @language), method: :delete, data: { confirm: t('.destroy_are_you_sure') }) %>
       <% end %>
     <% end %>
   </td>

--- a/app/views/spotlight/translations/_pages.html.erb
+++ b/app/views/spotlight/translations/_pages.html.erb
@@ -1,10 +1,10 @@
 <div role="tabpanel" class="tab-pane <%= 'active' if @tab == 'pages' %>" id="pages">
-  <p class="instructions"><%= t('spotlight.exhibits.translations.pages.help_html') %></p>
+  <p class="instructions"><%= t('.help_html') %></p>
 
   <%= bootstrap_form_for @exhibit, url: polymorphic_path([:update_all, @exhibit, :pages]), layout: :horizontal, control_col: 'col-sm-10', html: {:'data-form-observer' => true} do |f| %>
     <div class="translation-home-page-settings">
       <h2 class="translation-subheading">
-        <%= t('spotlight.exhibits.translations.pages.home_page.label') %>
+        <%= t('.home_page.label') %>
       </h2>
       <%= render 'pages_table', pages: [current_exhibit.home_page], f: f %>
     </div>
@@ -12,7 +12,7 @@
     <% if current_exhibit.feature_pages.any? %>
       <div class="translation-feature-page-settings">
         <h2 class="translation-subheading">
-          <%= t('spotlight.exhibits.translations.pages.feature_pages.label') %>
+          <%= t('.feature_pages.label') %>
         </h2>
 
         <%= render 'pages_table', pages: current_exhibit.feature_pages.for_default_locale, f: f %>
@@ -22,7 +22,7 @@
     <% if current_exhibit.about_pages.any? %>
       <div class="translation-about-page-settings">
         <h2 class="translation-subheading">
-          <%= t('spotlight.exhibits.translations.pages.about_pages.label') %>
+          <%= t('.about_pages.label') %>
         </h2>
 
         <%= render 'pages_table', pages: current_exhibit.about_pages.for_default_locale, f: f %>

--- a/app/views/spotlight/translations/_pages_table.html.erb
+++ b/app/views/spotlight/translations/_pages_table.html.erb
@@ -1,11 +1,11 @@
 <table class="table table-striped">
   <thead>
     <tr>
-      <th><%= t('spotlight.exhibits.translations.pages.table_header.last_updated', language: t(:"locales.#{I18n.default_locale}")) %></th>
-      <th class="text-center"><%= t('spotlight.exhibits.translations.pages.table_header.default_published') %></th>
-      <th><%= t('spotlight.exhibits.translations.pages.table_header.last_updated', language: t(:"locales.#{@language}")) %></th>
-      <th class='text-center'><%= t('spotlight.exhibits.translations.pages.table_header.language_published') %></th>
-      <th class='text-center'><%= t('spotlight.exhibits.translations.pages.table_header.actions') %></th>
+      <th><%= t('.header.last_updated', language: t(:"locales.#{I18n.default_locale}")) %></th>
+      <th class="text-center"><%= t('.header.default_published') %></th>
+      <th><%= t('.header.last_updated', language: t(:"locales.#{@language}")) %></th>
+      <th class='text-center'><%= t('.header.language_published') %></th>
+      <th class='text-center'><%= t('.header.actions') %></th>
     </tr>
   </thead>
 

--- a/app/views/spotlight/translations/_search_fields.html.erb
+++ b/app/views/spotlight/translations/_search_fields.html.erb
@@ -6,7 +6,7 @@
 
     <div class='translation-field-based-search-fields'>
       <h2 class='translation-subheading'>
-        <%= t('spotlight.exhibits.translations.search_fields.field_based_search_fields.label') %>
+        <%= t('.field_based_search_fields.label') %>
       </h2>
 
       <% current_exhibit.blacklight_config.search_fields.select { |_, config| config.if }.each do |key, search_config| %>
@@ -36,7 +36,7 @@
 
     <div class='translation-facet-fields'>
       <h2 class='translation-subheading'>
-        <%= t('spotlight.exhibits.translations.search_fields.facet_fields.label') %>
+        <%= t('.facet_fields.label') %>
       </h2>
 
       <% current_exhibit.blacklight_config.facet_fields.each do |key, facet_config| %>
@@ -66,7 +66,7 @@
 
     <div class='translation-sort-fields'>
       <h2 class='translation-subheading'>
-        <%= t('spotlight.exhibits.translations.search_fields.sort_fields.label') %>
+        <%= t('.sort_fields.label') %>
       </h2>
 
       <% current_exhibit.blacklight_config.sort_fields.each do |key, sort_config| %>

--- a/app/views/spotlight/translations/edit.html.erb
+++ b/app/views/spotlight/translations/edit.html.erb
@@ -17,6 +17,8 @@
     </ul>
   </div>
 
+  <%= render partial: 'import' %>
+
   <div role="tabpanel">
     <ul class='nav nav-tabs' role="tablist">
       <li role="presentation" class="nav-item">

--- a/app/views/spotlight/translations/edit.html.erb
+++ b/app/views/spotlight/translations/edit.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <div class='translation-edit-form'>
-  <%= curation_page_title t('spotlight.exhibits.translations.title') %>
+  <%= curation_page_title t('.title') %>
 
   <div class='text-center'>
     <ul class='nav nav-pills'>
@@ -21,27 +21,27 @@
     <ul class='nav nav-tabs' role="tablist">
       <li role="presentation" class="nav-item">
         <a href='#general' class="nav-link <%= 'active' if @tab.blank? %>" aria-controls="general" role="tab" data-toggle="tab" data-behavior="translation-progress">
-          <%= t('spotlight.exhibits.translations.general.label') %> <span class="badge"></span>
+          <%= t('spotlight.translations.general.label') %> <span class="badge"></span>
         </a>
       </li>
       <li class="nav-item">
         <a href="#metadata" class="nav-link <%= 'active' if @tab == 'metadata' %>" aria-controls="metadata" role="tab" data-toggle="tab" data-behavior="translation-progress">
-          <%= t('spotlight.exhibits.translations.metadata.label') %> <span class="badge"></span>
+          <%= t('spotlight.translations.metadata.label') %> <span class="badge"></span>
         </a>
       </li>
       <li class="nav-item" >
         <a href="#search_fields" class="nav-link <%= 'active' if @tab == 'search_fields' %>" aria-controls="search_fields" role="tab" data-toggle="tab" data-behavior="translation-progress">
-          <%= t('spotlight.exhibits.translations.search_fields.label') %> <span class="badge"></span>
+          <%= t('spotlight.translations.search_fields.label') %> <span class="badge"></span>
         </a>
       </li>
       <li class="nav-item">
         <a href="#browse" class="nav-link <%= 'active' if @tab == 'browse' %>" aria-controls="browse" role="tab" data-toggle="tab" data-behavior="translation-progress">
-          <%= t('spotlight.exhibits.translations.browse_categories.label') %> <span class="badge"></span>
+          <%= t('spotlight.translations.browse_categories.label') %> <span class="badge"></span>
         </a>
       </li>
       <li class="nav-item">
         <a href="#pages" class="nav-link <%= 'active' if @tab == 'pages' %>" aria-controls="pages" role="tab" data-toggle="tab" data-behavior="translation-progress">
-          <%= t('spotlight.exhibits.translations.pages.label') %> <span class="badge"></span>
+          <%= t('spotlight.translations.pages.label') %> <span class="badge"></span>
         </a>
       </li>
     </ul>

--- a/app/views/spotlight/translations/show.yaml.yamlbuilder
+++ b/app/views/spotlight/translations/show.yaml.yamlbuilder
@@ -1,0 +1,60 @@
+json.set!(I18n.locale) do
+  json.set!(current_exhibit.slug) do
+    json.title(current_exhibit[:title])
+    json.subtitle(current_exhibit[:subtitle])
+    json.description(current_exhibit[:description])
+  end
+
+  json.spotlight do
+    json.curation do
+      json.nav do
+        json.home(t(:'spotlight.curation.nav.home', locale: I18n.default_locale))
+      end
+    end
+
+    json.catalog do
+      json.breadcrumb do
+        json.index(t(:'spotlight.catalog.breadcrumb.index', locale: I18n.default_locale))
+      end
+    end
+  end
+
+  json.main_navigation do
+    current_exhibit.main_navigations.each do |navigation|
+      json.set!(navigation.nav_type) do
+        json.label(navigation[:label].presence || navigation.default_label)
+      end
+    end
+  end
+
+  json.blacklight do
+    json.search do
+      json.fields do
+        json.search do
+          current_exhibit.blacklight_config.search_fields.select { |_, config| config.if }.each do |key, search_config|
+            json.set!(key, search_config.label)
+          end
+        end
+
+        json.sort do
+          current_exhibit.blacklight_config.sort_fields.each do |key, sort_config|
+            json.set!(key, sort_config.label)
+          end
+        end
+
+        json.facet do
+          current_exhibit.blacklight_config.facet_fields.each do |key, facet_config|
+            json.set!(key, facet_config.label)
+          end
+        end
+      end
+    end
+  end
+
+  current_exhibit.searches.each do |search|
+    json.set!(search.slug) do
+      json.title search[:title]
+      json.long_description search[:long_description]
+    end
+  end
+end

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -776,6 +776,13 @@ en:
           curated_features: Curated Features
           home: Home
           label: Main Menu
+      import:
+        description: You can import and export Rails-based YAML files containing the translated label values for the currently selected language for use in internationalization tools such as Transifex and i18n-tools. This feature does not include importing or exporting translations for Pages.
+        export_label: Export a YAML file
+        export_submit: Export translations
+        header: Import and export translations
+        import_label: Import a YAML file
+        import_submit: Import translations
       metadata:
         exhibit_specific_fields:
           label: Exhibit-Specific Fields

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -433,59 +433,6 @@ en:
             label: Title
       tags:
         all: All
-      translations:
-        browse_categories:
-          default_language_column_label: English language title
-          description_label: Description
-          label: Browse categories
-          translation_column_label: "%{language} translation"
-        general:
-          basic_settings:
-            description: Description
-            label: Basic Settings
-            subtitle: Subtitle
-            title: Title
-          label: General
-          main_menu:
-            about: About
-            browse: Browse
-            curated_features: Curated Features
-            home: Home
-            label: Main Menu
-        metadata:
-          exhibit_specific_fields:
-            label: Exhibit-Specific Fields
-          label: Metadata field labels
-        pages:
-          about_pages:
-            label: About Pages
-          destroy: Delete
-          destroy_are_you_sure: Are you sure you want to delete this page? If you delete this page all content, including any existing translations you have made in it, will be lost.
-          edit: Edit
-          feature_pages:
-            label: Feature Pages
-          help_html: Before exhibit visitors can view translated pages you must create, edit, and publish each page translation. When you create a translated page, a copy of the default language version of the page is made to serve as the initial translated page. You can then edit that translated page to replace the page title and any text fields with translated text. A translated page will not be visible to exhibit visitors until you publish it.  To replace a translated page with a current copy of the default language version of the page, use the <i>Recreate</i> action.
-          home_page:
-            label: Home Page
-          label: Pages
-          new: Create one now.
-          no_translated_page: No translated page.
-          recreate: Recreate
-          recreate_are_you_sure: Are you sure you want to recreate this page? If you recreate this page all content, including any existing translations you have made, will be replaced with the content of the English version of the page.
-          table_header:
-            actions: Actions
-            default_published: Published
-            language_published: Published
-            last_updated: "%{language} title / Last update"
-        search_fields:
-          facet_fields:
-            label: Facet Fields
-          field_based_search_fields:
-            label: Field-Based Search Fields
-          label: Search field labels
-          sort_fields:
-            label: Sort Fields
-        title: Translations
     exhibits_admin_invitation_mailer:
       invitation_instructions:
         accept: Accept invitation
@@ -808,6 +755,62 @@ en:
           count: Items tagged
     topbar:
       label: Utilities
+    translations:
+      browse_categories:
+        default_language_column_label: English language title
+        description_label: Description
+        label: Browse categories
+        translation_column_label: "%{language} translation"
+      edit:
+        title: Translations
+      general:
+        basic_settings:
+          description: Description
+          label: Basic Settings
+          subtitle: Subtitle
+          title: Title
+        label: General
+        main_menu:
+          about: About
+          browse: Browse
+          curated_features: Curated Features
+          home: Home
+          label: Main Menu
+      metadata:
+        exhibit_specific_fields:
+          label: Exhibit-Specific Fields
+        label: Metadata field labels
+      page:
+        destroy: Delete
+        destroy_are_you_sure: Are you sure you want to delete this page? If you delete this page all content, including any existing translations you have made in it, will be lost.
+        edit: Edit
+        new: Create one now.
+        no_translated_page: No translated page.
+        recreate: Recreate
+        recreate_are_you_sure: Are you sure you want to recreate this page? If you recreate this page all content, including any existing translations you have made, will be replaced with the content of the English version of the page.
+      pages:
+        about_pages:
+          label: About Pages
+        feature_pages:
+          label: Feature Pages
+        help_html: Before exhibit visitors can view translated pages you must create, edit, and publish each page translation. When you create a translated page, a copy of the default language version of the page is made to serve as the initial translated page. You can then edit that translated page to replace the page title and any text fields with translated text. A translated page will not be visible to exhibit visitors until you publish it.  To replace a translated page with a current copy of the default language version of the page, use the <i>Recreate</i> action.
+        home_page:
+          label: Home Page
+        label: Pages
+      pages_table:
+        header:
+          actions: Actions
+          default_published: Published
+          language_published: Published
+          last_updated: "%{language} title / Last update"
+      search_fields:
+        facet_fields:
+          label: Facet Fields
+        field_based_search_fields:
+          label: Field-Based Search Fields
+        label: Search field labels
+        sort_fields:
+          label: Sort Fields
     versions:
       redo: Redo changes
       undo: Undo changes

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -143,7 +143,12 @@ Spotlight::Engine.routes.draw do
       end
     end
     post 'solr/update' => 'solr#update'
-    resource :translations, only: %i[edit update]
+    resource :translations, only: %i[edit update show] do
+      collection do
+        post 'import'
+        patch 'import'
+      end
+    end
   end
 
   get '/:exhibit_id' => 'home_pages#show', as: :exhibit_root

--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -214,6 +214,25 @@ module Spotlight
     # add could add an available locale which could break things if unexpected.
     config.i18n.available_locales = config.i18n_locales.keys
 
+    # Copy of JbuilderHandler tweaked to spit out YAML for translation exports
+    class TranslationYamlHandler
+      cattr_accessor :default_format
+      self.default_format = :yaml
+
+      def self.call(template, source = nil)
+        source ||= template.source
+        # this juggling is required to keep line numbers right in the error
+        %{__already_defined = defined?(json); json||=JbuilderTemplate.new(self); #{source}
+          json.attributes!.to_yaml unless (__already_defined && __already_defined != "method")}
+      end
+    end
+
+    initializer :yamlbuilder do
+      ActiveSupport.on_load :action_view do
+        ActionView::Template.register_template_handler :yamlbuilder, TranslationYamlHandler
+      end
+    end
+
     # Query parameters for autocomplete requests
     config.autocomplete_search_field = 'autocomplete'
     config.default_autocomplete_params = { qf: 'id^1000 full_title_tesim^100 id_ng full_title_ng',

--- a/spec/views/spotlight/translations/_import.html.erb_spec.rb
+++ b/spec/views/spotlight/translations/_import.html.erb_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+describe 'spotlight/translations/_import.html.erb', type: :view do
+  let(:exhibit) { FactoryBot.create(:exhibit) }
+
+  before do
+    allow(view).to receive(:can?).and_return(true)
+    allow(view).to receive(:current_exhibit).and_return(exhibit)
+  end
+
+  it 'has a link to export the translation data' do
+    render
+    expect(rendered).to have_link 'Export translations', href: spotlight.exhibit_translations_path(exhibit_id: exhibit, format: 'yaml')
+  end
+
+  it 'has a form to import the translation data' do
+    render
+    expect(rendered).to have_selector "form[action='#{spotlight.import_exhibit_translations_path(exhibit_id: exhibit)}']"
+    expect(rendered).to have_selector 'input[name="file"]'
+  end
+end


### PR DESCRIPTION
Closes sul-dlss/dlme#868
![Screen Shot 2020-04-03 at 3 24 36 PM](https://user-images.githubusercontent.com/5402927/78409735-441a5080-75bf-11ea-98a4-40065e7fdc69.png)

This feature:
- Add export button that generates Rails-based YML (compatible with Transifex and other i18n tools for other workflows like i18n-tasks, etc. 
- Adds the ability to import a Rails-based YML file to the Curator UI (i.e. a file generated by Transifex)
  - Importing a YML file will override any existing translations
- This approach does not include Feature and About pages. This could be ticketed for future work, but I'm doubtful we would revisit that until we reconsider widget frameworks. 

TODOs:
- [x] write tests
- ~[-]~ add ability to export locales besides `I18n.default_locale` (English for the  generated test app) (splitting out to another ticket)
- [x] Get feedbak from @ggeisler on upload/import workflow and input (design ticket #2512)