### PR TITLE
Replace line breaks in sir-trevor text blocks with paragraphs

### DIFF
--- a/app/helpers/spotlight/pages_helper.rb
+++ b/app/helpers/spotlight/pages_helper.rb
@@ -21,7 +21,7 @@ module Spotlight
     # a more complete markdown rendered
     def sir_trevor_markdown(text)
       clean_text = if text
-                     text.gsub('<br>', "\n").gsub('<p>', '').gsub('</p>', "\n\n")
+                     text.gsub('<br>', "\n\n").gsub('<p>', '').gsub('</p>', "\n\n")
                    else
                      ''
                    end

--- a/spec/helpers/spotlight/pages_helper_spec.rb
+++ b/spec/helpers/spotlight/pages_helper_spec.rb
@@ -106,6 +106,14 @@ describe Spotlight::PagesHelper, type: :helper do
     it 'handles nil input' do
       expect(helper.sir_trevor_markdown(nil)).to be_blank
     end
+
+    it 'retains paragraphs' do
+      expect(helper.sir_trevor_markdown('<p>First Line</p><p>Second Line</p>').chomp).to match(%r{<p>First Line</p>\s*<p>Second Line</p>})
+    end
+
+    it 'replaces line breaks with paragraphs' do
+      expect(helper.sir_trevor_markdown('First Line<br>Second Line').chomp).to match(%r{<p>First Line</p>\s*<p>Second Line</p>})
+    end
   end
 
   describe '#content_editor_class' do


### PR DESCRIPTION
I believe this will address #2581 (but I'm not 100% sure)

I feel like this may have been the intent of the original code.  The current code passes a single new line character through (and it is not acted on in the markdown), so just creates on paragraph tag w/ the two lines joined by a new line character.

It appears that we could actually remove our `clean_text` (and just ensure `nil` is handled appropriately) however this ends up retaining the `<br>`, which in this case ends up wrapping the two lines with a paragraph tag and joining the two lines with the `<br>`.  While this visually appears the same, it might not necessarily be what the user wanted (and creates an odd inconsistency with what shift+enter does if you press it once vs. twice).

## Widget Before
<img width="1110" alt="st-before" src="https://user-images.githubusercontent.com/96776/106637754-f3091f00-6537-11eb-8779-ef525d55e091.png">

## Result Before
<img width="173" alt="results-before" src="https://user-images.githubusercontent.com/96776/106637807-02886800-6538-11eb-9029-7a654d5cf5bd.png">


## Result After

<img width="166" alt="result-after" src="https://user-images.githubusercontent.com/96776/106637818-05835880-6538-11eb-97e6-708dba98db2f.png">


