### PR TITLE
Updates to resolve issues with import/export exhibit lifecycle

### DIFF
--- a/app/controllers/spotlight/appearances_controller.rb
+++ b/app/controllers/spotlight/appearances_controller.rb
@@ -30,18 +30,5 @@ module Spotlight
                                       masthead_attributes: featured_image_params,
                                       thumbnail_attributes: featured_image_params)
     end
-
-    def featured_image_params
-      %i[
-        iiif_region iiif_tilesource
-        iiif_manifest_url iiif_canvas_id
-        iiif_image_id
-        display
-        source
-        image
-        document_global_id
-        upload_id
-      ]
-    end
   end
 end

--- a/app/controllers/spotlight/concerns/application_controller.rb
+++ b/app/controllers/spotlight/concerns/application_controller.rb
@@ -80,6 +80,19 @@ module Spotlight
       def default_document_index_view_type
         document_index_views.select { |_k, config| config.respond_to?(:default) && config.default }.keys.first || document_index_views.keys.first
       end
+
+      def featured_image_params
+        %i[
+          iiif_region iiif_tilesource
+          iiif_manifest_url iiif_canvas_id
+          iiif_image_id
+          display
+          source
+          image
+          document_global_id
+          upload_id
+        ]
+      end
     end
   end
 end

--- a/app/controllers/spotlight/pages_controller.rb
+++ b/app/controllers/spotlight/pages_controller.rb
@@ -150,14 +150,7 @@ module Spotlight
     end
 
     def allowed_page_params
-      [:title, :content, thumbnail_attributes: featured_image_attributes]
-    end
-
-    def featured_image_attributes
-      %i[
-        source image document_global_id iiif_region iiif_tilesource
-        iiif_manifest_url iiif_canvas_id iiif_image_id
-      ]
+      [:title, :content, thumbnail_attributes: featured_image_params]
     end
 
     def human_name

--- a/app/controllers/spotlight/searches_controller.rb
+++ b/app/controllers/spotlight/searches_controller.rb
@@ -120,17 +120,6 @@ module Spotlight
       params.to_unsafe_h.with_indifferent_access.except(:exhibit_id, :search, *blacklisted_search_session_params).reject { |_k, v| v.blank? }
     end
 
-    def featured_image_params
-      %i[
-        iiif_region iiif_tilesource
-        iiif_manifest_url iiif_canvas_id iiif_image_id
-        display
-        source
-        image
-        document_global_id
-      ]
-    end
-
     def blacklisted_search_session_params
       %i[id commit counter total search_id page per_page authenticity_token utf8 action controller]
     end

--- a/app/services/spotlight/exhibit_import_export_service.rb
+++ b/app/services/spotlight/exhibit_import_export_service.rb
@@ -216,6 +216,8 @@ module Spotlight
                                                      filename: file[:filename],
                                                      content_type: file[:content_type]
       end
+      # Unset the iiif_tilesource field as the new image should be different
+      image.iiif_tilesource = nil
       image.save!
       obj.update(method => image)
     end

--- a/spec/controllers/spotlight/about_pages_controller_spec.rb
+++ b/spec/controllers/spotlight/about_pages_controller_spec.rb
@@ -230,7 +230,6 @@ describe Spotlight::AboutPagesController, type: :controller, versioning: true do
       let(:page) { FactoryBot.create(:about_page, exhibit: exhibit) }
 
       it 'calls the CloneTranslatedPageFromLocale service' do
-        pending('RSpec mocks do not play nice with kwargs') if RUBY_VERSION >= '3.0'
         expect(
           Spotlight::CloneTranslatedPageFromLocale
         ).to receive(:call).with(locale: 'es', page: page).and_call_original

--- a/spec/controllers/spotlight/feature_pages_controller_spec.rb
+++ b/spec/controllers/spotlight/feature_pages_controller_spec.rb
@@ -240,7 +240,6 @@ describe Spotlight::FeaturePagesController, type: :controller, versioning: true 
       let!(:page) { FactoryBot.create(:feature_page, exhibit: exhibit) }
 
       it 'calls the CloneTranslatedPageFromLocale service' do
-        pending('RSpec mocks do not play nice with kwargs') if RUBY_VERSION >= '3.0'
         expect(
           Spotlight::CloneTranslatedPageFromLocale
         ).to receive(:call).with(locale: 'es', page: page).and_call_original

--- a/spec/controllers/spotlight/home_pages_controller_spec.rb
+++ b/spec/controllers/spotlight/home_pages_controller_spec.rb
@@ -116,7 +116,6 @@ describe Spotlight::HomePagesController, type: :controller, versioning: true do
     before { sign_in user }
 
     it 'calls the CloneTranslatedPageFromLocale service' do
-      pending('RSpec mocks do not play nice with kwargs') if RUBY_VERSION >= '3.0'
       expect(
         Spotlight::CloneTranslatedPageFromLocale
       ).to receive(:call).with(locale: 'es', page: page).and_call_original

--- a/spec/helpers/spotlight/title_helper_spec.rb
+++ b/spec/helpers/spotlight/title_helper_spec.rb
@@ -19,7 +19,6 @@ describe Spotlight::TitleHelper, type: :helper do
     end
 
     it 'renders just the section title if that was all that was provided' do
-      pending('RSpec mocks do not play nice with kwargs') if RUBY_VERSION >= '3.0'
       allow(helper).to receive(:t).and_call_original
       allow(helper).to receive(:t).with(:'.header', default: '').and_return('')
 

--- a/spec/services/spotlight/exhibit_import_export_service_spec.rb
+++ b/spec/services/spotlight/exhibit_import_export_service_spec.rb
@@ -333,6 +333,20 @@ describe Spotlight::ExhibitImportExportService do
         end
       end
 
+      context 'remote thumbnail with existing tilesource' do
+        it do
+          search.thumbnail.iiif_tilesource
+          search.thumbnail.save
+          source_exhibit.reload
+        end
+
+        it 'unsets the iiif_tilesource' do
+          subject
+          existing_search.reload
+          expect(existing_search.thumbnail.iiif_tilesource).not_to eq search.thumbnail.iiif_tilesource
+        end
+      end
+
       context 'with a thumbnail from an uploaded resource' do
         before do
           search.masthead.document_global_id = SolrDocument.new(id: 'xyz').to_global_id


### PR DESCRIPTION
Fixes https://github.com/sul-dlss/dlme/issues/1158

This pull request does two things:

1. Move all of the iiif crop image params to a single helper so that if we change/modify them they won't be different. A previous PR that added a param missed one of these.
2. Unset the iiif_tilesource for a Spotlight::FeaturedImage when importing an exhibit. The rationale here is that this field can be regenerated if unset and could contain some incorrect data coming from a remote image being reimported.
