### PR TITLE
Add Spotlight::Group and Spotlight::GroupMember models

### DIFF
--- a/app/controllers/spotlight/browse_controller.rb
+++ b/app/controllers/spotlight/browse_controller.rb
@@ -9,7 +9,8 @@ module Spotlight
     include Spotlight::Catalog
     include Blacklight::Facet
 
-    load_and_authorize_resource :search, except: :index, through: :exhibit, parent: false
+    load_resource :group, through: :exhibit
+    load_and_authorize_resource :search, through: %i[group exhibit], parent: false
     before_action :attach_breadcrumbs
     before_action :attach_search_breadcrumb, only: :show
     record_search_parameters only: :show
@@ -23,7 +24,8 @@ module Spotlight
     end
 
     def index
-      @searches = @exhibit.searches.published
+      @groups = @exhibit.groups.published
+      @searches = @searches.published
     end
 
     def show
@@ -66,10 +68,11 @@ module Spotlight
     def attach_breadcrumbs
       add_breadcrumb t(:'spotlight.curation.nav.home', title: @exhibit.title), @exhibit
       add_breadcrumb(@exhibit.main_navigations.browse.label_or_default, exhibit_browse_index_path(@exhibit))
+      add_breadcrumb(@group.title, exhibit_browse_groups_path(@exhibit, @group)) if @group.present?
     end
 
     def attach_search_breadcrumb
-      add_breadcrumb @search.full_title, exhibit_browse_path(@exhibit, @search)
+      add_breadcrumb @search.full_title, (@group.present? ? exhibit_browse_group_path(@exhibit, @group, @search) : exhibit_browse_path(@exhibit, @search))
     end
 
     def _prefixes

--- a/app/models/spotlight/exhibit.rb
+++ b/app/models/spotlight/exhibit.rb
@@ -4,6 +4,7 @@ require 'mail'
 module Spotlight
   ##
   # Spotlight exhibit
+  # rubocop:disable Metrics/ClassLength
   class Exhibit < ActiveRecord::Base
     class_attribute :themes_selector
     include Spotlight::ExhibitAnalytics
@@ -162,4 +163,5 @@ module Spotlight
       errors.add :slug, *errors.delete(:friendly_id) if errors[:friendly_id].present?
     end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/app/models/spotlight/exhibit.rb
+++ b/app/models/spotlight/exhibit.rb
@@ -55,6 +55,7 @@ module Spotlight
     has_many :custom_search_fields, dependent: :delete_all
 
     has_many :feature_pages, -> { for_default_locale }, extend: FriendlyId::FinderMethods
+    has_many :groups, dependent: :delete_all
     has_many :main_navigations, dependent: :delete_all
     has_many :reindexing_log_entries, dependent: :destroy
     has_many :resources

--- a/app/models/spotlight/group.rb
+++ b/app/models/spotlight/group.rb
@@ -14,7 +14,7 @@ module Spotlight
     belongs_to :exhibit
     has_many :group_members
     has_many :searches, through: :group_members, source: :member, source_type: 'Spotlight::Search'
-
+    scope :published, -> { where(published: true) }
     accepts_nested_attributes_for :group_members
     accepts_nested_attributes_for :searches
   end

--- a/app/models/spotlight/group.rb
+++ b/app/models/spotlight/group.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Spotlight
+  ##
+  # Exhibit saved searches
+  class Group < ActiveRecord::Base
+    include Spotlight::Translatables
+
+    extend FriendlyId
+    friendly_id :title, use: %i[slugged scoped finders history], scope: [:exhibit]
+    translates :title
+
+    self.table_name = 'spotlight_groups'
+    belongs_to :exhibit
+    has_many :group_members
+    has_many :searches, through: :group_members, source: :member, source_type: 'Spotlight::Search'
+
+    accepts_nested_attributes_for :group_members
+    accepts_nested_attributes_for :searches
+  end
+end

--- a/app/models/spotlight/group_member.rb
+++ b/app/models/spotlight/group_member.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Spotlight
+  ##
+  # Exhibit saved searches
+  class GroupMember < ActiveRecord::Base
+    self.table_name = 'spotlight_groups_members'
+    belongs_to :group
+    belongs_to :member, polymorphic: true
+  end
+end

--- a/app/models/spotlight/search.rb
+++ b/app/models/spotlight/search.rb
@@ -12,6 +12,10 @@ module Spotlight
 
     self.table_name = 'spotlight_searches'
     belongs_to :exhibit
+    has_many :group_memberships, class_name: 'Spotlight::GroupMember', as: :member, dependent: :delete_all
+    has_many :groups, through: :group_memberships
+    accepts_nested_attributes_for :group_memberships
+    accepts_nested_attributes_for :groups
     serialize :query_params, Hash
     default_scope { order('weight ASC') }
     scope :published, -> { where(published: true) }

--- a/app/views/spotlight/browse/_search.html.erb
+++ b/app/views/spotlight/browse/_search.html.erb
@@ -1,6 +1,6 @@
 <%= cache [@exhibit, search, I18n.locale] do %>
   <div class="col-md-4 col-12 category">
-    <%= link_to spotlight.exhibit_browse_path(@exhibit, search) do %>
+    <%= link_to @group.present? ? spotlight.exhibit_browse_group_path(@exhibit, @group, search) : spotlight.exhibit_browse_path(@exhibit, search) do %>
       <div class="image-overlay">
         <%= image_tag(search.thumbnail_image_url || 'spotlight/default_browse_thumbnail.jpg', class: 'img-responsive', alt: '') %>
         <div class="text-overlay">

--- a/app/views/spotlight/browse/index.html.erb
+++ b/app/views/spotlight/browse/index.html.erb
@@ -2,6 +2,19 @@
 <% set_html_page_title(title) %>
 <h1 class="sr-only"><%= title %></h1>
 
+<% if @groups.any? # active %>
+  <ul class="browse-group-navigation nav nav-pills justify-content-center">
+    <li class="nav-item">
+      <%= link_to t('spotlight.exhibits.groups.all'), exhibit_browse_index_path(current_exhibit), class: "nav-link #{'active' if @group.blank?}" %>
+    </li>
+    <% @groups.each do |group| %>
+      <li class="nav-item">
+        <%= link_to group.title, exhibit_browse_groups_path(current_exhibit, group), class: "nav-link #{'active' if @group.present? && @group.id == group.id}" %>
+      </li>
+    <% end %>
+  </ul>
+<% end %>
+
 <div class="browse-landing row">
   <%= render collection: @searches, partial: 'spotlight/browse/search' %>
 </div>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -403,6 +403,8 @@ en:
           published:
             help_block: ''
         uneditable_non_default_language: This field is not editable in the current language. Switch to the default language to edit it.
+      groups:
+        all: All
       import:
         button: Import data
         heading: Import data

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -100,6 +100,9 @@ Spotlight::Engine.routes.draw do
       end
     end
     resources :browse, only: %i[index show]
+    get 'browse/group/:group_id', to: 'browse#index', as: 'browse_groups'
+    get 'browse/group/:group_id/:id', to: 'browse#show', as: 'browse_group'
+
     resources :tags, only: %i[index destroy]
 
     resources :contacts, only: %i[edit update destroy]

--- a/db/migrate/20210113092223_create_spotlight_groups.rb
+++ b/db/migrate/20210113092223_create_spotlight_groups.rb
@@ -1,0 +1,23 @@
+class CreateSpotlightGroups < ActiveRecord::Migration[5.2]
+  def self.up
+    create_table :spotlight_groups do |t|
+      t.string     :slug
+      t.text       :title
+      t.references :exhibit
+      t.integer    :weight, default: 50
+      t.boolean    :published
+
+      t.timestamps
+    end
+
+    create_table :spotlight_groups_members, id: false do |t|
+      t.references :group
+      t.references :member, polymorphic: true
+    end
+  end
+
+  def self.down
+    drop_table :spotlight_groups
+    drop_table :spotlight_groups_members
+  end
+end

--- a/spec/factories/group.rb
+++ b/spec/factories/group.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :group, class: 'Spotlight::Group' do
+    exhibit
+
+    factory :group_with_searches do
+      transient do
+        searches_count { 5 }
+      end
+    end
+
+    after(:create) do |group, evaluator|
+      create_list(:search, evaluator.searches_count, groups: [group]) if evaluator.respond_to?(:searches_count)
+    end
+  end
+end

--- a/spec/factories/searches.rb
+++ b/spec/factories/searches.rb
@@ -7,6 +7,16 @@ FactoryBot.define do
     sequence(:slug) { |n| "Search#{n}" }
 
     after(:build) { |search| search.thumbnail = FactoryBot.create(:featured_image) }
+
+    factory :search_with_groups do
+      transient do
+        groups_count { 2 }
+      end
+    end
+
+    after(:create) do |search, evaluator|
+      create_list(:group, evaluator.groups_count, searches: [search]) if evaluator.respond_to?(:groups_count)
+    end
   end
 
   factory :published_search, parent: :search do

--- a/spec/features/browse_category_navigation_spec.rb
+++ b/spec/features/browse_category_navigation_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+describe 'Browse pages' do
+  let(:exhibit) { FactoryBot.create(:exhibit) }
+  let!(:search) { FactoryBot.create(:search, title: 'Some Saved Search', exhibit: exhibit, published: true) }
+  let!(:search_2) { FactoryBot.create(:search, title: 'Some Other Saved Search', exhibit: exhibit, published: true) }
+  let!(:group) { FactoryBot.create(:group, title: 'Awesome group', exhibit: exhibit, published: true, searches: [search]) }
+
+  describe 'landing page' do
+    before do
+      visit spotlight.exhibit_browse_index_path(exhibit)
+    end
+
+    it 'displays all categories and tabs for each group' do
+      within '.browse-group-navigation' do
+        expect(page).to have_css 'li.nav-item a.nav-link.active', text: 'All'
+        expect(page).to have_css 'li.nav-item a.nav-link', count: exhibit.groups.count + 1
+      end
+      within '.browse-landing' do
+        expect(page).to have_css '.category', count: 2
+      end
+    end
+
+    it 'filters browse categories when navigated' do
+      within '.browse-group-navigation' do
+        click_link group.title
+        expect(page).to have_css 'li.nav-item a.nav-link.active', text: group.title
+      end
+      within '.browse-landing' do
+        expect(page).to have_css '.category', count: 1
+      end
+    end
+
+    it 'clicking through from the context of a category provides the breadcrums' do
+      within '.browse-group-navigation' do
+        click_link group.title
+        expect(page).to have_css 'li.nav-item a.nav-link.active', text: group.title
+      end
+      click_link 'Some Saved Search'
+      expect(page).to have_css 'ul.breadcrumb li.breadcrumb-item', count: 4
+      expect(page).to have_css 'li.breadcrumb-item', text: 'Awesome group'
+    end
+  end
+end

--- a/spec/models/spotlight/group_spec.rb
+++ b/spec/models/spotlight/group_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+describe Spotlight::Group, type: :model do
+  let(:exhibit) { FactoryBot.create(:exhibit) }
+
+  describe '#searches' do
+    let(:group) { FactoryBot.create(:group_with_searches, exhibit: exhibit, searches_count: 4) }
+
+    it do
+      expect(group.searches.count).to eq 4
+    end
+
+    it do
+      group.searches.all do |search|
+        expect(search).to be_an Spotlight::Search
+      end
+    end
+  end
+end

--- a/spec/models/spotlight/search_spec.rb
+++ b/spec/models/spotlight/search_spec.rb
@@ -98,4 +98,18 @@ describe Spotlight::Search, type: :model do
       expect(search_params).to include user_params
     end
   end
+
+  describe '#groups' do
+    let(:search) { FactoryBot.create(:search_with_groups, groups_count: 3) }
+
+    it do
+      expect(search.groups.count).to eq 3
+    end
+
+    it do
+      search.groups.all do |group|
+        expect(group).to be_an Spotlight::Group
+      end
+    end
+  end
 end

--- a/spec/views/spotlight/browse/index.html.erb_spec.rb
+++ b/spec/views/spotlight/browse/index.html.erb_spec.rb
@@ -7,11 +7,13 @@ describe 'spotlight/browse/index', type: :view do
   before { allow(view).to receive(:current_exhibit).and_return(search.exhibit) }
 
   it 'has a title' do
+    assign :groups, []
     render
     expect(response).to have_selector 'h1', text: 'Browse'
   end
 
   it 'renders the collection of searches' do
+    assign :groups, []
     assign :searches, [search, another_search]
     stub_template 'spotlight/browse/_search.html.erb' => '<%= search.id %> <br/>'
     render


### PR DESCRIPTION
Part of #2562 

This sets up models and associations to "group" browse categories. The group modeling sets us up for potential polymorphic membership (or, more likely, model re-use for grouping other types of things), but Rails doesn't care for polymorphic `has_many` relations, so we're stuck with the database model being ready for it but with Rails accessors that need to be targeted at specific models 🤷‍♂️ 

For future compatibility, the join table for group members is made explicit in anticipation of emerging or future requirements  (perhaps ordering group members or other features that require some metadata on the membership relation).

TODO:
- [x] model tests
- [x] adding the user-facing piece #2567 to validate the modeling