### PR TITLE
generated initializer list of sir treavor widgets should match configured list

### DIFF
--- a/lib/generators/spotlight/templates/config/initializers/spotlight_initializer.rb
+++ b/lib/generators/spotlight/templates/config/initializers/spotlight_initializer.rb
@@ -73,7 +73,7 @@
 # These are set by default by Spotlight's configuration,
 # but you can customize them here, or in the SirTrevorRails::Block#custom_block_types method
 # Spotlight::Engine.config.sir_trevor_widgets = %w(
-#   Heading Text List Quote Iframe Video Oembed Rule UploadedItems Browse BrowseGroupCategories
+#   Heading Text List Quote Iframe Video Oembed Rule UploadedItems Browse BrowseGroupCategories LinkToSearch
 #   FeaturedPages SolrDocuments SolrDocumentsCarousel SolrDocumentsEmbed
 #   SolrDocumentsFeatures SolrDocumentsGrid SearchResults
 # )


### PR DESCRIPTION
Updates list of sir treavor widgets in the generator initializer to match those defined in [lib/spotlight/engine.rb](https://github.com/projectblacklight/spotlight/blob/master/lib/spotlight/engine.rb#L270-L274)