### PR TITLE
Accessibility: Link text used for multiple different destinations - Visit Exhibit button

### DIFF
--- a/app/views/spotlight/exhibits/_exhibit_card_back.html.erb
+++ b/app/views/spotlight/exhibits/_exhibit_card_back.html.erb
@@ -18,6 +18,15 @@
   </p>
 <% end %>
 
+<%
+  # The inclusion of the hidden `<div>` addresses an accessibility issue where a link label should not be used with multiple link
+  # locations.  In this case, the label is 'Visit exhibit' and it is used for all links leading to the various exhibits.
+  #
+  # Using just the `exhibit.id` is not sufficient to create a unique id as this code is used in each tab (i.e. Published exhibits,
+  # Unpublished exhibits, and Your exhibits).  To ensure the ID is unique across tabs, it is appended with a random hex string.
+  label_id = "visit-exhibit-#{exhibit.id}-#{SecureRandom.hex(8)}"
+%>
+<div class="hidden" id="<%= label_id %>"><%= "#{t(:'.visit_exhibit')} #{exhibit.title}" %></div>
 <div class="visit-exhibit center-btn">
-  <%= link_to t(:'.visit_exhibit'), exhibit, class: "btn btn-primary", role: "button" %>
+  <%= link_to t(:'.visit_exhibit'), exhibit, class: "btn btn-primary", role: "button", "aria-labelledby" => "#{label_id}" %>
 </div>


### PR DESCRIPTION
_NOTE: This was identified as an accessibility error by SiteImprove: Link text used for multiple different destinations_

### Description

The text "Visit Exhibit" is used multiple times but all go to different locations. Accessibility expects that identical text should always go to the same location.

### Solution

Add an "aria-labelledby" element and have it point to the exhibit title on the back of the card.

### Request to maintainers

This issue does not exist in 3.x code.  This PR is set to merge into branch `release-2.x` in order to be included in a future 2.x series release.