### PR TITLE
Adds the ability to provide curator translations to Browse Groups

### DIFF
--- a/app/views/spotlight/translations/_groups.html.erb
+++ b/app/views/spotlight/translations/_groups.html.erb
@@ -1,0 +1,34 @@
+<div role="tabpanel" class="tab-pane <%= 'active' if @tab == 'groups' %>" id="groups">
+  <%= bootstrap_form_for current_exhibit, url: spotlight.exhibit_translations_path(current_exhibit), layout: :horizontal do |f| %>
+    <% # Add hidden fields for the language and tab so the redirect knows how to come back here %>
+    <%= hidden_field_tag :language, @language %>
+    <%= hidden_field_tag :tab, 'groups' %>
+
+    <% current_exhibit.groups.each do |group| %>
+      <% title_translation = Translation.find_or_initialize_by(exhibit: current_exhibit, key: "#{group.slug}.title", locale: @language) %>
+      <%= f.fields_for :translations, title_translation do |translation_fields| %>
+        <%= translation_fields.hidden_field :key %>
+        <%= translation_fields.hidden_field :locale %>
+        <div data-translation-progress-item="true" class="row form-group browse-group-title">
+          <%= translation_fields.label :value, group[:title], class: 'col-form-label col-12 col-sm-2' %>
+          <div class="col-11 col-sm-9">
+            <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
+          </div>
+          <div class="col-1">
+            <% if title_translation.value.present? %>
+              <span data-translation-present="true">
+                <%= blacklight_icon('check', classes: 'translation-complete') %>
+              </span>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
+
+    <div class="form-actions">
+      <div class="primary-actions">
+        <%= f.submit nil, class: 'btn btn-primary' %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/spotlight/translations/edit.html.erb
+++ b/app/views/spotlight/translations/edit.html.erb
@@ -42,6 +42,11 @@
         </a>
       </li>
       <li class="nav-item">
+        <a href="#groups" class="nav-link <%= 'active' if @tab == 'groups' %>" aria-controls="groups" role="tab" data-toggle="tab" data-behavior="translation-progress">
+          <%= t('spotlight.translations.groups.label') %> <span class="badge"></span>
+        </a>
+      </li>
+      <li class="nav-item">
         <a href="#pages" class="nav-link <%= 'active' if @tab == 'pages' %>" aria-controls="pages" role="tab" data-toggle="tab" data-behavior="translation-progress">
           <%= t('spotlight.translations.pages.label') %> <span class="badge"></span>
         </a>
@@ -54,6 +59,7 @@
       <%= render 'search_fields' %>
       <%= render 'browse_categories' %>
       <%= render 'pages' %>
+      <%= render 'groups' %>
     </div>
   </div>
 </div>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -810,6 +810,8 @@ en:
           curated_features: Curated features
           home: Home
           label: Main menu
+      groups:
+        label: Browse groups
       import:
         description: You can import and export Rails-based YAML files containing the translated label values for the currently selected language for use in internationalization tools such as Transifex and i18n-tools. This feature does not include importing or exporting translations for Pages.
         export_current_locale: Export %{language}

--- a/spec/features/exhibits/translation_editing_spec.rb
+++ b/spec/features/exhibits/translation_editing_spec.rb
@@ -378,6 +378,55 @@ describe 'Translation editing', type: :feature do
     end
   end
 
+  describe 'Browse groups' do
+    before do
+      FactoryBot.create(:group, exhibit: exhibit, title: 'Browse Group 1')
+      FactoryBot.create(:group, exhibit: exhibit, title: 'Browse Group 2')
+
+      visit spotlight.edit_exhibit_translations_path(exhibit, language: 'fr')
+    end
+
+    it 'has a title browse group' do
+      within '#groups' do
+        expect(page).to have_css('input[type="text"]', count: 2)
+
+        expect(page).to have_field 'Browse Group 1'
+        expect(page).to have_field 'Browse Group 2'
+      end
+    end
+
+    it 'redirects to the same form tab' do
+      click_link 'Browse categories'
+      within('#groups', visible: true) do
+        fill_in 'Browse Group 1', with: 'parcourir le groupe 1'
+        click_button 'Save changes'
+      end
+
+      expect(page).to have_css '.nav-pills .nav-link.active', text: 'French'
+      expect(page).to have_css '.nav-tabs .nav-link.active', text: 'Browse groups'
+    end
+
+    it 'persists changes', js: true do
+      click_link 'Browse groups'
+
+      within('#groups', visible: true) do
+        fill_in 'Browse Group 1', with: 'parcourir le groupe 1'
+
+        click_button 'Save changes'
+      end
+
+      expect(page).to have_css('.flash_messages', text: 'The exhibit was successfully updated.')
+
+      expect(exhibit.groups.first.title).to eq 'Browse Group 1'
+
+      I18n.locale = :fr
+      Translation.current_exhibit = exhibit
+      expect(exhibit.groups.first.title).to eq 'parcourir le groupe 1'
+      I18n.locale = I18n.default_locale
+      Translation.current_exhibit = nil
+    end
+  end
+
   describe 'home page translation table entry' do
     let(:feature_page) { FactoryBot.create(:feature_page, exhibit: exhibit) }
     let(:about_page) { FactoryBot.create(:about_page, exhibit: exhibit) }


### PR DESCRIPTION
Not specified yet in a ticket I could find, but provides a similar interface to Browse Categories.

![Screen Shot 2021-01-27 at 6 21 43 AM](https://user-images.githubusercontent.com/1656824/105996861-234c4b80-6068-11eb-9250-e46965938815.png)

![Kapture 2021-01-27 at 06 13 18](https://user-images.githubusercontent.com/1656824/105996879-28a99600-6068-11eb-8f3e-5d36f671b05e.gif)
