### PR TITLE
Accessibility: Image with no alt attribute - Exhibit cards

### DIFF
--- a/app/views/spotlight/exhibits/_exhibit_card_front.html.erb
+++ b/app/views/spotlight/exhibits/_exhibit_card_front.html.erb
@@ -1,7 +1,7 @@
 <% if exhibit.thumbnail.present? && exhibit.thumbnail.iiif_url %>
-  <%= image_tag(exhibit.thumbnail.iiif_url) %>
+  <%= image_tag(exhibit.thumbnail.iiif_url, alt: '') %>
 <% else %>
-  <%= image_tag 'spotlight/default_thumbnail.jpg', class: 'default-thumbnail' %>
+  <%= image_tag 'spotlight/default_thumbnail.jpg', class: 'default-thumbnail', alt: '' %>
 <% end %>
 
 <% unless exhibit.published? %>


### PR DESCRIPTION
_NOTE: This was identified as an accessibility error by SiteImprove: Fix accessibility Image with no alt attribute_

### Description

The image displayed on the Exhibit card on the home page does not have `alt` attribute.  

### Solution

As the purpose of the image is decoration, and in keeping with the 3.x solution,  the alt text is added as an empty string.

### Request to maintainers

This issue does not exist in 3.x code.  This PR is set to merge into branch `release-2.x` in order to be included in a future 2.x series release.