### PR TITLE
Add Link URL attribute to the uploaded item row widget

### DIFF
--- a/app/assets/javascripts/spotlight/admin/blocks/uploaded_items_block.js
+++ b/app/assets/javascripts/spotlight/admin/blocks/uploaded_items_block.js
@@ -85,9 +85,13 @@ SirTrevor.Blocks.UploadedItems = (function(){
                 '</div>',
                 '<div class="main form-horizontal">',
                   '<div class="title card-title">' + dataTitle + '</div>',
-                  '<div class="field">',
+                  '<div class="field row mr-3">',
                     '<label for="' + this.formId('caption_' + dataId) + '" class="col-form-label col-md-3"><%= i18n.t("blocks:uploaded_items:caption") %></label>',
-                    '<input type="text" class="form-control" id="' + this.formId('caption_' + dataId) + '" name="item[' + index + '][caption]" data-field="caption"/>',
+                    '<input type="text" class="form-control col" id="' + this.formId('caption_' + dataId) + '" name="item[' + index + '][caption]" data-field="caption"/>',
+                  '</div>',
+                  '<div class="field row mr-3">',
+                    '<label for="' + this.formId('link_' + dataId) + '" class="col-form-label col-md-3"><%= i18n.t("blocks:uploaded_items:link") %></label>',
+                    '<input type="text" class="form-control col" id="' + this.formId('link_' + dataId) + '" name="item[' + index + '][link]" data-field="link"/>',
                   '</div>',
                 '</div>',
                 '<div class="remove float-right">',
@@ -99,6 +103,7 @@ SirTrevor.Blocks.UploadedItems = (function(){
 
       var panel = $(_.template(markup)(this));
       panel.find('[data-field="caption"]').val(data.caption);
+      panel.find('[data-field="link"]').val(data.link);
       var context = this;
 
       $('.remove a', panel).on('click', function(e) {

--- a/app/assets/javascripts/spotlight/admin/sir-trevor/locales.js
+++ b/app/assets/javascripts/spotlight/admin/sir-trevor/locales.js
@@ -29,8 +29,9 @@ SirTrevor.Locales.en.blocks = $.extend(SirTrevor.Locales.en.blocks, {
 
   uploaded_items: {
     title: "Uploaded Item Row",
-    description: "This widget displays uploaded items in a horizontal row. Optionally, you can add a heading and/or text to be displayed adjacent to the items.",
-    caption: 'Caption'
+    description: "This widget displays uploaded items in a horizontal row. Optionally, you can add a heading and/or text to be displayed adjacent to the items. The item caption and link URL fields are also optional.",
+    caption: 'Caption',
+    link: 'Link URL'
   },
 
   featured_pages: {

--- a/app/views/spotlight/sir_trevor/blocks/_uploaded_items_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_uploaded_items_block.html.erb
@@ -4,7 +4,13 @@
       <% uploaded_items_block.files.each do |file| %>
         <div class="box" data-id="<%= file[:id] %>">
           <div class="contents">
-            <img class="img-thumbnail" src='<%= file[:url] %>' alt='' />
+            <% if file[:link].present? %>
+              <%= link_to file[:link], rel: 'ugc' do %>
+                <%= image_tag file[:url], class: 'img-thumbnail', alt: file[:caption] %>
+              <% end %>
+            <% else %>
+              <%= image_tag file[:url], class: 'img-thumbnail', alt: '', role: 'presentation' %>
+            <% end %>
             <% if file[:caption].present? %>
               <div class="caption">
                 <%= file[:caption] %>

--- a/spec/features/javascript/blocks/uploaded_items_block_spec.rb
+++ b/spec/features/javascript/blocks/uploaded_items_block_spec.rb
@@ -26,6 +26,7 @@ describe 'Uploaded Items Block', feature: true, js: true, versioning: true do
     within('.dd-list') do
       expect(page).to have_css('.card-title', text: '800x600.png')
       fill_in 'Caption', with: 'Some caption text'
+      fill_in 'Link URL', with: 'https://example.com/'
     end
 
     attach_file('uploaded_item_url', fixture_file2)
@@ -41,8 +42,10 @@ describe 'Uploaded Items Block', feature: true, js: true, versioning: true do
     expect(page).to have_css('p', text: text)
 
     within('.uploaded-items-block') do
-      expect(page).to have_css('img[alt=""]', count: 2)
+      expect(page).to have_css('img[alt=""]', count: 1)
+      expect(page).to have_css('img[alt="Some caption text"]', count: 1)
       expect(page).to have_css '.caption', text: 'Some caption text'
+      expect(page).to have_link 'Some caption text', href: 'https://example.com/'
     end
   end
 


### PR DESCRIPTION
fixes #2034

<img width="901" alt="Screen Shot 2020-04-10 at 06 56 53" src="https://user-images.githubusercontent.com/111218/78996026-96e09480-7af8-11ea-94c3-b1a059190155.png">
<img width="361" alt="Screen Shot 2020-04-10 at 06 58 29" src="https://user-images.githubusercontent.com/111218/78996071-b081dc00-7af8-11ea-8512-5586f4a52efb.png">

