### PR TITLE
Add the initial bulk updates admin pages

### DIFF
--- a/app/controllers/spotlight/bulk_updates_controller.rb
+++ b/app/controllers/spotlight/bulk_updates_controller.rb
@@ -1,9 +1,42 @@
 # frozen_string_literal: true
 
+require 'csv'
+
 module Spotlight
   ##
   # Controller enabling bulk functionality for items defined in a spreadsheet.
   class BulkUpdatesController < Spotlight::ApplicationController
+    before_action :authenticate_user!
+    before_action :check_authorization
+
     def edit; end
+
+    def download_template
+      send_data csv_template, type: 'text/csv', filename: 'bulk-update-template.csv'
+    end
+
+    private
+
+    def csv_template
+      boolean = ActiveModel::Type::Boolean.new
+      Spotlight::BulkUpdatesCsvTemplateService.new(exhibit: current_exhibit).template(
+        view_context: view_context,
+        title: boolean.cast(reference_field_params[:item_title]),
+        tags: boolean.cast(updatable_field_params[:tags]),
+        visibility: boolean.cast(updatable_field_params[:visibility])
+      )
+    end
+
+    def reference_field_params
+      params.require(:reference_fields).permit(:item_title)
+    end
+
+    def updatable_field_params
+      params.require(:updatable_fields).permit(:visibility, :tags)
+    end
+
+    def check_authorization
+      authorize! :curate, current_exhibit
+    end
   end
 end

--- a/app/controllers/spotlight/bulk_updates_controller.rb
+++ b/app/controllers/spotlight/bulk_updates_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Spotlight
+  ##
+  # Controller enabling bulk functionality for items defined in a spreadsheet.
+  class BulkUpdatesController < Spotlight::ApplicationController
+    def edit; end
+  end
+end

--- a/app/controllers/spotlight/bulk_updates_controller.rb
+++ b/app/controllers/spotlight/bulk_updates_controller.rb
@@ -36,7 +36,7 @@ module Spotlight
     end
 
     def check_authorization
-      authorize! :curate, current_exhibit
+      authorize! :bulk_update, current_exhibit
     end
   end
 end

--- a/app/models/concerns/spotlight/exhibit_documents.rb
+++ b/app/models/concerns/spotlight/exhibit_documents.rb
@@ -23,11 +23,11 @@ module Spotlight
       end
     end
 
-    private
-
     def exhibit_search_builder
       blacklight_config.search_builder_class.new(exhibit_search_builder_context).except(:apply_permissive_visibility_filter)
     end
+
+    private
 
     def exhibit_search_builder_context
       OpenStruct.new(blacklight_config: blacklight_config.tap { |x| x.current_exhibit = self })

--- a/app/models/spotlight/ability.rb
+++ b/app/models/spotlight/ability.rb
@@ -37,7 +37,7 @@ module Spotlight
       can :manage, Spotlight::Lock, by: user
 
       can :read, Spotlight::Language, exhibit_id: user.exhibit_roles.pluck(:resource_id)
-      can %i[read curate tag], Spotlight::Exhibit, id: user.exhibit_roles.pluck(:resource_id)
+      can %i[read curate tag bulk_update], Spotlight::Exhibit, id: user.exhibit_roles.pluck(:resource_id)
 
       # public
       can :read, Spotlight::HomePage

--- a/app/services/spotlight/bulk_updates_csv_template_service.rb
+++ b/app/services/spotlight/bulk_updates_csv_template_service.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'csv'
+
+module Spotlight
+  # A service to generate a CSV template suitable for re-uploading for bulk updates
+  class BulkUpdatesCsvTemplateService
+    attr_reader :exhibit
+
+    def initialize(exhibit:)
+      @exhibit = exhibit
+    end
+
+    def template(view_context:, title: true, tags: true, visibility: true)
+      ::CSV.generate(headers: csv_headers(title: title, tags: tags, visibility: visibility), write_headers: true) do |csv|
+        each_document do |document|
+          sidecar = document.sidecar(exhibit)
+          csv << [
+            document.id,
+            (title_column(view_context, document) if title),
+            (visibility_column(sidecar) if visibility),
+            (tags_column(sidecar) if tags)
+          ].flatten.compact
+        end
+      end
+    end
+
+    private
+
+    def title_column(view_context, document)
+      CGI.unescapeHTML(view_context.document_presenter(document).heading)
+    end
+
+    def visibility_column(sidecar)
+      sidecar.public
+    end
+
+    def tags_column(sidecar)
+      exhibit_tags.map do |tag|
+        sidecar.all_tags_list.include?(tag) ? 'TRUE' : ' '
+      end
+    end
+
+    def exhibit_tags
+      @exhibit_tags ||= exhibit.owned_tags.map(&:name)
+    end
+
+    def csv_headers(title:, tags:, visibility:)
+      headers = [bulk_updates_config.csv_id]
+      headers.append(bulk_updates_config.csv_title) if title
+      headers.append(bulk_updates_config.csv_visibility) if visibility
+      if tags
+        exhibit_tags.each do |tag|
+          headers.append(format(bulk_updates_config.csv_tags, tag))
+        end
+      end
+      headers
+    end
+
+    def bulk_updates_config
+      Spotlight::Engine.config.bulk_updates
+    end
+
+    # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+    def each_document(&block)
+      return to_enum(:each_document) unless block_given?
+
+      cursor_mark = nil
+      next_cursor_mark = '*'
+
+      solr_params = exhibit&.exhibit_search_builder&.to_h || {}
+
+      until next_cursor_mark == cursor_mark || next_cursor_mark.nil?
+        cursor_mark = next_cursor_mark
+        response = exhibit.blacklight_config.repository.search(
+          solr_params.merge(
+            'q' => '*',
+            'rows' => Spotlight::Engine.config.bulk_actions_batch_size,
+            'cursorMark' => cursor_mark,
+            'sort' => "#{exhibit.blacklight_config.document_model.unique_key} asc"
+          )
+        )
+        response.documents.each do |document|
+          block.call(document)
+        end
+
+        next_cursor_mark = response['nextCursorMark']
+      end
+    end
+    # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+  end
+end

--- a/app/views/spotlight/bulk_updates/_download.html.erb
+++ b/app/views/spotlight/bulk_updates/_download.html.erb
@@ -1,23 +1,21 @@
-<p class="instructions">
-  A CSV file listing each item in this exhibit will be generated with the reference and updatable fields you specify below. <i>Reference fields</i> are intended to help you identify items that you intend to update. <i>Updatable fields</i> are the fields for which you can update values (see guidelines below).
-</p>
+<p class="instructions"><%= t('.instructions_html') %></p>
 
 <%= bootstrap_form_with(url: download_template_exhibit_bulk_updates_path) do |f| %>
   <div class="row">
     <div class="col col-3">
-      <%= f.form_group(:reference_fields, label: { text: 'Reference fields' }) do %>
-        <%= f.check_box('reference_fields[item_id]', label: 'Item ID', checked: true, disabled: true) %>
-        <%= f.check_box('reference_fields[item_title]', label: 'Item title') %>
+      <%= f.form_group(:reference_fields, label: { text: t('.reference_fields.heading'), class: 'font-weight-bold' }) do %>
+        <%= f.check_box('reference_fields[item_id]', label: t('.item_id'), checked: true, disabled: true) %>
+        <%= f.check_box('reference_fields[item_title]', label: t('.item_title')) %>
       <% end %>
     </div>
     <div class="col col-3">
-      <%= f.form_group(:updatable_fields, label: { text: 'Updatable fields' }) do %>
-        <%= f.check_box('updatable_fields[visibility]', label: 'Visibility') %>
-        <%= f.check_box('updatable_fields[tags]', label: 'Tags') %>
+      <%= f.form_group(:updatable_fields, label: { text: t('.updatable_fields.heading'), class: 'font-weight-bold' }) do %>
+        <%= f.check_box('updatable_fields[visibility]', checked: true, label: t('.visibility')) %>
+        <%= f.check_box('updatable_fields[tags]', label: t('.tags')) %>
       <% end %>
     </div>
     <div class="col col-3">
-      <%= f.submit 'Download CSV file', class: 'btn btn-primary'  %>
+      <%= f.submit t('.submit'), class: 'btn btn-primary'  %>
     </div>
   </div>
 <% end %>

--- a/app/views/spotlight/bulk_updates/_download.html.erb
+++ b/app/views/spotlight/bulk_updates/_download.html.erb
@@ -19,3 +19,5 @@
     </div>
   </div>
 <% end %>
+
+<%= t('.guidelines_html') %>

--- a/app/views/spotlight/bulk_updates/_download.html.erb
+++ b/app/views/spotlight/bulk_updates/_download.html.erb
@@ -1,0 +1,23 @@
+<p class="instructions">
+  A CSV file listing each item in this exhibit will be generated with the reference and updatable fields you specify below. <i>Reference fields</i> are intended to help you identify items that you intend to update. <i>Updatable fields</i> are the fields for which you can update values (see guidelines below).
+</p>
+
+<%= bootstrap_form_with(url: download_template_exhibit_bulk_updates_path) do |f| %>
+  <div class="row">
+    <div class="col col-3">
+      <%= f.form_group(:reference_fields, label: { text: 'Reference fields' }) do %>
+        <%= f.check_box('reference_fields[item_id]', label: 'Item ID', checked: true, disabled: true) %>
+        <%= f.check_box('reference_fields[item_title]', label: 'Item title') %>
+      <% end %>
+    </div>
+    <div class="col col-3">
+      <%= f.form_group(:updatable_fields, label: { text: 'Updatable fields' }) do %>
+        <%= f.check_box('updatable_fields[visibility]', label: 'Visibility') %>
+        <%= f.check_box('updatable_fields[tags]', label: 'Tags') %>
+      <% end %>
+    </div>
+    <div class="col col-3">
+      <%= f.submit 'Download CSV file', class: 'btn btn-primary'  %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/spotlight/bulk_updates/_overview.html.erb
+++ b/app/views/spotlight/bulk_updates/_overview.html.erb
@@ -1,18 +1,1 @@
-<p>You can update in bulk several properties of items in this exhibit:</p>
-
-<ul>
-  <li>Visibility</li>
-  <li>Tags</li>
-  <li>Custom metadata fields</li>
-</ul>
-
-<p>The steps to making bulk updates are:</p>
-
-<ol>
-  <li>Download a CSV (comma-separated values) file from the Download CSV tab above. The downloaded CSV file will contain a row for every item in this exhibit. Each row contains the unique ID of an exhibit item along with the values of the reference and updatable fields you specify.</li>
-  <li>Import the CSV file into a new spreadsheet, using an application such as a Google Sheets or Excel.</li>
-  <li>In the new spreadsheet, update the values for the updatable fields of exhibit items you want to change. When you’ve finished making updates, save the spreadsheet.</li>
-  <li>(Optional) Remove the rows for items that contain no updated values. This is not required but for exhibits with many items this can speed up the import process. If necessary, save the spreadsheet.</li>
-  <li>Download/export the updated spreadsheet to your computer as a .csv file.</li>
-  <li>Use the Upload CSV tab above to submit the updated file for processing.</li>
-</ol>
+<%= t('.instructions_html') %>

--- a/app/views/spotlight/bulk_updates/_overview.html.erb
+++ b/app/views/spotlight/bulk_updates/_overview.html.erb
@@ -1,0 +1,18 @@
+<p>You can update in bulk several properties of items in this exhibit:</p>
+
+<ul>
+  <li>Visibility</li>
+  <li>Tags</li>
+  <li>Custom metadata fields</li>
+</ul>
+
+<p>The steps to making bulk updates are:</p>
+
+<ol>
+  <li>Download a CSV (comma-separated values) file from the Download CSV tab above. The downloaded CSV file will contain a row for every item in this exhibit. Each row contains the unique ID of an exhibit item along with the values of the reference and updatable fields you specify.</li>
+  <li>Import the CSV file into a new spreadsheet, using an application such as a Google Sheets or Excel.</li>
+  <li>In the new spreadsheet, update the values for the updatable fields of exhibit items you want to change. When you’ve finished making updates, save the spreadsheet.</li>
+  <li>(Optional) Remove the rows for items that contain no updated values. This is not required but for exhibits with many items this can speed up the import process. If necessary, save the spreadsheet.</li>
+  <li>Download/export the updated spreadsheet to your computer as a .csv file.</li>
+  <li>Use the Upload CSV tab above to submit the updated file for processing.</li>
+</ol>

--- a/app/views/spotlight/bulk_updates/edit.html.erb
+++ b/app/views/spotlight/bulk_updates/edit.html.erb
@@ -23,6 +23,7 @@
     </div>
 
     <div role="tabpanel" class="tab-pane" id="download">
+      <%= render 'download' %>
     </div>
 
     <div role="tabpanel" class="tab-pane" id="upload">

--- a/app/views/spotlight/bulk_updates/edit.html.erb
+++ b/app/views/spotlight/bulk_updates/edit.html.erb
@@ -1,0 +1,31 @@
+<% content_for(:sidebar) do %>
+  <%= render 'spotlight/shared/exhibit_sidebar' %>
+<% end %>
+
+<%= curation_page_title t(:".header") %>
+
+<div role="tabpanel">
+  <ul class="nav nav-tabs" role="tablist">
+    <li role="presentation" class="nav-item">
+      <a href="#overview" aria-controls="overview" role="tab" data-toggle="tab" class="nav-link active"><%= t(:'.overview.heading') %></a>
+    </li>
+    <li role="presentation" class="nav-item">
+      <a href="#download" aria-controls="download" role="tab" data-toggle="tab" class="nav-link"><%= t(:'.download.heading') %></a>
+    </li>
+    <li role="presentation" class="nav-item">
+      <a href="#upload" aria-controls="upload" role="tab" data-toggle="tab" class="nav-link"><%= t(:'.upload.heading') %></a>
+    </li>
+  </ul>
+
+  <div class="tab-content">
+    <div role="tabpanel" class="tab-pane active" id="overview">
+      <%= render 'overview' %>
+    </div>
+
+    <div role="tabpanel" class="tab-pane" id="download">
+    </div>
+
+    <div role="tabpanel" class="tab-pane" id="upload">
+    </div>
+  </div>
+</div>

--- a/app/views/spotlight/shared/_curation_sidebar.html.erb
+++ b/app/views/spotlight/shared/_curation_sidebar.html.erb
@@ -17,7 +17,7 @@
   <% if (can? :manage, current_exhibit.translations.first_or_initialize) && current_exhibit.languages.any? %>
     <%= nav_link t(:'spotlight.curation.sidebar.translations'), spotlight.edit_exhibit_translations_path(current_exhibit), 'data-no-turbolink' => true %>
   <% end %>
-  <% if can? :curate, current_exhibit %>
+  <% if can? :bulk_update, current_exhibit %>
     <%= nav_link t(:'spotlight.curation.sidebar.bulk_updates'), spotlight.edit_exhibit_bulk_updates_path(current_exhibit), 'data-no-turbolink' => true %>
   <% end %>
 </ul>

--- a/app/views/spotlight/shared/_curation_sidebar.html.erb
+++ b/app/views/spotlight/shared/_curation_sidebar.html.erb
@@ -17,4 +17,7 @@
   <% if (can? :manage, current_exhibit.translations.first_or_initialize) && current_exhibit.languages.any? %>
     <%= nav_link t(:'spotlight.curation.sidebar.translations'), spotlight.edit_exhibit_translations_path(current_exhibit), 'data-no-turbolink' => true %>
   <% end %>
+  <% if can? :curate, current_exhibit %>
+    <%= nav_link t(:'spotlight.curation.sidebar.bulk_updates'), spotlight.edit_exhibit_bulk_updates_path(current_exhibit), 'data-no-turbolink' => true %>
+  <% end %>
 </ul>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -275,6 +275,46 @@ en:
         label: Enter tags to remove
     bulk_updates:
       download:
+        guidelines_html: |
+          <h2>Guidelines for CSV updates</h2>
+          <p class="instructions">
+            The downloadable CSV file for this exhibit contains one line for each item in the exhibit. Each line contains one or more comma-separated values. Although you can update the CSV file directly, we strongly recommended importing it into a spreadsheet application and making your updates there. The rest of these guidelines assume you are making updates in a spreadsheet.
+          </p>
+
+          <h3>Column headers</h3>
+          <p class="instructions">
+            Do not edit the column headers. These are used to match property values to existing exhibit item fields.
+          </p>
+
+          <h3>Reference fields</h3>
+          <p class="instructions">
+            Do not edit the reference fields. These are intended to help you identify items whose updatable fields you might want to change. Updates to the reference fields will not be processed.
+          </p>
+
+          <p class="instructions">
+            If you are making a lot of updates, we recommended you use the protect or lock feature of your spreadsheet application to lock the reference field columns and ensure you don’t inadvertently edit them.
+          </p>
+
+          <h3>Updatable fields</h3>
+          <dl>
+            <dt>Visibility</dt>
+            <dd>Valid values are public and private. If no value is present, the item is assigned a value of private.</dd>
+
+            <dt>Tags</dt>
+            <dd>
+              <p class="instructions">
+                If you chose to include tags in the CSV file, there will be a column in the spreadsheet for each existing tag in the exhibit, prefixed with “Tag:”, such as “Tag: apples”.
+              </p>
+
+              <p class="instructions">
+                To assign a tag to an exhibit item, the value of the “Tag:” column for that item must be true. A blank value (or any value other than true) in the “Tag:” column for an item means that tag is not assigned to that item.
+              </p>
+
+              <p class="instructions">
+                To remove a tag currently assigned to an item, remove the true value from the appropriate “Tag:” column for that item.
+              </p>
+            </dd>
+          </dl>
         instructions_html: A CSV file listing each item in this exhibit will be generated with the reference and updatable fields you specify below. <i>Reference fields</i> are intended to help you identify items that you intend to update. <i>Updatable fields</i> are the fields for which you can update values (see guidelines below).
         item_id: Item ID
         item_title: Item title

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -273,6 +273,15 @@ en:
           other: "<p>There are %{count} items in the current search result set. Tags shown below are assigned to one or more of those items.</p><p>When you delete a tag below it will be removed from any item in the current result set to which that tag is assigned.</p>"
         heading: Remove tags
         label: Enter tags to remove
+    bulk_updates:
+      edit:
+        download:
+          heading: Download CSV
+        header: Bulk updates
+        overview:
+          heading: Overview
+        upload:
+          heading: Upload CSV
     catalog:
       admin:
         header: Items
@@ -355,6 +364,7 @@ en:
         about_pages: About pages
         analytics: Analytics
         browse: Browse
+        bulk_updates: Bulk updates
         dashboard: Dashboard
         feature_pages: Feature pages
         header: Curation

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -274,6 +274,17 @@ en:
         heading: Remove tags
         label: Enter tags to remove
     bulk_updates:
+      download:
+        instructions_html: A CSV file listing each item in this exhibit will be generated with the reference and updatable fields you specify below. <i>Reference fields</i> are intended to help you identify items that you intend to update. <i>Updatable fields</i> are the fields for which you can update values (see guidelines below).
+        item_id: Item ID
+        item_title: Item title
+        reference_fields:
+          heading: Reference fields
+        submit: Download CSV file
+        tags: Tags
+        updatable_fields:
+          heading: Updatable fields
+        visibility: Visibility
       edit:
         download:
           heading: Download CSV
@@ -282,6 +293,20 @@ en:
           heading: Overview
         upload:
           heading: Upload CSV
+      overview:
+        instructions_html: |
+          <p>You can update in bulk several properties of items in this exhibit:</p> <ul>
+            <li>Visibility</li>
+            <li>Tags</li>
+            <li>Custom metadata fields</li>
+          </ul> <p>The steps to making bulk updates are:</p> <ol>
+            <li>Download a CSV (comma-separated values) file from the Download CSV tab above. The downloaded CSV file will contain a row for every item in this exhibit. Each row contains the unique ID of an exhibit item along with the values of the reference and updatable fields you specify.</li>
+            <li>Import the CSV file into a new spreadsheet, using an application such as a Google Sheets or Excel.</li>
+            <li>In the new spreadsheet, update the values for the updatable fields of exhibit items you want to change. When you’ve finished making updates, save the spreadsheet.</li>
+            <li>(Optional) Remove the rows for items that contain no updated values. This is not required but for exhibits with many items this can speed up the import process. If necessary, save the spreadsheet.</li>
+            <li>Download/export the updated spreadsheet to your computer as a .csv file.</li>
+            <li>Use the Upload CSV tab above to submit the updated file for processing.</li>
+          </ol>
     catalog:
       admin:
         header: Items

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -149,7 +149,11 @@ Spotlight::Engine.routes.draw do
       end
     end
 
-    resource :bulk_updates, only: %i[edit]
+    resource :bulk_updates, only: %i[edit] do
+      member do
+        post :download_template
+      end
+    end
 
     post '/pages/:id/preview' => 'pages#preview', as: :preview_block
     get '/pages' => 'pages#index', constraints: { format: 'json' }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -148,6 +148,9 @@ Spotlight::Engine.routes.draw do
         post :remove_tags
       end
     end
+
+    resource :bulk_updates, only: %i[edit]
+
     post '/pages/:id/preview' => 'pages#preview', as: :preview_block
     get '/pages' => 'pages#index', constraints: { format: 'json' }
 

--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -292,6 +292,12 @@ module Spotlight
     config.reindexing_batch_count = nil
     config.bulk_actions_batch_size = 1000
 
+    config.bulk_updates = OpenStruct.new
+    config.bulk_updates.csv_id = 'Item ID'
+    config.bulk_updates.csv_title = 'Item Title'
+    config.bulk_updates.csv_visibility = 'Visibility'
+    config.bulk_updates.csv_tags = 'Tag: %s'
+
     config.assign_default_roles_to_first_user = true
 
     config.exhibit_roles = %w[admin curator]

--- a/spec/controllers/spotlight/bulk_actions_controller_spec.rb
+++ b/spec/controllers/spotlight/bulk_actions_controller_spec.rb
@@ -60,7 +60,7 @@ describe Spotlight::BulkActionsController, type: :controller do
       it 'redirects and sets a notice' do
         allow(controller).to receive(:current_search_session).and_return(search_session)
         request.env['HTTP_REFERER'] = '/referring_url'
-        post :add_tags, params: { 'tags' => 'hello,world', 'q' => 'map', exhibit_id: exhibit }
+        post :add_tags, params: { 'tags' => 'howdy,planet', 'q' => 'map', exhibit_id: exhibit }
         expect(response).to redirect_to '/referring_url'
         expect(flash[:notice]).to eq 'Tags are being added for 55 items.'
       end

--- a/spec/controllers/spotlight/bulk_updates_controller_spec.rb
+++ b/spec/controllers/spotlight/bulk_updates_controller_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+describe Spotlight::BulkUpdatesController, type: :controller do
+  routes { Spotlight::Engine.routes }
+  let(:exhibit) { FactoryBot.create(:exhibit) }
+
+  describe 'when the user is not authorized' do
+    before do
+      sign_in FactoryBot.create(:exhibit_visitor)
+    end
+
+    describe 'GET edit' do
+      it 'denies access' do
+        get :edit, params: { exhibit_id: exhibit }
+        expect(response).to redirect_to main_app.root_path
+        expect(flash[:alert]).to be_present
+      end
+    end
+
+    describe 'POST download_template' do
+      it 'denies access' do
+        post :download_template, params: { exhibit_id: exhibit }
+        expect(response).to redirect_to main_app.root_path
+        expect(flash[:alert]).to be_present
+      end
+    end
+  end
+
+  describe 'when the user is a curator' do
+    before do
+      sign_in FactoryBot.create(:exhibit_curator, exhibit: exhibit)
+    end
+
+    describe 'GET edit' do
+      it 'is allowed' do
+        get :edit, params: { exhibit_id: exhibit }
+        expect(response).to be_successful
+      end
+    end
+
+    describe 'POST download_template' do
+      it 'downloads a CSV template' do
+        post :download_template, params: {
+          exhibit_id: exhibit,
+          reference_fields: { item_id: 1, item_title: 1 },
+          updatable_fields: { tags: 0, visibility: 1 }
+        }
+
+        content = CSV.parse(response.body)
+        expect(content.length).to eq 56
+        expect(content[0]).to eq ['Item ID', 'Item Title', 'Visibility']
+      end
+    end
+  end
+end

--- a/spec/models/spotlight/ability_spec.rb
+++ b/spec/models/spotlight/ability_spec.rb
@@ -80,6 +80,7 @@ describe Spotlight::Ability, type: :model do
     it { is_expected.to be_able_to(:destroy, translation) }
 
     it { is_expected.to be_able_to(:tag, exhibit) }
+    it { is_expected.to be_able_to(:bulk_update, exhibit) }
 
     it { is_expected.to be_able_to(:edit, contact) }
     it { is_expected.to be_able_to(:new, contact) }

--- a/spec/services/spotlight/bulk_updates_csv_template_service_spec.rb
+++ b/spec/services/spotlight/bulk_updates_csv_template_service_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Spotlight::BulkUpdatesCsvTemplateService do
+  subject(:service) { described_class.new(exhibit: exhibit) }
+
+  let(:exhibit) { FactoryBot.create(:exhibit) }
+  let!(:tag1) { FactoryBot.create(:tagging, tagger: exhibit, taggable: exhibit) }
+  let!(:tag2) { FactoryBot.create(:tagging, tagger: exhibit, taggable: exhibit) }
+
+  describe '#template' do
+    let(:view_context) { double('ViewContext', document_presenter: double('DocumentPresenter', heading: 'Document Title')) }
+
+    it 'has a row for every document (+ the header)' do
+      template = CSV.parse(service.template(view_context: view_context))
+      expect(template).to have_at_least(56).items
+      expect(template[0].join(',')).to match(/Item ID,Item Title,Visibility,Tag: tagging\d,Tag: tagging\d/)
+    end
+
+    it 'only has requested columns' do
+      template = CSV.parse(service.template(view_context: view_context, tags: false))
+      expect(template[0].join(',')).to eq 'Item ID,Item Title,Visibility'
+    end
+  end
+end


### PR DESCRIPTION
Part of sul-dlss/exhibits#1995
Closes sul-dlss/exhibits#1996
Closes sul-dlss/exhibits#1997
Closes sul-dlss/exhibits#1998
Closes sul-dlss/exhibits#1999

This will be a bit slow with a large amount of records.  I'm not sure there is much we could do about that unless we put this in the background and email the resulting CSV / CSV download link (which would be a pretty big departure from this)

<img width="1173" alt="Screen Shot 2021-02-25 at 4 36 00 PM" src="https://user-images.githubusercontent.com/96776/109238004-917b4f80-7787-11eb-8b8c-0026ff903e41.png">

<img width="668" alt="Screen Shot 2021-03-03 at 1 11 58 PM" src="https://user-images.githubusercontent.com/96776/109874059-78f5b400-7c23-11eb-8689-7fe526d7b862.png">
