### PR TITLE
Now that we're not sending explicit commits after indexing as part of…

### DIFF
--- a/spec/controllers/spotlight/catalog_controller_spec.rb
+++ b/spec/controllers/spotlight/catalog_controller_spec.rb
@@ -128,7 +128,6 @@ describe Spotlight::CatalogController, type: :controller do
 
           perform_enqueued_jobs do
             uploaded_resource.save_and_index
-            SolrDocument.index.connection.commit
           end
 
           get :manifest, params: { exhibit_id: uploaded_resource.exhibit, id: compound_id }


### PR DESCRIPTION
… ReindexJob... we need to do it ourselves