### PR TITLE
Pin to Solr v8.7.0 until specs can be fixed for v8.8.0

### DIFF
--- a/.solr_wrapper
+++ b/.solr_wrapper
@@ -3,3 +3,4 @@
 collection:
   dir: solr_conf/conf/
   name: blacklight-core
+version: 8.7.0


### PR DESCRIPTION
```
Failures:

  1) Spotlight::CatalogController when the user is not authenticated GET autocomplete has partial matches for title
     Failure/Error: expect(assigns[:document_list].first.id).to eq 'ps921pn8250'

     NoMethodError:
       undefined method `id' for nil:NilClass
     # ./spec/controllers/spotlight/catalog_controller_spec.rb:99:in `block (4 levels) in <top (required)>'

  2) Spotlight::CatalogController when the user is not authenticated GET autocomplete has partial matches for id
     Failure/Error: expect(assigns[:document_list].first.id).to eq 'dx157dh4345'

     NoMethodError:
       undefined method `id' for nil:NilClass
     # ./spec/controllers/spotlight/catalog_controller_spec.rb:113:in `block (4 levels) in <top (required)>'
```

https://github.com/projectblacklight/spotlight/runs/1807245542?check_suite_focus=true#step:5:3533