### PR TITLE
Adjust styling of About page Contacts info

### DIFF
--- a/app/assets/stylesheets/spotlight/_pages.scss
+++ b/app/assets/stylesheets/spotlight/_pages.scss
@@ -58,13 +58,18 @@
   }
 
   .contact-properties {
-    padding-left: 1rem;
-    text-indent: -1rem;
+    padding-left: 0.125rem;
+
+    > div {
+      padding-bottom: 5px;
+    }
   }
 
   ol.contacts {
+    line-height: 1.33;
+
     li {
-      margin-bottom: $spacer * .5;
+      margin-bottom: 1rem;
       margin-top: $spacer * .5;
       word-break: break-word;
       .name {
@@ -76,7 +81,7 @@
   ol.sidenav {
     li {
       color: $gray-900;
-      margin-top: $spacer * .25;
+      margin-top: $spacer * .5;
     }
 
     ol.subsection {


### PR DESCRIPTION
When we last updated Spotlight to the latest version of Bootstrap, we styled the About page Contacts sidebar info to indent the second line of a contact person's info when it needed to wrap due to lack of column width.

However, I've heard from several curators who were confused the resulting uneven left alignment of the contact info and thought the page might be broken. I had some concerns about that as well.

This PR updates the styling to go back to the even left alignment of contact info and tries to make distinguishing the wrapped lines of a single piece of contact info from subsequent pieces of info by slightly reducing the line-height (which I think is still sufficient in this context) and slightly increasing the vertical space between each piece of contact info.

In the before and after examples below the left image is on a narrower desktop viewport and the right image wide desktop viewport.

## Before 
The red arrows and lines indicate the things the people reported finding visually confusing.

<img width="1176" alt="Screen Shot 2020-08-07 at 3 40 29 PM" src="https://user-images.githubusercontent.com/101482/89694478-9a790200-d8c5-11ea-87dd-89c5dd1f4561.png">

## After
<img width="1183" alt="Screen Shot 2020-08-07 at 3 41 34 PM" src="https://user-images.githubusercontent.com/101482/89694497-b086c280-d8c5-11ea-9e65-ce246d5734cc.png">
