### PR TITLE
Provide IIIF URLs for any image attached to a Spotlight::FeaturedImage

### DIFF
--- a/app/models/spotlight/featured_image.rb
+++ b/app/models/spotlight/featured_image.rb
@@ -66,7 +66,7 @@ module Spotlight
     def iiif_tilesource
       if self[:iiif_tilesource]
         self[:iiif_tilesource]
-      elsif source == 'remote' && file_present?
+      elsif file_present?
         riiif = Riiif::Engine.routes.url_helpers
         riiif.info_path(id)
       end

--- a/spec/models/spotlight/featured_image_spec.rb
+++ b/spec/models/spotlight/featured_image_spec.rb
@@ -36,7 +36,6 @@ describe Spotlight::FeaturedImage do
 
       context 'with an uploaded image' do
         before do
-          featured_image.source = 'remote'
           featured_image.image = temp_image.image
           featured_image.save!
         end


### PR DESCRIPTION
Fixes a regression  introduced  in https://github.com/projectblacklight/spotlight/commit/4d7786c2f6c465e369060dd4f99a84e1853b697b.

This patch seems  in the spirit of the previous implementation, at least? (https://github.com/projectblacklight/spotlight/commit/4d7786c2f6c465e369060dd4f99a84e1853b697b#diff-bcb0a609fba5effed919e646fc3312e1L52)

Fixes https://github.com/sul-dlss/exhibits/issues/1903.