### PR TITLE
Adjust responsive font sizing for browse/pages widget

### DIFF
--- a/app/assets/stylesheets/spotlight/_featured_browse_categories_block.scss
+++ b/app/assets/stylesheets/spotlight/_featured_browse_categories_block.scss
@@ -70,10 +70,22 @@ $xl-sidebar-five-tile-width: ($container-xl-sidebar / 5) - $tile-margin;
   }
 
   .category-title {
-    font-size: $font-size-lg;
+    font-size: $h4-font-size;
     line-height: 1.2;
     margin: 0;
     padding: $spacer / 4;
+
+    @media (min-width: breakpoint-min("sm")) {
+      font-size: 1.125rem;
+    }
+
+    @media (min-width: breakpoint-min("md")) {
+      font-size: $h5-font-size;
+    }
+
+    @media (min-width: breakpoint-min("lg")) {
+      font-size: $h4-font-size;
+    }
   }
 
   .category-subtitle {
@@ -83,6 +95,10 @@ $xl-sidebar-five-tile-width: ($container-xl-sidebar / 5) - $tile-margin;
   .item-count {
     font-size: $font-size-base;
     text-transform: uppercase;
+
+    @media (min-width: breakpoint-min("sm")) and (max-width: breakpoint-min("lg")) {
+      font-size: $font-size-sm;
+    }
   }
 }
 
@@ -185,6 +201,23 @@ $xl-sidebar-five-tile-width: ($container-xl-sidebar / 5) - $tile-margin;
       @media (min-width: breakpoint-min("xl")) {
         width: $xl-five-tile-width;
         height: $xl-five-tile-width * $aspect-ratio-factor-4x3;
+      }
+    }
+  }
+}
+
+[data-sidebar="true"] {
+  // Font size smaller at "lg" breakpoint only when there is a sidebar
+  .browse-category {
+    .category-title {
+      @media (min-width: breakpoint-min("lg")) and (max-width: breakpoint-min("xl")) {
+        font-size: $h5-font-size;
+      }
+    }
+
+    .item-count {
+      @media (min-width: breakpoint-min("lg")) and (max-width: breakpoint-min("xl")) {
+        font-size: $font-size-sm;
       }
     }
   }


### PR DESCRIPTION
This PR updates the font sizing for the text displayed on the tiles used in the Browse Categories and Pages widgets. Currently the same font size is used on this widgets, despite the very different tile sizes that are displayed depending on the user's viewport width and whether the page is displaying a sidebar or not. The current font size is usually okay, but in certain cases it is arguably too large, as in the `sm` viewport example below (the problem is more clear than below when the titles are longer than in my example):

<img width="553" alt="Screen Shot 2020-09-22 at 2 42 02 PM" src="https://user-images.githubusercontent.com/101482/93940988-5eb5c280-fce2-11ea-8a0a-5beceaa1f794.png">

This PR adds some adjustments to the font size, taking into account the tile size at different viewports widths and the difference in content area width at the `lg` viewport when there is or isn't a sidebar displayed.  Some examples of how things look with this PR:

<img width="1156" alt="Screen Shot 2020-09-22 at 2 37 16 PM" src="https://user-images.githubusercontent.com/101482/93941138-a4728b00-fce2-11ea-9565-952ea3e09eaa.png">

---

<img width="980" alt="Screen Shot 2020-09-22 at 2 38 12 PM" src="https://user-images.githubusercontent.com/101482/93941158-ab010280-fce2-11ea-87de-add40cde5007.png">

---

<img width="980" alt="Screen Shot 2020-09-22 at 2 38 58 PM" src="https://user-images.githubusercontent.com/101482/93941170-b0f6e380-fce2-11ea-840d-45c7ffd011f1.png">

---

<img width="553" alt="Screen Shot 2020-09-22 at 2 39 36 PM" src="https://user-images.githubusercontent.com/101482/93941179-b5230100-fce2-11ea-86f3-3220b2253ec4.png">
