### PR TITLE
Change the per_page setting so we get the default_per_page set …

### DIFF
--- a/app/models/spotlight/blacklight_configuration.rb
+++ b/app/models/spotlight/blacklight_configuration.rb
@@ -84,6 +84,8 @@ module Spotlight
 
         config.default_solr_params = config.default_solr_params.merge(default_solr_params)
 
+        config.default_per_page = default_per_page if default_per_page
+
         config.view.embed.partials ||= ['openseadragon']
         config.view.embed.if = false
         config.view.embed.locals ||= { osd_container_class: '' }
@@ -185,11 +187,6 @@ module Spotlight
         end
 
         config.per_page = (config.per_page & per_page) unless per_page.blank?
-
-        if default_per_page
-          config.per_page.delete(default_per_page)
-          config.per_page.unshift(default_per_page)
-        end
 
         unless document_index_view_types.blank?
           config.view.each do |k, v|

--- a/spec/models/spotlight/blacklight_configuration_spec.rb
+++ b/spec/models/spotlight/blacklight_configuration_spec.rb
@@ -449,11 +449,16 @@ describe Spotlight::BlacklightConfiguration, type: :model do
 
       expect(subject.blacklight_config.per_page).to eq [10, 50]
     end
+  end
 
-    it 'prepends the default per page' do
-      blacklight_config.per_page = [1, 10, 50, 100]
+  describe '#default_per_page' do
+    it 'is the first per page option by default' do
+      expect(subject.blacklight_config.default_per_page).to eq 10
+    end
+
+    it "is set from the model's default_per_page" do
       subject.default_per_page = 50
-      expect(subject.blacklight_config.per_page.first).to eq 50
+      expect(subject.blacklight_config.default_per_page).to eq 50
     end
   end
 


### PR DESCRIPTION
…explicitly in the configuration instead re-ordering per_page

Closes sul-dlss/exhibits#1941

In the example below the exhibit has set a default per-page of 50, and the user has not selected a specific per-page option (so the default is being acted on).

## Before
<img width="597" alt="per-page-before" src="https://user-images.githubusercontent.com/96776/107292341-80f47680-6a1e-11eb-87d3-c742d51cd9c1.png">

## After
<img width="603" alt="per-page-after" src="https://user-images.githubusercontent.com/96776/107292345-82be3a00-6a1e-11eb-899f-47841ac1196d.png">
