### PR TITLE
Change breadcrumb truncation to a css strategy so things like HTML...

### DIFF
--- a/app/assets/stylesheets/spotlight/_breadcrumbs.scss
+++ b/app/assets/stylesheets/spotlight/_breadcrumbs.scss
@@ -1,0 +1,8 @@
+.breadcrumb-item {
+  .truncated-value {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    width: 30ex;
+  }
+}

--- a/app/assets/stylesheets/spotlight/_spotlight.scss
+++ b/app/assets/stylesheets/spotlight/_spotlight.scss
@@ -5,6 +5,7 @@
 @import "spotlight/sir-trevor_overrides";
 @import "spotlight/attachments";
 @import "spotlight/pages";
+@import "spotlight/breadcrumbs";
 @import "spotlight/browse";
 @import "spotlight/header";
 @import "spotlight/footer";

--- a/app/builders/spotlight/bootstrap_breadcrumbs_builder.rb
+++ b/app/builders/spotlight/bootstrap_breadcrumbs_builder.rb
@@ -31,8 +31,7 @@ module Spotlight
     private
 
     def element_label(element)
-      label = compute_name(element)
-      @context.truncate(label, escape: !label.html_safe?, length: 30, separator: ' ')
+      @context.content_tag(:span, class: 'truncated-value') { compute_name(element) }
     end
   end
 end


### PR DESCRIPTION
...document titles are supported (and don't break the html response)

Connected to sul-dlss/dlme#1055

The titles in the record below are wrapped in a `<bdi>` element, which breaks using standard rails `truncate`.

## Before
<img width="520" alt="before" src="https://user-images.githubusercontent.com/96776/104391521-e1ae9300-54f4-11eb-98be-af2b3b3066cc.png">


## After
<img width="492" alt="after" src="https://user-images.githubusercontent.com/96776/104391534-e96e3780-54f4-11eb-8f7b-bfce0f6c3361.png">

