### PR TITLE
Improve styling of item tags on show and results pages

### DIFF
--- a/app/assets/stylesheets/spotlight/_catalog.scss
+++ b/app/assets/stylesheets/spotlight/_catalog.scss
@@ -122,14 +122,14 @@ form.edit_solr_document {
   margin-right: $spacer * 0.1;
 }
 
-#document {
-  dd.blacklight-exhibit_tags {
-    color: $body-bg;
-    line-height: 2em;
-  }
-
+#document,
+.document {
   .blacklight-exhibit_tags a {
     @extend .badge;
     @extend .badge-secondary;
+
+    &:not(:last-child) {
+      @extend .mr-2;
+    }
   }
 }


### PR DESCRIPTION
When multiple exhibit item tags are assigned to an item they currently display with no spacing between each other, and on the results pages the tags have no special styling. I'm guessing, but I suspect these might be styling regressions that were missed during the upgrade to Bootstrap 4.

This PR adds right-margin after each tag except the last one. It also removes some styling to assign font color, which I think is covered by the use of the Bootstrap `badge-secondary` class, and a line-height specification, which appears no longer needed for the correct line alignment. I don't think removing these should affect any existing implementation, unless there is an implementation that uses a dark color for their page backgrounds and they have reassigned the  `badge-secondary` class to a light background color, but I haven't seen any implementation that does that.

## Before: Show page

<img width="507" alt="Screen Shot 2020-08-21 at 1 38 08 PM" src="https://user-images.githubusercontent.com/101482/90935047-41c26280-e3b7-11ea-948a-b4d2d10499f8.png">

## Before: Results page

<img width="893" alt="Screen Shot 2020-08-21 at 1 37 22 PM" src="https://user-images.githubusercontent.com/101482/90935430-0aa08100-e3b8-11ea-8bd0-af3b7998e22c.png">

## After: Show page

<img width="507" alt="Screen Shot 2020-08-21 at 2 00 07 PM" src="https://user-images.githubusercontent.com/101482/90935454-17bd7000-e3b8-11ea-95a9-0706220d03e0.png">

## After: Results page

<img width="889" alt="Screen Shot 2020-08-21 at 2 00 22 PM" src="https://user-images.githubusercontent.com/101482/90935475-23109b80-e3b8-11ea-9733-59598bde6157.png">
