### PR TITLE
Pass format explicitly through page form/controller when updating.

### DIFF
--- a/app/controllers/spotlight/pages_controller.rb
+++ b/app/controllers/spotlight/pages_controller.rb
@@ -70,7 +70,7 @@ module Spotlight
       @page.lock&.delete
 
       if @page.update(page_params.merge(last_edited_by: current_user))
-        redirect_to [spotlight, @page.exhibit, @page], flash: { html_safe: true }, notice: undo_notice(:updated)
+        redirect_to [spotlight, @page.exhibit, @page, format: params.permit(:format)], flash: { html_safe: true }, notice: undo_notice(:updated)
       else
         render action: 'edit'
       end

--- a/app/views/spotlight/pages/_form.html.erb
+++ b/app/views/spotlight/pages/_form.html.erb
@@ -2,7 +2,7 @@
   # TODO: the "if @page.persisted?" business below could possibly be done w/ some clever polymorphic routing.
   # Leaving as-is for now since technically you can't get to the new page form anyway.
 %>
-<%= bootstrap_form_for([spotlight, @page.exhibit, @page], role: 'form', html: { data: configurations_for_current_page.merge('form-observer': true)}) do |f| %>
+<%= bootstrap_form_for(@page, url: url_for([spotlight, @page.exhibit, @page, format: nil]), role: 'form', html: { data: configurations_for_current_page.merge('form-observer': true)}) do |f| %>
   <%= render @page.lock if @page.lock and not @page.lock.stale? and not @page.lock.current_session? %>
   <% if @page.errors.any? %>
     <div id="error_explanation">

--- a/spec/controllers/spotlight/home_pages_controller_spec.rb
+++ b/spec/controllers/spotlight/home_pages_controller_spec.rb
@@ -41,7 +41,7 @@ describe Spotlight::HomePagesController, type: :controller, versioning: true do
       it 'redirects to the feature page index action' do
         put :update, params: { id: page, exhibit_id: page.exhibit.id, home_page: valid_attributes }
         page.reload
-        expect(response).to redirect_to(exhibit_home_page_path(page.exhibit, page))
+        expect(response).to redirect_to(exhibit_home_page_path(page.exhibit))
         expect(flash[:notice]).to have_link 'Undo changes'
       end
     end

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -31,6 +31,15 @@ describe 'Home page', type: :feature, versioning: true do
     expect(page).to have_selector '.card-title a', text: 'New Home Page Title'
   end
 
+  it 'redirects back to the correct home page URL after updating (no format param to interfere w/ faceting)' do
+    visit spotlight.exhibit_home_page_path(exhibit.home_page)
+
+    click_link 'Edit'
+    click_button 'Save changes'
+
+    expect(page.current_url).to eq spotlight.exhibit_home_page_url(exhibit)
+  end
+
   it 'has working facet links' do
     visit spotlight.exhibit_home_page_path(exhibit.home_page)
     click_button 'Genre'


### PR DESCRIPTION
Fixes sul-dlss/dlme#967

The polymorphic routing seems to choke on allowing us to handle both the has_many feature/about pages relation and the has_one home_page relation the same.

In the case of the has_one relationship we're seeing the "slug" or ID of the page being appended like a format to the URL.

If we explicitly pass a nil format through the form (which should always be HTML and is handled appropriately as the default) and then pass the format param explicitly back through the redirect after update (so updating via API will still work in theory) and things appear to work out both on the home and feature/about pages side of things.

## Before
![page-update-format-before](https://user-images.githubusercontent.com/96776/80041280-e0de5880-84b0-11ea-928b-5b3368f8d73f.gif)

## After
![page-update-format-after](https://user-images.githubusercontent.com/96776/80041285-e3d94900-84b0-11ea-9ad3-10af4e4b4f80.gif)
