### PR TITLE
Downcase the model before sending through as an i18n key in …

### DIFF
--- a/app/helpers/spotlight/crud_link_helpers.rb
+++ b/app/helpers/spotlight/crud_link_helpers.rb
@@ -112,7 +112,7 @@ module Spotlight
       defaults << :"helpers.action.#{object_name}.#{key}"
       defaults << :"helpers.action.#{key}"
       defaults << "#{key.to_s.humanize} #{model}"
-      I18n.t(defaults.shift, model: model, default: defaults)
+      I18n.t(defaults.shift, model: model.downcase, default: defaults)
     end
     # rubocop:enable Metrics/MethodLength
   end

--- a/spec/helpers/spotlight/crud_link_helpers_spec.rb
+++ b/spec/helpers/spotlight/crud_link_helpers_spec.rb
@@ -104,7 +104,7 @@ describe Spotlight::CrudLinkHelpers, type: :helper do
   describe '#action_default_value' do
     it 'attempts i18n lookups for models' do
       expect(I18n).to receive(:t).with(:'helpers.action.spotlight/feature_page.edit',
-                                       model: some_model.class.model_name.human,
+                                       model: some_model.class.model_name.human.downcase,
                                        default: [:'helpers.action.edit', 'Edit Feature page'])
       expect(helper.send(:action_default_value, some_model))
     end
@@ -112,14 +112,14 @@ describe Spotlight::CrudLinkHelpers, type: :helper do
     it 'attempts i18n lookups for unpersisted models' do
       some_model = Spotlight::FeaturePage.new
       expect(I18n).to receive(:t).with(:'helpers.action.spotlight/feature_page.create',
-                                       model: some_model.class.model_name.human,
+                                       model: some_model.class.model_name.human.downcase,
                                        default: [:'helpers.action.create', 'Create Feature page'])
       expect(helper.send(:action_default_value, some_model))
     end
 
     it 'attempts i18n lookups for models with an explicit action' do
       expect(I18n).to receive(:t).with(:'helpers.action.spotlight/feature_page.custom_action',
-                                       model: some_model.class.model_name.human,
+                                       model: some_model.class.model_name.human.downcase,
                                        default: [:'helpers.action.custom_action', 'Custom action Feature page'])
       expect(helper.send(:action_default_value, some_model, :custom_action))
     end


### PR DESCRIPTION
…action_default_value (used in crud_link_helpers)

Connected to #2615 
Noted in https://github.com/projectblacklight/spotlight/pull/2620#issuecomment-769172211

## Before
<img width="452" alt="Screen Shot 2021-01-27 at 5 32 18 PM" src="https://user-images.githubusercontent.com/96776/106174952-65e65480-614a-11eb-826d-9fa4631eacfe.png">

## After
<img width="451" alt="Screen Shot 2021-01-28 at 9 21 26 AM" src="https://user-images.githubusercontent.com/96776/106174967-6979db80-614a-11eb-91fd-6c1a0d36e3ae.png">
