### PR TITLE
Change unsetting for iiif_tilesource location

### DIFF
--- a/app/services/spotlight/exhibit_import_export_service.rb
+++ b/app/services/spotlight/exhibit_import_export_service.rb
@@ -215,9 +215,10 @@ module Spotlight
         image.image = CarrierWave::SanitizedFile.new tempfile: StringIO.new(Base64.decode64(file[:content])),
                                                      filename: file[:filename],
                                                      content_type: file[:content_type]
+        # Unset the iiif_tilesource field as the new image should be different, because
+        # the source has been reloaded
+        image.iiif_tilesource = nil
       end
-      # Unset the iiif_tilesource field as the new image should be different
-      image.iiif_tilesource = nil
       image.save!
       obj.update(method => image)
     end

--- a/spec/services/spotlight/exhibit_import_export_service_spec.rb
+++ b/spec/services/spotlight/exhibit_import_export_service_spec.rb
@@ -351,6 +351,8 @@ describe Spotlight::ExhibitImportExportService do
         before do
           search.masthead.document_global_id = SolrDocument.new(id: 'xyz').to_global_id
           search.masthead.source = 'exhibit'
+          search.masthead.iiif_tilesource = 'foo'
+          search.masthead.image = nil # Setting to nil to mimick an exhibit source
           search.masthead.save
 
           source_exhibit.reload
@@ -360,6 +362,12 @@ describe Spotlight::ExhibitImportExportService do
           subject
           existing_search.reload
           expect(existing_search.masthead).not_to be_blank
+        end
+
+        it 'does not unset the iiif_tilesource' do
+          subject
+          existing_search.reload
+          expect(existing_search.masthead.iiif_tilesource).to eq search.masthead.iiif_tilesource
         end
       end
 


### PR DESCRIPTION
I think I made a mistake in #2624 and now I've tested this with a full round trip to verify that this change should work.

For a given exhibit export with a thumbnail:

```json
      ],
      "thumbnail": {
        "display": null,
        "source": "exhibit",
        "document_global_id": "gid://dlme/SolrDocument/p15795coll21%2F494",
        "image_crop_x": null,
        "image_crop_y": null,
        "image_crop_w": null,
        "image_crop_h": null,
        "created_at": "2021-01-29 21:24:27 UTC",
        "updated_at": "2021-01-29 21:24:27 UTC",
        "iiif_region": "250,211,916,688",
        "iiif_manifest_url": "https://cdm15795.contentdm.oclc.org/iiif/info/p15795coll21/494/manifest.json",
        "iiif_canvas_id": "https://cdm15795.contentdm.oclc.org/digital/iiif/p15795coll21/492/canvas/c0",
        "iiif_image_id": "https://cdm15795.contentdm.oclc.org/digital/iiif/p15795coll21/492/annotation/a0",
        "iiif_tilesource": "https://cdm15795.contentdm.oclc.org/digital/iiif/p15795coll21/492/info.json"
      }
```
This resource would be iiif_tilesource unset, probably not what we want.

Though a thumbnail like this, we would want that iiif_tilesource unset:

```json
  ],
      "thumbnail": {
        "display": null,
        "source": "remote",
        "document_global_id": "",
        "image_crop_x": null,
        "image_crop_y": null,
        "image_crop_w": null,
        "image_crop_h": null,
        "created_at": "2021-01-29 23:52:52 UTC",
        "updated_at": "2021-01-29 23:52:52 UTC",
        "iiif_region": "39,14,181,135",
        "iiif_manifest_url": "",
        "iiif_canvas_id": "",
        "iiif_image_id": "",
        "iiif_tilesource": "/images/139/info.json",
        "image": {
          "filename": "Screen_Shot_2021-01-29_at_12.55.03_PM.png",
          "content_type": "image/png",
          "content": "iVBORw0KGgoAAAANSUhEUgAAAWsAAADGCAYAAAAUs6H8AAAK0WlDQ1BJQ0Mg\nUHJvZmlsZQAASImVlwdUU2kWgP/30kNCS4iAlNCb9A5SQg+gIB1EJSQhCSWE\nFFRsiAyOwIiiIoJlREdEFByVOhZEFNsgYMM6IIOKMg4WbKjsA5Yws3t29+w9\n557/y839b3nn/9+5DwCyOkskSoeVAcgQSsURgT70uPgEOm4QEIEaUAZ2wIbF\nlogY4eGhAJGZ9e/y/g6AJteblpOx/v3//yoqHK6EDQAUjnAyR8LOQPgUot/Y\nIrEUABTCwGC5VDTJfQhTxUiBCI9MMm+K0ZNxqMnTTJ3yiYrwRdgUADyJxRLz\nACA5IHZ6NpuHxCFFIWwj5AiECOcj7MnmszgIdyA8LyMjc5JHETZN/ksc3t9i\nJstjslg8OU/3MiV4P4FElM5a+X8+jv8tGemymRzGiJL44qCIaYb60jJD5CxM\nXhg2wwLOjD/Ux5cFRc8wW+KbMMMcll+IfG/6wtAZThEEMOVxpMyoGeZK/CNn\nWJwZIc+VIvZlzDBLPJtXlhYtt/O5THn8HH5U7AxnC2IWzrAkLTJk1sdXbhfL\nIuT1c4WBPrN5A+S9Z0j+0q+AKd8r5UcFyXtnzdbPFTJmY0ri5LVxuH7+sz7R\ncn+R1EeeS5QeLvfnpgfK7ZLsSPleKXIgZ/eGy59hKis4fIZBFOADGRACDuAC\nMUgGmSAdSAEd+AEBkAAR8osFkOMk5a6QTjbnmylaKRbw+FI6A7l1XDpTyLaa\nR7ezsXUFYPIOTx+Rt7SpuwnRrs7astoAcC1EjLxZG8sAgJanAFDez9oM3iDH\nawsAZ7rZMnH2tG3qrmGQt4MSoAINoAMMgCmwRN4TTsAdeAN/EAzCkE7iwVLA
```

So rather than do it for everything, lets just do it in a before validation for things that are coming from a remote source.