### PR TITLE
Bump Ruby minimum version to 2.5

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,9 @@ Bundler/DuplicatedGem:
 Bundler/OrderedGems:
   Enabled: false
 
+Capybara/VisibilityMatcher:
+  Enabled: false
+
 Layout/LineLength:
   Max: 160
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -80,6 +80,7 @@ RSpec/DescribeClass:
   Exclude:
     - 'spec/features/**/*'
     - 'spec/views/**/*'
+    - 'spec/i18n_spec.rb'
 
 RSpec/NestedGroups:
   Max: 4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ AllCops:
     - 'db/**/*'
     - 'spec/internal/**/*'
     - 'vendor/**/*'
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.5
   DisplayCopNames: true
 
 Bundler/DuplicatedGem:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Read more about what Spotlight is, our motivations for creating it, and how to i
 
 ## Requirements
 
-1. Ruby (2.3.0 or greater)
+1. Ruby (2.5.0 or greater)
 2. Rails (5.1 or greater)
 3. Java (7 or greater) *for Solr*
 4. ImageMagick (http://www.imagemagick.org/script/index.php) due to [carrierwave](https://github.com/carrierwaveuploader/carrierwave#adding-versions)
@@ -93,7 +93,7 @@ Spotlight ships with [`i18n-tasks`](https://github.com/glebm/i18n-tasks) to help
 $ bundle exec i18n-tasks health
 ```
 
-See [developer-facing instructions for enabling translation](https://github.com/projectblacklight/spotlight/wiki/Translations) on the wiki. 
+See [developer-facing instructions for enabling translation](https://github.com/projectblacklight/spotlight/wiki/Translations) on the wiki.
 
 ## Community
 

--- a/blacklight-spotlight.gemspec
+++ b/blacklight-spotlight.gemspec
@@ -66,7 +66,7 @@ these collections.)
   s.add_development_dependency 'rspec-collection_matchers'
   s.add_development_dependency 'rspec-its'
   s.add_development_dependency 'rspec-rails', '>= 4.0.0.beta1'
-  s.add_development_dependency 'rubocop', '~> 0.79.0'
+  s.add_development_dependency 'rubocop', '~> 0.83.0'
   s.add_development_dependency 'rubocop-rspec'
   s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'simplecov', '~> 0.12'

--- a/blacklight-spotlight.gemspec
+++ b/blacklight-spotlight.gemspec
@@ -19,7 +19,7 @@ these collections.)
   s.files = Dir['{app,config,db,lib,vendor}/**/*', 'Rakefile', 'README.md', 'LICENSE']
   s.test_files = Dir['spec/**/*']
 
-  s.required_ruby_version = '~> 2.3'
+  s.required_ruby_version = '~> 2.5'
 
   s.add_dependency 'acts-as-taggable-on', '>= 5.0', '< 7'
   s.add_dependency 'almond-rails', '~> 0.1'

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -2,7 +2,6 @@
 
 require 'i18n/tasks'
 
-# rubocop:disable RSpec/DescribeClass
 RSpec.describe 'I18n' do
   let(:i18n) { I18n::Tasks::BaseTask.new }
   let(:missing_keys) { i18n.missing_keys }
@@ -26,4 +25,3 @@ RSpec.describe 'I18n' do
     expect(non_normalized).to be_empty, error_message
   end
 end
-# rubocop:enable RSpec/DescribeClass


### PR DESCRIPTION
[Ruby 2.4 is EOL](https://www.ruby-lang.org/en/downloads/branches/) as of March 31, 2020.
