### PR TITLE
Update i18n for Spotlight::Group to be named "Browse group"

### DIFF
--- a/app/controllers/spotlight/groups_controller.rb
+++ b/app/controllers/spotlight/groups_controller.rb
@@ -34,14 +34,14 @@ module Spotlight
     def update
       @group.update(group_params)
 
-      redirect_to spotlight.exhibit_searches_path(anchor: 'browse-groups')
+      redirect_to spotlight.exhibit_searches_path(anchor: 'browse-groups'), notice: t(:'helpers.submit.group.updated', model: human_name)
     end
 
     # DELETE /groups/1
     def destroy
       @group.destroy
 
-      redirect_to spotlight.exhibit_searches_path(anchor: 'browse-groups')
+      redirect_to spotlight.exhibit_searches_path(anchor: 'browse-groups'), alert: t(:'helpers.submit.group.destroyed', model: human_name)
     end
 
     def update_all
@@ -62,7 +62,7 @@ module Spotlight
     private
 
     def human_name
-      @human_name ||= group_collection_name.humanize.downcase.singularize
+      @human_name ||= @group ? @group.class.model_name.human.downcase : Spotlight::Group.model_name.human.pluralize
     end
 
     alias group_collection_name controller_name

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -39,6 +39,7 @@ ignore_unused:
   - activerecord.attributes.spotlight/masthead.display # app/views/spotlight/appearances/edit.html.erb
   - activerecord.attributes.spotlight/custom_field.is_multiple # app/views/spotlight/custom_fields/_form.html.erb
   - activerecord.attributes.spotlight/custom_search_field.field # app/views/spotlight/custom_search_fields/_form.html.erb
+  - activerecord.models.spotlight/group # Used in flash messages around the app to rename Group to Browse group
   - activerecord.models.spotlight/search # Used in flash messages around the app to rename Search to Browse category
   - helpers.label.spotlight/filter.{field,value} # app/views/spotlight/filters/_form.html.erb
   - spotlight.catalog.admin.{title,header} # app/helpers/spotlight/title_helper.rb
@@ -60,6 +61,7 @@ ignore_unused:
   - helpers.submit.filter.{batch_error,batch_updated,create,created,destroyed,submit,update} # Generic repeated template
   - helpers.action.destroy_are_you_sure # app/helpers/spotlight/crud_link_helpers.rb
   - helpers.action.spotlight/role.{create,destroy} # app/views/spotlight/roles/index.html.erb
+  - helpers.action.spotlight/group.destroy # app/views/spotlight/searches/_group.html.erb
   - helpers.action.{edit,edit_long,new,view} # app/helpers/spotlight/crud_link_helpers.rb
   - helpers.action.spotlight/search.edit_long # app/views/spotlight/searches/_search.html.erb
   - spotlight.about_pages.page_options.published # app/views/spotlight/about_pages/_page_options.html.erb

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -24,6 +24,7 @@ en:
     models:
       spotlight:
         page: Page
+      spotlight/group: Browse group
       spotlight/search: Browse category
   cancel: Cancel
   drag: Drag
@@ -45,6 +46,8 @@ en:
         create: Add new field
       spotlight/custom_search_field:
         create: Add new field
+      spotlight/group:
+        destroy: Delete group
       spotlight/role:
         create: Add a new user
         destroy: Remove from site

--- a/spec/controllers/spotlight/groups_controller_spec.rb
+++ b/spec/controllers/spotlight/groups_controller_spec.rb
@@ -51,7 +51,7 @@ describe Spotlight::GroupsController, type: :controller do
       it 'creates a saved search' do
         post :create, params: { exhibit_id: exhibit, group: { title: 'Hello' } }
         expect(response).to redirect_to spotlight.exhibit_searches_path(exhibit, anchor: 'browse-groups')
-        expect(flash[:notice]).to eq 'The group was created.'
+        expect(flash[:notice]).to eq 'The browse group was created.'
       end
     end
 

--- a/spec/features/javascript/browse_group_admin_spec.rb
+++ b/spec/features/javascript/browse_group_admin_spec.rb
@@ -18,7 +18,7 @@ describe 'Browse Group Adminstration', js: true do
 
     add_new_via_button('My New Group')
 
-    expect(page).to have_content 'The group was created.'
+    expect(page).to have_content 'The browse group was created.'
     expect(page).to have_css('li.dd-item')
     expect(page).to have_css('h4', text: 'My New Group')
   end


### PR DESCRIPTION
Closes #2613 

A few other updates I made was to add a flash message after a group was deleted consistent with our other flash messages.

<img width="884" alt="Screen Shot 2021-01-29 at 11 38 42 AM" src="https://user-images.githubusercontent.com/96776/106327862-ac63ae00-6233-11eb-9a19-a7c5d56af507.png">
<img width="673" alt="Screen Shot 2021-01-29 at 11 39 01 AM" src="https://user-images.githubusercontent.com/96776/106327869-aec60800-6233-11eb-9a05-df793fda70f9.png">
<img width="545" alt="Screen Shot 2021-01-29 at 11 39 32 AM" src="https://user-images.githubusercontent.com/96776/106327872-af5e9e80-6233-11eb-9cf2-421bb13eab81.png">
<img width="445" alt="Screen Shot 2021-01-29 at 1 13 25 PM" src="https://user-images.githubusercontent.com/96776/106327936-ce5d3080-6233-11eb-83a3-c5e16ea647ce.png">
