### PR TITLE
Fixes #2597 by associating BrowseCategories with Groups

### DIFF
--- a/app/controllers/spotlight/searches_controller.rb
+++ b/app/controllers/spotlight/searches_controller.rb
@@ -50,6 +50,7 @@ module Spotlight
     end
 
     def edit
+      @groups = @exhibit.groups
       add_breadcrumb @search.full_title, edit_exhibit_search_path(@search.exhibit, @search)
       @exhibit = @search.exhibit
     end
@@ -109,6 +110,7 @@ module Spotlight
         :long_description,
         :search_box,
         :default_index_view_type,
+        group_ids: [],
         masthead_attributes: featured_image_params,
         thumbnail_attributes: featured_image_params
       )

--- a/app/views/spotlight/searches/_form.html.erb
+++ b/app/views/spotlight/searches/_form.html.erb
@@ -17,6 +17,10 @@
       </li>
 
       <li role="presentation" class="nav-item">
+        <a href="#search-group" aria-controls="search-group" role="tab" data-toggle="tab" class="nav-link"><%= t(:'.search_group') %></a>
+      </li>
+
+      <li role="presentation" class="nav-item">
         <a href="#search-masthead" aria-controls="search-masthead" role="tab" data-toggle="tab" class="nav-link"><%= t(:'.search_masthead') %></a>
       </li>
 
@@ -48,6 +52,14 @@
               </div>
             </div>
           </div>
+        <% end %>
+      </div>
+      <div role="tabpanel" class="tab-pane" id="search-group">
+        <% if @groups.present? %>
+          <p class="instructions"><%= t(:'.group.help') %></p>
+          <%= f.collection_check_boxes(:group_ids, @groups, :id, :title, hide_label: true) %>
+        <% else %>
+          <p class="instructions"><%= t(:'.group.help_no_groups') %></p>
         <% end %>
       </div>
       <div role="tabpanel" class="tab-pane" id="search-masthead">

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -699,6 +699,9 @@ en:
         title: Curation - browse
       form:
         default_index_view_type: Default view
+        group:
+          help: You can add this browse category to any number of browse groups. When you add a browse category to a group it will be displayed when an exhibit visitor selects that browse group’s filter button on the Browse landing page.
+          help_no_groups: You cannot add this browse category to a browse group because no browse groups have been created. To create a browse group, use the Browse groups tab on the Curation > Browse page.
         masthead:
           help: You can select and crop an image to use as a browse category-specific masthead, instead of the default site masthead, for this browse category's detail page.
           help_secondary: To create a browse category-specific masthead, you should use an image that is at least 120 pixels tall and 1200 pixels wide. For best results use an image at least 1800 pixels wide. You can crop larger images using the cropping tool below.
@@ -708,6 +711,7 @@ en:
           help_block: Displays a search box that enables users to search within the browse category results
           label: Search box
         search_description: Description
+        search_group: Group
         search_masthead: Masthead
         search_thumbnail: Thumbnail
         thumbnail:

--- a/spec/features/browse_category_admin_spec.rb
+++ b/spec/features/browse_category_admin_spec.rb
@@ -48,6 +48,38 @@ describe 'Browse Category Administration', type: :feature do
       end
     end
 
+    describe 'with a group present' do
+      let!(:group) { FactoryBot.create(:group, exhibit: exhibit, title: 'Good group') }
+
+      it 'enables group selection' do
+        visit spotlight.edit_exhibit_search_path(exhibit, search)
+        click_link 'Group'
+        expect(page).to have_content 'You can add this browse category'
+
+        within '#search-group' do
+          expect(find('input[type="checkbox"]')).not_to be_checked
+          check 'Good group'
+        end
+
+        click_button 'Save changes'
+        expect(page).to have_content('The search was successfully updated.')
+        visit spotlight.edit_exhibit_search_path(exhibit, search)
+        click_link 'Group'
+
+        within '#search-group' do
+          expect(find('input[type="checkbox"]')).to be_checked
+        end
+      end
+    end
+
+    describe 'without a group present' do
+      it 'displays no group help text' do
+        visit spotlight.edit_exhibit_search_path(exhibit, search)
+        click_link 'Group'
+        expect(page).to have_content 'You cannot add this browse category'
+      end
+    end
+
     it 'attaches a masthead image' do
       visit spotlight.edit_exhibit_search_path exhibit, search
 


### PR DESCRIPTION

## No groups present
![Screen Shot 2021-01-22 at 7 34 32 AM](https://user-images.githubusercontent.com/1656824/105503839-4e0f5c00-5c84-11eb-9011-bc2843a6dda7.png)

## Groups are present
![Kapture 2021-01-22 at 07 35 32](https://user-images.githubusercontent.com/1656824/105503976-77c88300-5c84-11eb-965e-a75f1a932f5d.gif)
