### PR TITLE
Derive the document class constant through a new (private) method …

### DIFF
--- a/app/models/spotlight/solr_document_sidecar.rb
+++ b/app/models/spotlight/solr_document_sidecar.rb
@@ -33,11 +33,7 @@ module Spotlight
 
     # Roll our own polymorphism because our documents are not AREL-able
     def document
-      document_type.new document_type.unique_key => document_id
-    end
-
-    def document_type
-      (super.constantize if defined?(super)) || default_document_type
+      document_type_class.new document_type_class.unique_key => document_id
     end
 
     def default_document_type
@@ -45,6 +41,12 @@ module Spotlight
     end
 
     private
+
+    def document_type_class
+      return default_document_type unless document_type.is_a?(String)
+
+      document_type.constantize
+    end
 
     def visibility_field
       blacklight_config.document_model.visibility_field(exhibit)

--- a/app/services/spotlight/exhibit_import_export_service.rb
+++ b/app/services/spotlight/exhibit_import_export_service.rb
@@ -14,7 +14,6 @@ module Spotlight
       add_page_content
       attach_featured_images
       attach_attachments
-      stringify_classes
     ]
 
     attr_reader :exhibit, :include
@@ -285,16 +284,6 @@ module Spotlight
       end
 
       json[:home_page][:content] = exhibit.home_page.read_attribute(:content) if json[:home_page]
-
-      json
-    end
-
-    def stringify_classes(json)
-      return json unless json[:solr_document_sidecars]
-
-      json[:solr_document_sidecars].each do |obj|
-        obj[:document_type] = obj[:document_type].to_s
-      end
 
       json
     end


### PR DESCRIPTION
... that does not override an AR attribute accessor.
