### PR TITLE
Adjust alignment of group categories widget elements

### DIFF
--- a/app/views/spotlight/sir_trevor/blocks/_browse_group_categories_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_browse_group_categories_block.html.erb
@@ -2,9 +2,9 @@
   <% browse_group_categories_block.groups.each do |group| %>
     <div class="browse-group-categories-block" data-browse-group-categories-count="<%= group.searches.count %>">
       <div class="d-flex flex-column flex-md-row py-2">
-        <div class="d-flex justify-content-between align-items-end">
+        <div class="d-flex justify-content-between align-items-baseline">
           <h2 class="m-0"><%= group.title %></h2>
-          <div class="pl-5">
+          <div class="pl-3">
             <%= link_to t(:'.view_all'), exhibit_browse_groups_path(current_exhibit, group) %>
           </div>
         </div>
@@ -21,7 +21,7 @@
       </div>
       <div class="spotlight-flexbox browse-categories categories-<%= [group.searches.count, (@page.display_sidebar? ? 3 : 4)].min %>" data-browse-group-categories-carousel data-sidebar='<%= @page.display_sidebar? %>' data-browse-group-categories-count="<%= group.searches.count %>">
         <% group.searches.published.each_with_index do |search, index| %>
-          <div class="box category-1 justify-content-center justify-content-md-start">
+          <div class="box category-1 justify-content-center justify-content-md-space-around">
             <%= link_to spotlight.exhibit_browse_group_path(current_exhibit, group, search), class: 'justify-content-center' do %>
               <div class="browse-category" style='background-image: linear-gradient(rgba(0, 0, 0, 0.0), rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.5)), url("<%= search.thumbnail.iiif_url if search.thumbnail %>")'>
                 <div class="category-caption">


### PR DESCRIPTION
This PR adjusts a few things with the group categories widget for better alignment purposes.

- Makes the browse group categories widget tiles have the same horizontal alignment as the older browse categories widget (compare before and after below to see how currently the browse group categories widget is further left and its tiles are not directly in line with the ones in the row below). This is especially important if a current ever uses those two widgets on the same page and in somewhat close proximity.

- Sets the browse group categories widget title, "view all" link, and nav arrow icons on the same baseline
- Reduces the horizontal space between the browse group categories widget title and the "View all" link

(Note this PR does not try to fix anything with [a ticket](#2653) I just filed on a responsive problem with this same widget.)

### Before
<img width="1016" alt="Screen Shot 2021-02-05 at 5 04 31 PM" src="https://user-images.githubusercontent.com/101482/107102121-b1e26a80-67d6-11eb-92f8-d9e4f6bd7be8.png">

### After
<img width="752" alt="Screen Shot 2021-02-05 at 5 16 02 PM" src="https://user-images.githubusercontent.com/101482/107102129-b870e200-67d6-11eb-92cb-31f859c7c577.png">
