### PR TITLE
Update text strings to be more consistent in usage

### DIFF
--- a/app/views/spotlight/about_pages/_empty.html.erb
+++ b/app/views/spotlight/about_pages/_empty.html.erb
@@ -4,19 +4,19 @@
 
     <ol>
       <li>
-        To add content to this page, click the Edit button above to enter Edit mode.
+        To add content to this page, select the Edit button above to enter edit mode.
       </li>
       <li>
-        In Edit mode, click the plus sign icon to display the widget selection panel. This panel displays a range of widgets, each of which adds a different type of content to the page.
+        In edit mode, select the plus sign icon to display the widget selection panel. This panel displays a range of widgets, each of which adds a different type of content to the page.
       </li>
       <li>
-        Select a widget to configure. Click <strong>Save changes</strong> when you're ready to add it to the page.
+        Select a widget to configure. Select <b>Save changes</b> when you're ready to add it to the page.
       </li>
       <li>
         Repeat the steps above to continue adding widgets to build out the page. To work more efficiently, you can configure multiple widgets before saving the page. Use the icons in the lower right of the widget configuration panel to preview, reorder, or delete widgets.
       </li>
       <li>
-        Use the checkbox in the <strong>Options</strong> tab to publish or unpublish the page.
+        Use the checkbox in the <b>Options</b> tab to publish or unpublish the page.
       </li>
       <li>
         Visit the Spotlight <%= link_to 'documentation pages', 'https://github.com/projectblacklight/spotlight/wiki' %> to learn more about creating exhibit pages.

--- a/app/views/spotlight/contacts/_form.html.erb
+++ b/app/views/spotlight/contacts/_form.html.erb
@@ -9,7 +9,7 @@
   <%= f.fields_for :avatar, (@contact.avatar || @contact.build_avatar) do |af| %>
     <div data-cropper="<%= af.object.model_name.singular_route_key %>" data-form-prefix="<%= form_prefix(af) %>">
     <%= field_set_tag(t(:'.avatar.header')) do %>
-      <p class="instructions"><%= t(:'featured_images.form.crop_area.help', scope: [:spotlight], thing: 'contact photo') %></p>
+      <p class="instructions"><%= t(:'featured_images.form.crop_area.help_html', scope: [:spotlight], thing: 'contact photo') %></p>
 
       <div>
         <%= af.radio_button(:source, :remote, label: t(:'.source.remote.label')) %>

--- a/app/views/spotlight/feature_pages/_empty.html.erb
+++ b/app/views/spotlight/feature_pages/_empty.html.erb
@@ -4,19 +4,19 @@
 
     <ol>
       <li>
-        To add content to this page, click the Edit button above to enter Edit mode.
+        To add content to this page, select the Edit button above to enter edit mode.
       </li>
       <li>
-        In Edit mode, click the plus sign icon to display the widget selection panel. This panel displays a range of widgets, each of which adds a different type of content to the page.
+        In edit mode, select the plus sign icon to display the widget selection panel. This panel displays a range of widgets, each of which adds a different type of content to the page.
       </li>
       <li>
-        Select a widget to configure. Click <strong>Save changes</strong> when you're ready to add it to the page.
+        Select a widget to configure. Select <b>Save changes</b> when you're ready to add it to the page.
       </li>
       <li>
         Repeat the steps above to continue adding widgets to build out the page. To work more efficiently, you can configure multiple widgets before saving the page. Use the icons in the lower right of the widget configuration panel to preview, reorder, or delete widgets.
       </li>
       <li>
-        Note the <strong>Options</strong> and <strong>Thumbnail</strong> tabs at the top of the page in Edit mode. Options in these tabs enable you to publish or unpublish the page, turn on or off the page sidebar, and create a thumbnail image to represent the page.
+        Note the <b>Options</b> and <b>Thumbnail</b> tabs at the top of the page in edit mode. Options in these tabs enable you to publish or unpublish the page, turn on or off the page sidebar, and create a thumbnail image to represent the page.
       </li>
       <li>
         Visit the Spotlight <%= link_to 'documentation pages', 'https://github.com/projectblacklight/spotlight/wiki' %> to learn more about creating exhibit pages.

--- a/app/views/spotlight/featured_images/_form.html.erb
+++ b/app/views/spotlight/featured_images/_form.html.erb
@@ -30,7 +30,7 @@
   </div>
 <% end %>
 <%= field_set_tag(t(:'.source.remote.header')) do %>
-  <p class="instructions"><%= t(:'.crop_area.help', thing: crop_type) %></p>
+  <p class="instructions"><%= t(:'.crop_area.help_html', thing: crop_type) %></p>
   <%= iiif_cropper_tags f, initial_crop_selection: initial_crop_selection %>
 <% end %>
 </div>

--- a/app/views/spotlight/featured_images/_upload_form.html.erb
+++ b/app/views/spotlight/featured_images/_upload_form.html.erb
@@ -12,7 +12,7 @@
   </div>
 <% end %>
 <%= field_set_tag(t(:'.source.remote.header')) do %>
-  <p class="instructions"><%= t(:'.crop_area.help', thing: crop_type) %></p>
+  <p class="instructions"><%= t(:'.crop_area.help_html', thing: crop_type) %></p>
   <%= iiif_cropper_tags f, initial_crop_selection: initial_crop_selection %>
 <% end %>
 </div>

--- a/app/views/spotlight/home_pages/_empty.html.erb
+++ b/app/views/spotlight/home_pages/_empty.html.erb
@@ -20,11 +20,11 @@
       <% end %>
 
       <% if Spotlight::Engine.config.resource_partials.any? %>
-        <li>Add items to the exhibit. Go to the <%= link_to "Curation > Items", admin_exhibit_catalog_path(current_exhibit) %> page and click <strong>Add items</strong>. You can add items individually or in bulk via a CSV file.</li>
+        <li>Add items to the exhibit. Go to the <%= link_to "Curation > Items", admin_exhibit_catalog_path(current_exhibit) %> page and select <b>Add items</b>. You can add items individually or in bulk via a CSV file.</li>
       <% end %>
 
       <% if can? :update, current_exhibit.blacklight_configuration %>
-        <li>Use the other Curation pages, such as <%= link_to "Curation > Metadata", edit_exhibit_metadata_configuration_path(current_exhibit) %> and <%= link_to "Curation > Search", edit_exhibit_search_configuration_path(current_exhibit) %>, to customize the way various features are presented to exhibit visitors.</li>
+        <li>Use the other curation pages, such as <%= link_to "Curation > Metadata", edit_exhibit_metadata_configuration_path(current_exhibit) %> and <%= link_to "Curation > Search", edit_exhibit_search_configuration_path(current_exhibit) %>, to customize the way various features are presented to exhibit visitors.</li>
       <% end %>
 
       <li>Visit the Spotlight <%= link_to "documentation pages", "https://github.com/projectblacklight/spotlight/wiki" %> to learn how to add and edit feature pages, about pages, custom browse categories, and more.</li>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -196,7 +196,7 @@ en:
       edit:
         header: Appearance
         main_navigation:
-          help: Select the menu items you want to be displayed in the main navigation menu (menu items are only displayed when published pages exist for that item). Click a menu item to change its display label. Drag and drop a menu item to change their order in the menu.
+          help: Select the menu items you want to be displayed in the main navigation menu (menu items are only displayed when published pages exist for that item). Select a menu item to change its display label. Drag and drop a menu item to change their order in the menu.
           menu: Main menu
         site_masthead:
           heading: Exhibit masthead
@@ -440,7 +440,7 @@ en:
     exhibits_admin_invitation_mailer:
       invitation_instructions:
         accept: Accept invitation
-        accept_invitation: " You can accept this invitation by clicking the link below."
+        accept_invitation: You can accept this invitation by selecting the link below.
         hello: Hello!
         ignore: If you don't want to accept the invitation, please ignore this email. Your exhibits administrator account won't be created until you access the link above.
         someone_invited_you: The Exhibits Administrator has invited you to help manage exhibits.
@@ -451,7 +451,7 @@ en:
     featured_images:
       form:
         crop_area:
-          help: Adjust the image so that the rectangle contains the area you want to use as the %{thing}. Click "Save changes" to save the cropped area.
+          help_html: Adjust the image so that the rectangle contains the area you want to use as the %{thing}. Select <b>Save changes</b> to save the cropped area.
         non_iiif_alert_html: The image source must be a IIIF image. Contact your exhibits adminstrator or see the <a href="http://iiif.io">IIIF website</a> for more information about IIIF.
         source:
           exhibit:
@@ -464,7 +464,7 @@ en:
             label: Upload an image
       upload_form:
         crop_area:
-          help: Adjust the image so that the rectangle contains the area you want to use as the %{thing}. Click "Save changes" to save the cropped area.
+          help_html: Adjust the image so that the rectangle contains the area you want to use as the %{thing}. Select <b>Save changes</b> to save the cropped area.
         non_iiif_alert_html: The image source must be a IIIF image. Contact your exhibits adminstrator or see the <a href="http://iiif.io">IIIF website</a> for more information about IIIF.
         source:
           exhibit:
@@ -494,7 +494,7 @@ en:
         title: Your CSV file has just finished being processed.
     invitation_mailer:
       invitation_instructions:
-        accept_invitation: You can accept this invitation by clicking the link below.
+        accept_invitation: You can accept this invitation by selecting the link below.
         hello: Hello!
         ignore: If you don't want to accept the invitation, please ignore this email. Your account won't be created until you access the link above.
         someone_invited_you: The Exhibits Administrator has invited you to help work on the "%{exhibit_name}" exhibit.
@@ -513,7 +513,7 @@ en:
         field:
           label: Field name
         header: Metadata
-        instructions: Select metadata fields to display on each type of page. Click a field name to edit its display label. Drag and drop fields to specify the order in which they are displayed.
+        instructions: Select metadata fields to display on each type of page. Select a field name to edit its display label. Drag and drop fields to specify the order in which they are displayed.
         order_header: Display and Order Metadata Fields
         select_all: Select all
         view:
@@ -527,7 +527,7 @@ en:
         page_options: Options
         page_thumbnail: Thumbnail
         thumbnail:
-          help: You can select and crop an image to visually represent this page. It will be used as the thumbnail image if you include this page using the 'Highlight Featured Pages' widget.
+          help: You can select and crop an image to visually represent this page. It will be used as the thumbnail image if you include this page in the Pages widget.
         title_placeholder: Title
       index:
         about_pages:
@@ -660,7 +660,7 @@ en:
           one: "%{count} unique value"
           other: "%{count} unique values"
       facets:
-        help: If the sidebar is visible, users can use the facets shown in the sidebar to limit a search.  You can select the facets that are available for searching below. Click a facet field name to edit its display label. Drag and drop facets to specify the order they are displayed in the sidebar.
+        help: If the sidebar is visible, users can use the facets shown in the sidebar to limit a search.  You can select the facets that are available for searching below. Select a facet field name to edit its display label. Drag and drop facets to specify the order they are displayed in the sidebar.
         sort_by:
           count: Frequency
           index: Value
@@ -672,10 +672,10 @@ en:
           instructions: You can add custom search fields to supplement the search fields that are part of the default configuration.
         header: Field-based search
         help: If the search box is displayed, you can also enable field-based search. Field-based search adds a dropdown menu to your exhibit site's search box that provides the user with an option to restrict a search query to a single metadata field.
-        instructions: If enabled, you can select below the metadata fields that are available for searching. Click a field name to edit its display label.  Drag and drop fields to specify the order they are displayed in the search box dropdown menu.
+        instructions: If enabled, you can select below the metadata fields that are available for searching. Select a field name to edit its display label.  Drag and drop fields to specify the order they are displayed in the search box dropdown menu.
       sort:
         header: Sort fields
-        help: Select the fields you want to be available to users for sorting results. Click a field title to change its display label. Drag and drop fields to change their order in the sort dropdown menu. The field listed first is the default sort field.
+        help: Select the fields you want to be available to users for sorting results. Select a field title to change its display label. Drag and drop fields to change their order in the sort dropdown menu. The field listed first is the default sort field.
         keys:
           asc: ascending
           desc: descending
@@ -809,7 +809,7 @@ en:
           label: About Pages
         feature_pages:
           label: Feature Pages
-        help_html: Before exhibit visitors can view translated pages you must create, edit, and publish each page translation. When you create a translated page, a copy of the default language version of the page is made to serve as the initial translated page. You can then edit that translated page to replace the page title and any text fields with translated text. A translated page will not be visible to exhibit visitors until you publish it.  To replace a translated page with a current copy of the default language version of the page, use the <i>Recreate</i> action.
+        help_html: Before exhibit visitors can view translated pages you must create, edit, and publish each page translation. When you create a translated page, a copy of the default language version of the page is made to serve as the initial translated page. You can then edit that translated page to replace the page title and any text fields with translated text. A translated page will not be visible to exhibit visitors until you publish it.  To replace a translated page with a current copy of the default language version of the page, use the <b>Recreate</b> action.
         home_page:
           label: Home Page
         label: Pages


### PR DESCRIPTION
Goal of this PR is to make some text-related things more consistent in the UI.

I think all strings affected are in the curator admin side of things.

The primary changes are:

- Changed occurrences of "click" to "select" to make the wording less mouse-centric

- When referring to a specific button, wrapped the text referring to the button label in `<b>` (sometimes it was in double-quotes, sometimes not, and when it was wrapped in an element, we were using `<strong>` but `<b>` is the more appropriate element to use because we're not emphasizing the text for importance, just to distinguish it from the surrounding text).

## Before examples

<img width="922" alt="Screen Shot 2020-08-11 at 2 16 53 PM" src="https://user-images.githubusercontent.com/101482/89950486-8ba09100-dbde-11ea-9554-99f1b386d329.png">

---

<img width="853" alt="Screen Shot 2020-08-11 at 2 17 45 PM" src="https://user-images.githubusercontent.com/101482/89950500-95c28f80-dbde-11ea-9783-a310774537ca.png">

## After examples

<img width="922" alt="Screen Shot 2020-08-11 at 2 16 36 PM" src="https://user-images.githubusercontent.com/101482/89950522-a1ae5180-dbde-11ea-8b8d-c18d6ece241e.png">

---

<img width="853" alt="Screen Shot 2020-08-11 at 2 16 03 PM" src="https://user-images.githubusercontent.com/101482/89950536-a6730580-dbde-11ea-8bff-1f4c08d1d3d0.png">
