### PR TITLE
Define SirTrevor block types in Spotlight's engine config, and …

### DIFF
--- a/lib/generators/spotlight/templates/config/initializers/sir_trevor_rails.rb
+++ b/lib/generators/spotlight/templates/config/initializers/sir_trevor_rails.rb
@@ -4,25 +4,7 @@
 # https://github.com/madebymany/sir-trevor-rails#upgrade-guide-to-v060
 class SirTrevorRails::Block
   def self.custom_block_types
-    %w[
-      Browse
-      FeaturedPages
-      Heading
-      Iframe
-      LinkToSearch
-      List
-      Oembed
-      Quote
-      Rule
-      SearchResults
-      SolrDocuments
-      SolrDocumentsCarousel
-      SolrDocumentsEmbed
-      SolrDocumentsFeatures
-      SolrDocumentsGrid
-      Text
-      UploadedItems
-      Video
-    ]
+    # You can define your custom block types directly here or in your engine config.
+    Spotlight::Engine.config.sir_trevor_widgets
   end
 end

--- a/lib/generators/spotlight/templates/config/initializers/spotlight_initializer.rb
+++ b/lib/generators/spotlight/templates/config/initializers/spotlight_initializer.rb
@@ -69,6 +69,15 @@
 # Spotlight::Engine.config.ga_page_analytics_options = config.ga_analytics_options.merge(limit: 5)
 # Spotlight::Engine.config.ga_anonymize_ip = false # false for backwards compatibility
 
+# ==> Sir Trevor Widget Configuration
+# These are set by default by Spotlight's configuration,
+# but you can customize them here, or in the SirTrevorRails::Block#custom_block_types method
+# Spotlight::Engine.config.sir_trevor_widgets = %w(
+#   Heading Text List Quote Iframe Video Oembed Rule UploadedItems Browse
+#   FeaturedPages SolrDocuments SolrDocumentsCarousel SolrDocumentsEmbed
+#   SolrDocumentsFeatures SolrDocumentsGrid SearchResults
+# )
+#
 # Page configurations made available to widgets
 # Spotlight::Engine.config.page_configurations = {
 #   'my-local-config': ->(context) { context.my_custom_data_path(context.current_exhibit) }

--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -264,6 +264,14 @@ module Spotlight
 
     config.default_page_content_type = 'SirTrevor'
 
+    # Added here for backwards compatability with SirTrevor 0.6
+    # and apps who have customized their avaialble widgets
+    config.sir_trevor_widgets = %w[
+      Heading Text List Quote Iframe Video Oembed Rule UploadedItems Browse LinkToSearch
+      FeaturedPages SolrDocuments SolrDocumentsCarousel SolrDocumentsEmbed
+      SolrDocumentsFeatures SolrDocumentsGrid SearchResults
+    ]
+
     config.routes = OpenStruct.new
     config.routes.solr_documents = {}
 


### PR DESCRIPTION
…consume that config in the sir_trevor_rails initializer.

This is intended to help w/ the upgrade path/backwards compatibility of the breaking change SirTrevor introduced in 0.6: https://github.com/madebymany/sir-trevor-rails#upgrade-guide-to-v060