### PR TITLE
Update the gallery classes under the browse controller to have 4 …

### DIFF
--- a/app/controllers/spotlight/browse_controller.rb
+++ b/app/controllers/spotlight/browse_controller.rb
@@ -20,6 +20,7 @@ module Spotlight
 
     before_action do
       blacklight_config.track_search_session = false
+      blacklight_config.view.gallery.classes = 'row-cols-2 row-cols-md-4'
     end
 
     def index


### PR DESCRIPTION
…columns at the md breakpoint.

Closes #2595 

I don't think that we allow browse categories to be faceted (or display a sidebar) so I think this can be done unconditionally in the controller

I was looking into doing something similar for search results when rendered inside sir-trevor blocks, however; there seems to be some other issues surrounding that and I don't want to hold this change up.