### PR TITLE
Accessibility: Link text used for multiple different destinations - Home Links on Exhibit

### DIFF
--- a/app/controllers/spotlight/catalog_controller.rb
+++ b/app/controllers/spotlight/catalog_controller.rb
@@ -126,15 +126,11 @@ module Spotlight
     protected
 
     def attach_breadcrumbs
-      # The "q: ''" is necessary so that the breadcrumb builder recognizes that a path like this:
-      # /exhibits/1?f%5Bgenre_sim%5D%5B%5D=map&q= is not the same as /exhibits/1
-      # Otherwise the exhibit breadcrumb won't be a link.
-      # see http://api.rubyonrails.org/classes/ActionView/Helpers/UrlHelper.html#method-i-current_page-3F
       if view_context.current_page?({ action: :admin })
-        add_breadcrumb t(:'spotlight.exhibits.breadcrumb', title: @exhibit.title), exhibit_root_path(@exhibit, q: '')
+        add_breadcrumb t(:'spotlight.exhibits.breadcrumb', title: @exhibit.title), exhibit_root_path(@exhibit)
       else
         # When not on the admin page, get the translated value for the "Home" breadcrumb
-        add_breadcrumb t(:'spotlight.curation.nav.home', title: @exhibit.title), exhibit_root_path(@exhibit, q: '')
+        add_breadcrumb t(:'spotlight.curation.nav.home', title: @exhibit.title), exhibit_root_path(@exhibit)
       end
     end
 

--- a/spec/controllers/spotlight/catalog_controller_spec.rb
+++ b/spec/controllers/spotlight/catalog_controller_spec.rb
@@ -29,7 +29,7 @@ describe Spotlight::CatalogController, type: :controller do
       let(:search) { FactoryBot.create(:search, exhibit: exhibit) }
 
       it 'shows the item' do
-        expect(controller).to receive(:add_breadcrumb).with('Home', exhibit_path(exhibit, q: ''))
+        expect(controller).to receive(:add_breadcrumb).with('Home', exhibit_path(exhibit))
         expect(controller).to receive(:add_breadcrumb).with('L&#39;AMERIQUE', exhibit_solr_document_path(exhibit, document))
         get :show, params: { exhibit_id: exhibit, id: 'dq287tq6352' }
         expect(response).to be_successful
@@ -38,7 +38,7 @@ describe Spotlight::CatalogController, type: :controller do
       it 'shows the item with breadcrumbs to the browse page' do
         allow(controller).to receive_messages(current_browse_category: search)
 
-        expect(controller).to receive(:add_breadcrumb).with('Home', exhibit_path(exhibit, q: ''))
+        expect(controller).to receive(:add_breadcrumb).with('Home', exhibit_path(exhibit))
         expect(controller).to receive(:add_breadcrumb).with('Browse', exhibit_browse_index_path(exhibit))
         expect(controller).to receive(:add_breadcrumb).with(search.title, exhibit_browse_path(exhibit, search))
         expect(controller).to receive(:add_breadcrumb).with('L&#39;AMERIQUE', exhibit_solr_document_path(exhibit, document))
@@ -50,7 +50,7 @@ describe Spotlight::CatalogController, type: :controller do
         feature_page = FactoryBot.create(:feature_page, exhibit: exhibit)
         allow(controller).to receive_messages(current_page_context: feature_page)
 
-        expect(controller).to receive(:add_breadcrumb).with('Home', exhibit_path(exhibit, q: ''))
+        expect(controller).to receive(:add_breadcrumb).with('Home', exhibit_path(exhibit))
         expect(controller).to receive(:add_breadcrumb).with(feature_page.title, [exhibit, feature_page])
         expect(controller).to receive(:add_breadcrumb).with('L&#39;AMERIQUE', exhibit_solr_document_path(exhibit, document))
         get :show, params: { exhibit_id: exhibit, id: 'dq287tq6352' }
@@ -61,7 +61,7 @@ describe Spotlight::CatalogController, type: :controller do
         home_page = FactoryBot.create(:home_page)
         allow(controller).to receive_messages(current_page_context: home_page)
 
-        expect(controller).to receive(:add_breadcrumb).with('Home', exhibit_path(exhibit, q: ''))
+        expect(controller).to receive(:add_breadcrumb).with('Home', exhibit_path(exhibit))
         expect(controller).to receive(:add_breadcrumb).with('L&#39;AMERIQUE', exhibit_solr_document_path(exhibit, document))
         get :show, params: { exhibit_id: exhibit, id: 'dq287tq6352' }
         expect(response).to be_successful
@@ -80,7 +80,7 @@ describe Spotlight::CatalogController, type: :controller do
 
     describe 'GET index' do
       it 'shows the index when there are parameters' do
-        expect(controller).to receive(:add_breadcrumb).with('Home', exhibit_path(exhibit, q: ''))
+        expect(controller).to receive(:add_breadcrumb).with('Home', exhibit_path(exhibit))
         expect(controller).to receive(:add_breadcrumb).with('Search results', search_exhibit_catalog_path(exhibit, q: 'map'))
         get :index, params: { exhibit_id: exhibit, q: 'map' }
         expect(response).to be_successful
@@ -216,7 +216,7 @@ describe Spotlight::CatalogController, type: :controller do
     before { sign_in FactoryBot.create(:exhibit_curator, exhibit: exhibit) }
 
     it 'shows all the items' do
-      expect(controller).to receive(:add_breadcrumb).with('Home', exhibit_path(exhibit, q: ''))
+      expect(controller).to receive(:add_breadcrumb).with('Home', exhibit_path(exhibit))
       expect(controller).to receive(:add_breadcrumb).with('Curation', exhibit_dashboard_path(exhibit))
       expect(controller).to receive(:add_breadcrumb).with('Items', admin_exhibit_catalog_path(exhibit))
       get :admin, params: { exhibit_id: exhibit }


### PR DESCRIPTION
**_NOTE: This replaces PR #2656.  I had problems with the fork associated with that PR because it was out of date.  I had to create a new fork and new PR.  Comments are copied forward from the original PR._**

----
_NOTE: This was identified as an accessibility error by SiteImprove: Link text used for multiple different destinations_

### Description

On item show pages (e.g. http://localhost:3000/test-exhibit/catalog/3-9), the "Home" link in the exhibit navigation menu and the "Home" link in the breadcrumbs are going to two different locations. 

| Menu | URL |
| -- | -- |
| "Home" navigation menu | https://localhost/test-exhibit |
| "Home" breadcrumb | https://localhost/test-exhibit?q= |

### Solution

Change the breadcrumb "Home" link to match the one in the navigation menu.

### Potential similar fix

Fixed a similar issue on line 131 of the same file that also used `q: ''` parameter which causes the URL to end with `?q=`.

### Request to maintainers

Please backport this to the 2.x series.
