### PR TITLE
Inject classes to the gallery view to allow for more columns to …

### DIFF
--- a/app/controllers/spotlight/pages_controller.rb
+++ b/app/controllers/spotlight/pages_controller.rb
@@ -19,6 +19,10 @@ module Spotlight
 
     helper_method :get_search_results, :search_results, :fetch, :page_collection_name, :presenter
 
+    before_action do
+      blacklight_config.view.gallery.classes = 'row-cols-2 row-cols-md-4' unless @page&.display_sidebar
+    end
+
     # GET /exhibits/1/pages
     def index
       # set up a model the inline "add a new page" form

--- a/spec/controllers/spotlight/feature_pages_controller_spec.rb
+++ b/spec/controllers/spotlight/feature_pages_controller_spec.rb
@@ -92,6 +92,17 @@ describe Spotlight::FeaturePagesController, type: :controller, versioning: true 
           expect(response).to redirect_to(exhibit_feature_page_path(exhibit, page_es))
         end
       end
+
+      context 'when the sidebar is set to not display' do
+        let(:page) { FactoryBot.create(:feature_page, exhibit: exhibit, published: true) }
+
+        before { page.update(display_sidebar: false) }
+
+        it 'injects custom classes into the gallery view' do
+          get :show, params: { exhibit_id: exhibit.id, id: page.id }
+          expect(assigns(:exhibit).blacklight_config.view.gallery.classes).to eq 'row-cols-2 row-cols-md-4'
+        end
+      end
     end
 
     describe 'GET new' do


### PR DESCRIPTION
…display when no sidebar is present on a Spotlight::Page.

This gets us more in line with the gallery display column changes for browse categories updated in #2595

Note that this only affects pages who configure their sidebar to not be displayed (and have a search result widget with a gallery view added to the page)

## Before
<img width="747" alt="fp-gallery-before" src="https://user-images.githubusercontent.com/96776/105254083-a126c900-5b35-11eb-87c4-1e800a4e3078.png">

## After
<img width="726" alt="fp-gallery-after" src="https://user-images.githubusercontent.com/96776/105254085-a257f600-5b35-11eb-82d4-ad9d60e881b8.png">
