### PR TITLE
Update the i18n for the Spotlight::Search model name to …

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -39,6 +39,7 @@ ignore_unused:
   - activerecord.attributes.spotlight/masthead.display # app/views/spotlight/appearances/edit.html.erb
   - activerecord.attributes.spotlight/custom_field.is_multiple # app/views/spotlight/custom_fields/_form.html.erb
   - activerecord.attributes.spotlight/custom_search_field.field # app/views/spotlight/custom_search_fields/_form.html.erb
+  - activerecord.models.spotlight/search # Used in flash messages around the app to rename Search to Browse category
   - helpers.label.spotlight/filter.{field,value} # app/views/spotlight/filters/_form.html.erb
   - spotlight.catalog.admin.{title,header} # app/helpers/spotlight/title_helper.rb
   - spotlight.{contacts,pages,searches}.edit.{title,header} # app/helpers/spotlight/title_helper.rb

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -24,6 +24,7 @@ en:
     models:
       spotlight:
         page: Page
+      spotlight/search: Browse category
   cancel: Cancel
   drag: Drag
   helpers:

--- a/spec/controllers/spotlight/searches_controller_spec.rb
+++ b/spec/controllers/spotlight/searches_controller_spec.rb
@@ -41,7 +41,7 @@ describe Spotlight::SearchesController, type: :controller do
       request.env['HTTP_REFERER'] = '/referring_url'
       post :create, params: { 'search' => { 'title' => 'A bunch of maps' }, 'f' => { 'genre_ssim' => ['map'] }, exhibit_id: exhibit }
       expect(response).to redirect_to '/referring_url'
-      expect(flash[:notice]).to eq 'The search was created.'
+      expect(flash[:notice]).to eq 'The browse category was created.'
       expect(assigns[:search].title).to eq 'A bunch of maps'
       expect(assigns[:search].query_params).to eq('f' => { 'genre_ssim' => ['map'] })
     end
@@ -162,7 +162,7 @@ describe Spotlight::SearchesController, type: :controller do
           delete :destroy, params: { id: search, exhibit_id: search.exhibit }
         end.to change { Spotlight::Search.count }.by(-1)
         expect(response).to redirect_to exhibit_searches_path(search.exhibit)
-        expect(flash[:alert]).to eq 'The search was deleted.'
+        expect(flash[:alert]).to eq 'The browse category was deleted.'
       end
     end
 
@@ -188,7 +188,7 @@ describe Spotlight::SearchesController, type: :controller do
         expect(search2.reload.published).to be_falsey
         expect(search3.reload.published).to be_truthy # should remain untouched since it wasn't present
         expect(response).to redirect_to 'http://example.com'
-        expect(flash[:notice]).to eq 'Searches were successfully updated.'
+        expect(flash[:notice]).to eq 'Browse categories were successfully updated.'
       end
     end
   end

--- a/spec/features/browse_category_admin_spec.rb
+++ b/spec/features/browse_category_admin_spec.rb
@@ -62,7 +62,7 @@ describe 'Browse Category Administration', type: :feature do
         end
 
         click_button 'Save changes'
-        expect(page).to have_content('The search was successfully updated.')
+        expect(page).to have_content('The browse category was successfully updated.')
         visit spotlight.edit_exhibit_search_path(exhibit, search)
         click_link 'Group'
 
@@ -95,7 +95,7 @@ describe 'Browse Category Administration', type: :feature do
 
       click_button 'Save changes'
 
-      expect(page).to have_content('The search was successfully updated.')
+      expect(page).to have_content('The browse category was successfully updated.')
 
       search.reload
 
@@ -115,7 +115,7 @@ describe 'Browse Category Administration', type: :feature do
 
       click_button 'Save changes'
 
-      expect(page).to have_content('The search was successfully updated.')
+      expect(page).to have_content('The browse category was successfully updated.')
 
       search.reload
 
@@ -129,7 +129,7 @@ describe 'Browse Category Administration', type: :feature do
       check 'Search box'
 
       click_button 'Save changes'
-      expect(page).to have_content('The search was successfully updated.')
+      expect(page).to have_content('The browse category was successfully updated.')
       search.reload
 
       expect(search.search_box).to eq true
@@ -141,7 +141,7 @@ describe 'Browse Category Administration', type: :feature do
 
       click_button 'Save changes'
 
-      expect(page).to have_content('The search was successfully updated.')
+      expect(page).to have_content('The browse category was successfully updated.')
 
       search.reload
 


### PR DESCRIPTION
…"Browse category"

Closes #2615 

Since I'm overriding how the model name is translated, this gets update in a few other places

<img width="639" alt="Screen Shot 2021-01-27 at 5 31 30 PM" src="https://user-images.githubusercontent.com/96776/106080385-caae9a00-60cb-11eb-88d6-eaede33f773b.png">
<img width="743" alt="Screen Shot 2021-01-27 at 5 31 43 PM" src="https://user-images.githubusercontent.com/96776/106080386-cbdfc700-60cb-11eb-814b-a16ddcab05c3.png">
<img width="452" alt="Screen Shot 2021-01-27 at 5 32 18 PM" src="https://user-images.githubusercontent.com/96776/106080389-cc785d80-60cb-11eb-9da6-4fc4ee0cff17.png">
<img width="708" alt="Screen Shot 2021-01-27 at 5 32 25 PM" src="https://user-images.githubusercontent.com/96776/106080391-cd10f400-60cb-11eb-9848-e2b192810484.png">
