### PR TITLE
Add YML export for locales beside the default language

### DIFF
--- a/app/models/spotlight/main_navigation.rb
+++ b/app/models/spotlight/main_navigation.rb
@@ -26,8 +26,8 @@ module Spotlight
       end
     end
 
-    def default_label
-      I18n.t(:"spotlight.main_navigation.#{nav_type}")
+    def default_label(**options)
+      I18n.t(:"spotlight.main_navigation.#{nav_type}", **options)
     end
 
     private

--- a/app/views/spotlight/translations/_import.html.erb
+++ b/app/views/spotlight/translations/_import.html.erb
@@ -17,7 +17,8 @@
     <div class="row col-md-12">
       <%= content_tag :span, t(".export_label"), class: 'col-form-label col-12 col-sm-3 text-right' %>
 
-      <%= link_to t(:'.export_submit'), spotlight.exhibit_translations_path(current_exhibit, format: "yaml"), class: 'btn btn-primary' %>
+      <%= link_to t(:'.export_current_locale', language: t(:"locales.#{@language}")), spotlight.exhibit_translations_path(current_exhibit, format: "yaml", locale: @language), class: 'btn btn-primary mr-3' %>
+      <%= link_to t(:'.export_default_locale', language: t(:"locales.#{I18n.default_locale}")), spotlight.exhibit_translations_path(current_exhibit, format: "yaml", locale: I18n.default_locale), class: 'btn btn-primary' %>
     </div>
   </div>
 <% end %>

--- a/app/views/spotlight/translations/show.yaml.yamlbuilder
+++ b/app/views/spotlight/translations/show.yaml.yamlbuilder
@@ -1,20 +1,20 @@
-json.set!(I18n.locale) do
+json.set!(locale) do
   json.set!(current_exhibit.slug) do
-    json.title(current_exhibit[:title])
-    json.subtitle(current_exhibit[:subtitle])
-    json.description(current_exhibit[:description])
+    json.title(current_exhibit.translated_title(default: ''))
+    json.subtitle(current_exhibit.translated_subtitle(default: ''))
+    json.description(current_exhibit.translated_description(default: ''))
   end
 
   json.spotlight do
     json.curation do
       json.nav do
-        json.home(t(:'spotlight.curation.nav.home', locale: I18n.default_locale))
+        json.home(t(:'spotlight.curation.nav.home', default: ''))
       end
     end
 
     json.catalog do
       json.breadcrumb do
-        json.index(t(:'spotlight.catalog.breadcrumb.index', locale: I18n.default_locale))
+        json.index(t(:'spotlight.catalog.breadcrumb.index', default: ''))
       end
     end
   end
@@ -22,7 +22,7 @@ json.set!(I18n.locale) do
   json.main_navigation do
     current_exhibit.main_navigations.each do |navigation|
       json.set!(navigation.nav_type) do
-        json.label(navigation[:label].presence || navigation.default_label)
+        json.label(navigation.translated_label(default: navigation.default_label(default: '')))
       end
     end
   end
@@ -30,21 +30,41 @@ json.set!(I18n.locale) do
   json.blacklight do
     json.search do
       json.fields do
+        current_exhibit.blacklight_config.show_fields.each do |key, field_config|
+          if locale == I18n.default_locale
+            json.set!(key, field_config.label)
+          else
+            json.set!(key, t(:"blacklight.search.fields.#{key}", default: ''))
+          end
+        end
+
         json.search do
           current_exhibit.blacklight_config.search_fields.select { |_, config| config.if }.each do |key, search_config|
-            json.set!(key, search_config.label)
+            if locale == I18n.default_locale
+              json.set!(key, search_config.label)
+            else
+              json.set!(key, t(:"blacklight.search.fields.search.#{key}", default: ''))
+            end
           end
         end
 
         json.sort do
           current_exhibit.blacklight_config.sort_fields.each do |key, sort_config|
-            json.set!(key, sort_config.label)
+            if locale == I18n.default_locale
+              json.set!(key, sort_config.label)
+            else
+              json.set!(key, t(:"blacklight.search.fields.sort.#{key}", default: ''))
+            end
           end
         end
 
         json.facet do
           current_exhibit.blacklight_config.facet_fields.each do |key, facet_config|
-            json.set!(key, facet_config.label)
+            if locale == I18n.default_locale
+              json.set!(key, facet_config.label)
+            else
+              json.set!(key, t(:"blacklight.search.fields.facet.#{key}", default: ''))
+            end
           end
         end
       end
@@ -53,8 +73,9 @@ json.set!(I18n.locale) do
 
   current_exhibit.searches.each do |search|
     json.set!(search.slug) do
-      json.title search[:title]
-      json.long_description search[:long_description]
+      json.title search.translated_title(default: '')
+      json.subtitle search.translated_subtitle(default: '')
+      json.long_description search.translated_long_description(default: '')
     end
   end
 end

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -779,8 +779,9 @@ en:
           label: Main Menu
       import:
         description: You can import and export Rails-based YAML files containing the translated label values for the currently selected language for use in internationalization tools such as Transifex and i18n-tools. This feature does not include importing or exporting translations for Pages.
+        export_current_locale: Export %{language}
+        export_default_locale: Export %{language}
         export_label: Export a YAML file
-        export_submit: Export translations
         header: Import and export translations
         import_label: Import a YAML file
         import_submit: Import translations

--- a/spec/controllers/spotlight/translations_controller_spec.rb
+++ b/spec/controllers/spotlight/translations_controller_spec.rb
@@ -80,7 +80,10 @@ describe Spotlight::TranslationsController do
 
   describe '#show' do
     render_views
-    before { sign_in user }
+    before do
+      sign_in user
+      FactoryBot.create(:translation, exhibit: exhibit, locale: 'es', key: "#{exhibit.slug}.title", value: 'Titulo')
+    end
 
     let(:user) { FactoryBot.create(:site_admin) }
 
@@ -91,6 +94,16 @@ describe Spotlight::TranslationsController do
 
       expect(translations).to include :en
       expect(translations[:en]).to include :blacklight, :spotlight, exhibit.slug
+    end
+
+    it 'provides a YML dump of the requested language translations' do
+      get :show, params: { exhibit_id: exhibit, format: 'yaml', locale: 'es' }
+      expect(response).to be_successful
+      translations = YAML.safe_load(response.body).with_indifferent_access
+
+      expect(translations).to include :es
+      expect(translations[:es]).to include :blacklight, :spotlight, exhibit.slug
+      expect(translations[:es][exhibit.slug]).to include title: 'Titulo', subtitle: nil
     end
   end
 

--- a/spec/models/spotlight/exhibit_spec.rb
+++ b/spec/models/spotlight/exhibit_spec.rb
@@ -28,7 +28,7 @@ describe Spotlight::Exhibit, type: :model do
     end
 
     it 'does not validate the presence of the title under a non-default locale' do
-      expect(I18n).to receive(:locale).and_return(:fr)
+      allow(I18n).to receive(:locale).and_return(:fr)
       exhibit.title = ''
       expect do
         exhibit.save
@@ -402,6 +402,7 @@ describe Spotlight::Exhibit, type: :model do
       I18n.locale = 'fr'
       persisted_exhibit.reload
       expect(persisted_exhibit.title).to eq 'Titre français'
+      expect(persisted_exhibit.translated_title).to eq 'Titre français'
     end
 
     it 'has a translatable subtitle' do
@@ -416,6 +417,13 @@ describe Spotlight::Exhibit, type: :model do
       I18n.locale = 'fr'
       persisted_exhibit.reload
       expect(persisted_exhibit.description).to eq 'Description français'
+    end
+
+    it 'is nil if no translation has been prrovided' do
+      expect(persisted_exhibit.title).to eq 'Sample'
+      I18n.locale = 'es'
+      persisted_exhibit.reload
+      expect(persisted_exhibit.translated_title(default: '')).to eq nil
     end
   end
 end

--- a/spec/views/spotlight/translations/_import.html.erb_spec.rb
+++ b/spec/views/spotlight/translations/_import.html.erb_spec.rb
@@ -6,11 +6,14 @@ describe 'spotlight/translations/_import.html.erb', type: :view do
   before do
     allow(view).to receive(:can?).and_return(true)
     allow(view).to receive(:current_exhibit).and_return(exhibit)
+    assign(:language, :es)
+    I18n.default_locale = 'en'
   end
 
   it 'has a link to export the translation data' do
     render
-    expect(rendered).to have_link 'Export translations', href: spotlight.exhibit_translations_path(exhibit_id: exhibit, format: 'yaml')
+    expect(rendered).to have_link 'Export English', href: spotlight.exhibit_translations_path(exhibit_id: exhibit, format: 'yaml', locale: 'en')
+    expect(rendered).to have_link 'Export Spanish', href: spotlight.exhibit_translations_path(exhibit_id: exhibit, format: 'yaml', locale: 'es')
   end
 
   it 'has a form to import the translation data' do


### PR DESCRIPTION
Fixes #2516 

This PR builds on work from #2509 to make curator-provided translations exportable to YML files. This PR:
- Adds metadata field labels to YML export
- Updates UI for exporting YML: a user can export both the current language being translated and the default / source language
- adds `#translated_#{attr_name}` methods for looking up strings. My first pass at implementing this involved a lot of conditional logic in the `yamlbuilder`. 
  - Lookup for these strings can vary depending on several factors, such as:
    - whether the value is in the default locale or a translated language
    - whether a value has been provided in a translated language
    - whether the value uses Spotlight's default or has been customized by curator (e.g. facet field labels) 
  - empty string values have been provided because I18n throws a `MissingTranslationData` error when provided with nil, but ignores empty strings

## Screenshots
### Before
![translation interface with English export only](https://user-images.githubusercontent.com/5402927/79517339-c1ec4c00-8002-11ea-9662-1f23aa464089.png)

### After
![translation interface with options to export to Spanish and English](https://user-images.githubusercontent.com/5402927/79516720-fe1ead00-8000-11ea-808b-cca3d0bb3046.png)

### Sample YAML output - default language
```yaml
---
en:
  test:
    title: test
    subtitle: provided subtitle
    description:
```


### Sample YAML output - translated language
```yaml
---
es:
  test:
    title: titulo de ejemplo
    subtitle: ''
```