### PR TITLE
Update styling of import/export translations section

### DIFF
--- a/app/assets/stylesheets/spotlight/_translations.scss
+++ b/app/assets/stylesheets/spotlight/_translations.scss
@@ -78,3 +78,9 @@
   margin-top: $spacer;
   padding-bottom: 3px;
 }
+
+.translation-import-export-label {
+  @media (min-width: 576px) {
+    text-align: right;
+  }
+}

--- a/app/views/spotlight/translations/_import.html.erb
+++ b/app/views/spotlight/translations/_import.html.erb
@@ -1,10 +1,10 @@
 <% if can? :import_translations, Spotlight::Exhibit %>
-  <div class="row col-md-12 mb-4">
+  <div class="row col-md-12 mb-5">
     <h2><%= t(:'.header') %></h2>
     <p class="instructions"><%= t(:'.description') %></p>
 
-    <%= bootstrap_form_for current_exhibit, url: spotlight.import_exhibit_translations_path(current_exhibit), html: { class: 'row col-md-12 clearfix mb-3', multipart: true } do |f| %>
-      <%= f.label :value, t(".import_label"), class: 'col-form-label col-12 col-sm-3 text-right' %>
+    <%= bootstrap_form_for current_exhibit, url: spotlight.import_exhibit_translations_path(current_exhibit), html: { class: 'row col-md-12 align-items-center clearfix mb-3', multipart: true } do |f| %>
+      <%= f.label :value, t(".import_label"), class: 'col-form-label col-12 col-sm-3 pl-0 translation-import-export-label' %>
 
       <div class="input-group col px-0">
         <%= file_field_tag :file, class: 'form-control' %>
@@ -14,8 +14,8 @@
         </div>
       </div>
     <% end %>
-    <div class="row col-md-12">
-      <%= content_tag :span, t(".export_label"), class: 'col-form-label col-12 col-sm-3 text-right' %>
+    <div class="row col-md-12 align-items-center">
+      <%= content_tag :span, t(".export_label"), class: 'col-form-label col-12 col-sm-3 pl-0 translation-import-export-label' %>
 
       <%= link_to t(:'.export_current_locale', language: t(:"locales.#{@language}")), spotlight.exhibit_translations_path(current_exhibit, format: "yaml", locale: @language), class: 'btn btn-primary mr-3' %>
       <%= link_to t(:'.export_default_locale', language: t(:"locales.#{I18n.default_locale}")), spotlight.exhibit_translations_path(current_exhibit, format: "yaml", locale: I18n.default_locale), class: 'btn btn-primary' %>


### PR DESCRIPTION
Fixes #2554.

## `sm` viewport (stacked labels, left-aligned)
<img width="541" alt="Screen Shot 2020-08-10 at 11 17 31 AM" src="https://user-images.githubusercontent.com/101482/89816347-45263600-dafb-11ea-9a06-fe33c5878723.png">


## `md` and larger viewports (inline labels, right-aligned)
<img width="737" alt="Screen Shot 2020-08-10 at 11 09 23 AM" src="https://user-images.githubusercontent.com/101482/89816051-a994c580-dafa-11ea-97f9-e57ce0599fa4.png">

---

<img width="853" alt="Screen Shot 2020-08-10 at 11 09 36 AM" src="https://user-images.githubusercontent.com/101482/89816062-af8aa680-dafa-11ea-84e0-7bc5a05b92a8.png">

