### PR TITLE
Change label to Remove from exhibit

### DIFF
--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -46,7 +46,7 @@ en:
         create: Add new field
       spotlight/role:
         create: Add a new user
-        destroy: Remove from site
+        destroy: Remove from exhibit
       spotlight/search:
         destroy: Delete
         edit_long: Edit this saved search


### PR DESCRIPTION
Label `helpers.action.spotlight/role.destroy` is set to `Remove from site` but is used on the Exhibit Dashboard -> Users list when the action icon is clicked to allow a user to be removed from having a role in the exhibit.  I could not find it used anywhere else to remove a user from the entire site.

The action that occurs when the button is clicked is the user is removed from the current exhibit.  It has no impact on the user’s roles in other exhibits or their access to the site.  The current label is confusing.