### PR TITLE
Add bulk action functionality for updating item visibility

### DIFF
--- a/app/assets/stylesheets/spotlight/_catalog.scss
+++ b/app/assets/stylesheets/spotlight/_catalog.scss
@@ -117,7 +117,7 @@ form.edit_solr_document {
   @extend .clearfix;
 }
 
-#save-this-search {
+#save-this-search, .bulk-actions-dropdown {
   float:left;
   margin-right: $spacer * 0.1;
 }

--- a/app/controllers/concerns/spotlight/catalog.rb
+++ b/app/controllers/concerns/spotlight/catalog.rb
@@ -31,5 +31,10 @@ module Spotlight
       (current_exhibit && can?(:curate, current_exhibit)) &&
         !(params[:controller] == 'spotlight/catalog' && params[:action] == 'admin')
     end
+
+    def render_bulk_actions?
+      (current_exhibit && can?(:curate, current_exhibit)) &&
+        !(params[:controller] == 'spotlight/catalog' && params[:action] == 'admin')
+    end
   end
 end

--- a/app/controllers/spotlight/bulk_actions_controller.rb
+++ b/app/controllers/spotlight/bulk_actions_controller.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Spotlight
+  ##
+  # Controller enabling bulk functionality for search results
+  class BulkActionsController < Spotlight::CatalogController
+    before_action :authenticate_user!
+    before_action :check_authorization
+
+    # rubocop:disable Metrics/MethodLength
+    def visibility
+      solr_params = nil
+      # Get the total number of results
+      (response,) = search_service.search_results do |builder|
+        builder.merge(fl: 'id', rows: 1)
+        solr_params = builder.to_h
+      end
+
+      Spotlight::ChangeVisibilityJob.perform_later(
+        solr_params: solr_params,
+        exhibit: current_exhibit,
+        visibility: visibility_param,
+        user: current_user
+      )
+
+      redirect_back fallback_location: fallback_url,
+                    notice: t(:'spotlight.bulk_actions.change_visibility.changed', count: response.total)
+    end
+    # rubocop:enable Metrics/MethodLength
+
+    def visibility_param
+      params.require(:visibility)
+    end
+
+    def fallback_url
+      spotlight.search_exhibit_catalog_path(current_search_session.query_params)
+    end
+  end
+end

--- a/app/jobs/spotlight/change_visibility_job.rb
+++ b/app/jobs/spotlight/change_visibility_job.rb
@@ -23,7 +23,7 @@ module Spotlight
       cursor_mark = '*'
       response = {}
 
-      while response['nextCursorMark'] == cursor_mark
+      while response['nextCursorMark'] != cursor_mark
         response = exhibit.blacklight_config.repository.search(
           solr_params.merge(
             'rows' => Spotlight::Engine.config.bulk_actions_batch_size,

--- a/app/jobs/spotlight/change_visibility_job.rb
+++ b/app/jobs/spotlight/change_visibility_job.rb
@@ -12,8 +12,9 @@ module Spotlight
         when 'private'
           document.make_private!(exhibit)
         end
-        document.reindex
+        document.reindex(update_params: {})
       end
+      exhibit.blacklight_config.repository.connection.commit
     end
 
     # rubocop:disable Metrics/MethodLength

--- a/app/jobs/spotlight/change_visibility_job.rb
+++ b/app/jobs/spotlight/change_visibility_job.rb
@@ -4,8 +4,8 @@ module Spotlight
   ###
   class ChangeVisibilityJob < Spotlight::ApplicationJob
     def perform(solr_params:, exhibit:, visibility:, **)
-      response = exhibit.blacklight_config.repository.search(solr_params.merge('rows' => 999_999_999))
-      response.documents.each do |document|
+      documents = retrieve_documents(solr_params, exhibit)
+      documents.each do |document|
         case visibility
         when 'public'
           document.make_public!(exhibit)
@@ -15,5 +15,26 @@ module Spotlight
         document.reindex
       end
     end
+
+    # rubocop:disable Metrics/MethodLength
+    def retrieve_documents(solr_params, exhibit)
+      cursor_mark = '*'
+      documents = []
+      loop do
+        response = exhibit.blacklight_config.repository.search(
+          solr_params.merge(
+            'rows' => Spotlight::Engine.config.bulk_actions_batch_size,
+            'cursorMark' => cursor_mark,
+            'sort' => "#{exhibit.blacklight_config.document_model.unique_key} asc"
+          )
+        )
+        documents.concat response.documents
+        break if response['nextCursorMark'] == cursor_mark
+
+        cursor_mark = response['nextCursorMark']
+      end
+      documents
+    end
+    # rubocop:enable Metrics/MethodLength
   end
 end

--- a/app/jobs/spotlight/change_visibility_job.rb
+++ b/app/jobs/spotlight/change_visibility_job.rb
@@ -20,10 +20,11 @@ module Spotlight
     def each_document(solr_params, exhibit, &block)
       return to_enum(:each_document, solr_params, exhibit) unless block_given?
 
-      cursor_mark = '*'
-      response = {}
+      cursor_mark = nil
+      next_cursor_mark = '*'
 
-      while response['nextCursorMark'] != cursor_mark
+      until next_cursor_mark == cursor_mark || next_cursor_mark.nil?
+        cursor_mark = next_cursor_mark
         response = exhibit.blacklight_config.repository.search(
           solr_params.merge(
             'rows' => Spotlight::Engine.config.bulk_actions_batch_size,
@@ -36,7 +37,7 @@ module Spotlight
           block.call(document)
         end
 
-        cursor_mark = response['nextCursorMark']
+        next_cursor_mark = response['nextCursorMark']
       end
     end
     # rubocop:enable Metrics/MethodLength

--- a/app/jobs/spotlight/change_visibility_job.rb
+++ b/app/jobs/spotlight/change_visibility_job.rb
@@ -3,7 +3,14 @@
 module Spotlight
   ###
   class ChangeVisibilityJob < Spotlight::ApplicationJob
+    include Spotlight::JobTracking
+
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def perform(solr_params:, exhibit:, visibility:, **)
+      job_tracker.update(status: 'in_progress')
+
+      @errors = 0
+
       each_document(solr_params, exhibit) do |document|
         case visibility
         when 'public'
@@ -12,8 +19,24 @@ module Spotlight
           document.make_private!(exhibit)
         end
         document.reindex(update_params: {})
+        progress&.increment
+      rescue StandardError => e
+        job_tracker.append_log_entry(type: :error, exhibit: exhibit, message: e.to_s)
+        @errors += 1
       end
       exhibit.blacklight_config.repository.connection.commit
+      job_tracker.append_log_entry(type: :info, exhibit: exhibit, message: "#{progress.progress} of #{progress.total} (#{@errors} errors)")
+    ensure
+      job_tracker.update(status: @errors.zero? ? 'completed' : 'failed', data: { progress: progress.progress, total: progress.total })
+    end
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
+    def job_tracking_resource
+      arguments.last[:exhibit]
+    end
+
+    def reports_on_resource
+      arguments.last[:exhibit] if arguments.last.is_a?(Hash)
     end
 
     # rubocop:disable Metrics/MethodLength
@@ -32,7 +55,7 @@ module Spotlight
             'sort' => "#{exhibit.blacklight_config.document_model.unique_key} asc"
           )
         )
-
+        progress.total = response.total
         response.documents.each do |document|
           block.call(document)
         end

--- a/app/jobs/spotlight/change_visibility_job.rb
+++ b/app/jobs/spotlight/change_visibility_job.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Spotlight
+  ###
+  class ChangeVisibilityJob < Spotlight::ApplicationJob
+    def perform(solr_params:, exhibit:, visibility:, **)
+      response = exhibit.blacklight_config.repository.search(solr_params.merge('rows' => 999_999_999))
+      response.documents.each do |document|
+        case visibility
+        when 'public'
+          document.make_public!(exhibit)
+        when 'private'
+          document.make_private!(exhibit)
+        end
+        document.reindex
+      end
+    end
+  end
+end

--- a/app/models/concerns/spotlight/solr_document/atomic_updates.rb
+++ b/app/models/concerns/spotlight/solr_document/atomic_updates.rb
@@ -5,12 +5,12 @@ module Spotlight
     ##
     # Solr indexing strategy using Solr's Atomic Updates
     module AtomicUpdates
-      def reindex
+      def reindex(update_params: { commitWithin: 500 })
         return unless write?
 
         data = hash_for_solr_update(to_solr)
 
-        blacklight_solr.update params: { commitWithin: 500 }, data: data.to_json, headers: { 'Content-Type' => 'application/json' } unless data.empty?
+        blacklight_solr.update params: update_params, data: data.to_json, headers: { 'Content-Type' => 'application/json' } unless data.empty?
       end
 
       def write?

--- a/app/models/spotlight/blacklight_configuration.rb
+++ b/app/models/spotlight/blacklight_configuration.rb
@@ -81,6 +81,7 @@ module Spotlight
         config.index.thumbnail_field ||= Spotlight::Engine.config.thumbnail_field
 
         config.add_results_collection_tool 'save_search', if: :render_save_this_search?
+        config.add_results_collection_tool 'bulk_actions', if: :render_bulk_actions?
 
         config.default_solr_params = config.default_solr_params.merge(default_solr_params)
 

--- a/app/views/catalog/_bulk_actions.html.erb
+++ b/app/views/catalog/_bulk_actions.html.erb
@@ -26,7 +26,7 @@
         <% ['public', 'private'].each do |key| %>
           <div class="form-check">
             <%= label_tag "visibility_#{key}", class: 'form-check-label'  do %>
-              <%= radio_button_tag :visibility, key, class: 'form-check-input' %>
+              <%= radio_button_tag :visibility, key, {}, class: 'form-check-input' %>
               <%= t(:"spotlight.bulk_actions.change_visibility.#{key}") %>
             <% end %>
           </div>

--- a/app/views/catalog/_bulk_actions.html.erb
+++ b/app/views/catalog/_bulk_actions.html.erb
@@ -1,4 +1,4 @@
-<div>
+<div class="dropdown bulk-actions-dropdown">
   <button class="btn btn-secondary dropdown-toggle" type="button" id="bulk-actions-button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     <%= t(:'spotlight.bulk_actions.label') %>
   </button>

--- a/app/views/catalog/_bulk_actions.html.erb
+++ b/app/views/catalog/_bulk_actions.html.erb
@@ -1,0 +1,43 @@
+<div>
+  <button class="btn btn-secondary dropdown-toggle" type="button" id="bulk-actions-button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <%= t(:'spotlight.bulk_actions.label') %>
+  </button>
+  <div class="dropdown-menu" aria-labelledby="bulk-actions-button">
+    <%= link_to t(:'spotlight.bulk_actions.change_visibility.heading'), '#', class: 'dropdown-item', data: {toggle:"modal", target:"#change-visibility-modal"} %>
+  </div>
+</div>
+<div class="modal fade" id="change-visibility-modal" tabindex="-1" role="dialog" aria-labelledby="save-modal-label" aria-hidden="true">
+  <div class="modal-dialog">
+  <%= bootstrap_form_for([:visibility, current_exhibit], url: visibility_exhibit_bulk_actions_path(current_exhibit), method: 'post') do |f| %>
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title" id="save-modal-label"><%= t(:'spotlight.bulk_actions.change_visibility.heading') %></h4>
+        <button type="button" class="blacklight-modal-close close" data-dismiss="modal" aria-label="<%= t('blacklight.modal.close') %>">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <p>
+          <%= t(:'spotlight.bulk_actions.change_visibility.description', count: @response.total) %>
+        </p>
+        <div class="form-check-label">
+          <%= t(:'spotlight.bulk_actions.change_visibility.label') %>
+        </div>
+        <% ['public', 'private'].each do |key| %>
+          <div class="form-check">
+            <%= label_tag "visibility_#{key}", class: 'form-check-label'  do %>
+              <%= radio_button_tag :visibility, key, class: 'form-check-input' %>
+              <%= t(:"spotlight.bulk_actions.change_visibility.#{key}") %>
+            <% end %>
+          </div>
+        <% end %>
+        <%= render_hash_as_hidden_fields(search_state.params_for_search) %>
+      </div>
+      <div class="modal-footer d-flex flex-row-reverse justify-content-start">
+        <%= f.submit t(:'spotlight.bulk_actions.change'), class: 'btn btn-primary', data: { confirm: t(:'spotlight.bulk_actions.confirm') } %>
+        <button type="button" class="btn btn-link" data-dismiss="modal"><%= t :cancel %></button>
+      </div>
+    </div>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -237,6 +237,21 @@ en:
         zero_results:
           expand_html: You can <a href="%{clear_search_url}"> clear this search</a> or try <a href="%{expand_search_url}">searching all exhibit items for "%{browse_query}"</a>.
           result_number: Your search did not match any items in this browse category.
+    bulk_actions:
+      change: Change
+      change_visibility:
+        changed:
+          one: Visibility of %{count} item is being updated.
+          other: Visibility of %{count} items is being updated.
+        description:
+          one: There is %{count} item in the current search result set. This change will be applied to all items.
+          other: There are %{count} items in the current search result set. This change will be applied to all items.
+        heading: Change item visibility
+        label: Item visibility
+        private: Private
+        public: Public
+      confirm: Are you sure?
+      label: Bulk actions
     catalog:
       admin:
         header: Items

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -141,6 +141,11 @@ Spotlight::Engine.routes.draw do
         get :clone
       end
     end
+    resource :bulk_actions, only: [] do
+      member do
+        post :visibility
+      end
+    end
     post '/pages/:id/preview' => 'pages#preview', as: :preview_block
     get '/pages' => 'pages#index', constraints: { format: 'json' }
 

--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -290,6 +290,7 @@ module Spotlight
 
     config.reindexing_batch_size = nil
     config.reindexing_batch_count = nil
+    config.bulk_actions_batch_size = 1000
 
     config.assign_default_roles_to_first_user = true
 

--- a/spec/controllers/spotlight/bulk_actions_controller_spec.rb
+++ b/spec/controllers/spotlight/bulk_actions_controller_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+describe Spotlight::BulkActionsController, type: :controller do
+  routes { Spotlight::Engine.routes }
+  let(:exhibit) { FactoryBot.create(:exhibit) }
+
+  before do
+    allow(Spotlight::ChangeVisibilityJob).to receive(:perform_later)
+  end
+
+  describe 'when the user is not authorized' do
+    before do
+      sign_in FactoryBot.create(:exhibit_visitor)
+    end
+
+    describe 'POST visibility' do
+      it 'denies access' do
+        post :visibility, params: { exhibit_id: exhibit }
+        expect(response).to redirect_to main_app.root_path
+        expect(flash[:alert]).to be_present
+      end
+    end
+  end
+
+  describe 'when the user is a curator' do
+    before do
+      sign_in FactoryBot.create(:exhibit_curator, exhibit: exhibit)
+    end
+
+    let(:search) { FactoryBot.create(:search, exhibit: exhibit) }
+    let(:search_session) { instance_double('Blacklight::Search', query_params: { q: 'map' }) }
+
+    it 'redirects and sets a notice' do
+      allow(controller).to receive(:current_search_session).and_return(search_session)
+      request.env['HTTP_REFERER'] = '/referring_url'
+      post :visibility, params: { 'visibility' => 'private', 'q' => 'map', exhibit_id: exhibit }
+      expect(response).to redirect_to '/referring_url'
+      expect(flash[:notice]).to eq 'Visibility of 55 items is being updated.'
+    end
+  end
+end

--- a/spec/controllers/spotlight/catalog_controller_spec.rb
+++ b/spec/controllers/spotlight/catalog_controller_spec.rb
@@ -517,6 +517,25 @@ describe Spotlight::CatalogController, type: :controller do
         expect(controller).not_to be_render_save_this_search
       end
     end
+
+    describe 'render_bulk_actions?' do
+      it 'returns false if we are on the items admin screen' do
+        allow(controller).to receive(:can?).with(:curate, current_exhibit).and_return(true)
+        allow(controller).to receive(:params).and_return(controller: 'spotlight/catalog', action: 'admin')
+        expect(controller).not_to be_render_bulk_actions
+      end
+
+      it 'returns true if we are not on the items admin screen' do
+        allow(controller).to receive(:can?).with(:curate, current_exhibit).and_return(true)
+        allow(controller).to receive(:params).and_return(controller: 'spotlight/catalog', action: 'index')
+        expect(controller).to be_render_bulk_actions
+      end
+
+      it 'returns false if a user cannot curate the object' do
+        allow(controller).to receive(:can?).with(:curate, current_exhibit).and_return(false)
+        expect(controller).not_to be_render_bulk_actions
+      end
+    end
   end
 
   describe '#setup_next_and_previous_documents_from_browse_category' do

--- a/spec/features/bulk_actions_spec.rb
+++ b/spec/features/bulk_actions_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+describe 'Bulk actions' do
+  let(:exhibit) { FactoryBot.create(:exhibit) }
+  let(:curator) { FactoryBot.create(:exhibit_curator, exhibit: exhibit) }
+
+  before do
+    login_as curator
+    d = SolrDocument.new(id: 'dq287tq6352')
+    d.make_private! exhibit
+    d.reindex
+    Blacklight.default_index.connection.commit
+  end
+
+  after do
+    d = SolrDocument.new(id: 'dq287tq6352')
+    d.make_public! exhibit
+    d.reindex
+    Blacklight.default_index.connection.commit
+  end
+
+  it 'setting item visibility', js: true do
+    visit spotlight.search_exhibit_catalog_path(exhibit, { q: 'dq287tq6352' })
+
+    click_button 'Bulk actions'
+    click_link 'Change item visibility'
+    expect(page).to have_css 'h4', text: 'Change item visibility', visible: true
+    choose 'Private'
+    accept_confirm 'Are you sure?' do
+      click_button 'Change'
+    end
+    expect(page).to have_css '.alert', text: 'Visibility of 1 item is being updated.'
+    expect(SolrDocument.new(id: 'dq287tq6352').private?(exhibit)).to be true
+  end
+end

--- a/spec/jobs/spotlight/change_visibility_job_spec.rb
+++ b/spec/jobs/spotlight/change_visibility_job_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+describe Spotlight::ChangeVisibilityJob do
+  subject { described_class.new(solr_params: solr_params, exhibit: exhibit, visibility: visibility) }
+
+  let(:solr_params) { { q: 'map' } }
+  let(:exhibit) { FactoryBot.create(:exhibit) }
+  let(:visibility) { 'private' }
+
+  it 'sets the items based off of the visibility' do
+    subject.perform_now
+    response = exhibit.blacklight_config.repository.search(solr_params.merge('rows' => 999_999_999))
+    expect(response.total).to eq 55
+    response.documents.each do |document|
+      expect(document.private?(exhibit)).to be true
+      document.make_public!(exhibit)
+      document.reindex
+    end
+  end
+end

--- a/spec/jobs/spotlight/change_visibility_job_spec.rb
+++ b/spec/jobs/spotlight/change_visibility_job_spec.rb
@@ -15,6 +15,12 @@ describe Spotlight::ChangeVisibilityJob do
     subject.perform_now
     response = exhibit.blacklight_config.repository.search(solr_params.merge('rows' => 999_999_999))
     expect(response.total).to eq 55
+    expect(Spotlight::JobTracker.last).to have_attributes(
+      status: 'completed',
+      total: 55,
+      progress: 55,
+      job_class: 'Spotlight::ChangeVisibilityJob'
+    )
     response.documents.each do |document|
       expect(document.private?(exhibit)).to be true
       document.make_public!(exhibit)

--- a/spec/jobs/spotlight/change_visibility_job_spec.rb
+++ b/spec/jobs/spotlight/change_visibility_job_spec.rb
@@ -7,6 +7,10 @@ describe Spotlight::ChangeVisibilityJob do
   let(:exhibit) { FactoryBot.create(:exhibit) }
   let(:visibility) { 'private' }
 
+  before do
+    allow(Spotlight::Engine.config).to receive_messages(bulk_actions_batch_size: 5)
+  end
+
   it 'sets the items based off of the visibility' do
     subject.perform_now
     response = exhibit.blacklight_config.repository.search(solr_params.merge('rows' => 999_999_999))

--- a/spec/models/spotlight/solr_document/atomic_updates_spec.rb
+++ b/spec/models/spotlight/solr_document/atomic_updates_spec.rb
@@ -37,6 +37,16 @@ describe Spotlight::SolrDocument::AtomicUpdates, type: :model do
       subject.reindex
     end
 
+    it 'update parameters can be specified to modify commitWithin' do
+      expected = {
+        params: { commitWithin: 5001 },
+        data: [{ id: 'doc_id', a: { set: 1 }, b: { set: 2 }, timestamp: { set: nil } }].to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      }
+      expect(blacklight_solr).to receive(:update).with(expected)
+      subject.reindex(update_params: { commitWithin: 5001 })
+    end
+
     it 'cowardlies refuse to index a document if the only value is an id' do
       allow(subject).to receive_messages(to_solr: { id: 'doc_id' }, timestamp: { set: nil })
       expect(blacklight_solr).not_to receive(:update)


### PR DESCRIPTION
Fixes #2645 and fixes #2644
![Screen Shot 2021-02-24 at 7 56 54 AM](https://user-images.githubusercontent.com/1656824/109019093-e890ff80-7675-11eb-987d-50796542381f.png)
![Screen Shot 2021-02-24 at 7 57 43 AM](https://user-images.githubusercontent.com/1656824/109019182-fe9ec000-7675-11eb-8819-e5b319bf1010.png)

![Kapture 2021-02-24 at 07 56 31](https://user-images.githubusercontent.com/1656824/109019113-edee4a00-7675-11eb-8949-f4e628435c81.gif)



Todos:
 - [x] Use cursorMark to paginate solr response in job
 - [x] commit optimization?
 - [x] job tracking? (maybe can be split out?)