### PR TITLE
Spike out a way to see Spotlight::Event data related to a job tracker

### DIFF
--- a/app/controllers/spotlight/job_trackers_controller.rb
+++ b/app/controllers/spotlight/job_trackers_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Spotlight
+  ##
+  # Locking mechanism for page-level locks
+  class JobTrackersController < Spotlight::ApplicationController
+    load_and_authorize_resource :exhibit
+    load_and_authorize_resource through: :exhibit
+
+    # GET /:exhibit_id/job_trackers/1
+    def show
+      add_breadcrumb t(:'spotlight.exhibits.breadcrumb', title: @exhibit.title), @exhibit
+      add_breadcrumb t(:'spotlight.curation.sidebar.dashboard'), exhibit_dashboard_path(@exhibit)
+      add_breadcrumb t(:'spotlight.configuration.sidebar.job_trackers'), [@job_tracker.on, @job_tracker]
+    end
+  end
+end

--- a/app/helpers/spotlight/job_trackers_helper.rb
+++ b/app/helpers/spotlight/job_trackers_helper.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Spotlight
+  # HTML <meta> tag helpers
+  module JobTrackersHelper
+    def job_status_icon(job_tracker)
+      content_tag :span, title: t(job_tracker.status || 'missing', scope: 'spotlight.job_trackers.status') do # rubocop:disable Rails/ContentTag
+        if job_tracker.enqueued? || job_tracker.in_progress?
+          '⏱'
+        elsif job_tracker.completed?
+          '✅'
+        elsif job_tracker.failed?
+          '🟥'
+        else
+          ''
+        end
+      end
+    end
+
+    def job_tracker_event_table_row_class(event)
+      case event.type
+      when 'error'
+        'table-danger'
+      when 'info', 'summary'
+        ''
+      else
+        "table-#{event.type}"
+      end
+    end
+  end
+end

--- a/app/models/spotlight/ability.rb
+++ b/app/models/spotlight/ability.rb
@@ -34,6 +34,8 @@ module Spotlight
         Translation
       ], exhibit_id: user.exhibit_roles.pluck(:resource_id)
 
+      can :read, Spotlight::JobTracker, on_id: user.exhibit_roles.pluck(:resource_id), on_type: 'Spotlight::Exhibit'
+
       can :manage, Spotlight::Lock, by: user
 
       can :read, Spotlight::Language, exhibit_id: user.exhibit_roles.pluck(:resource_id)

--- a/app/views/spotlight/dashboards/_reindexing_activity.html.erb
+++ b/app/views/spotlight/dashboards/_reindexing_activity.html.erb
@@ -18,7 +18,7 @@
         <td class="col-3"><%= tracker.user.email if tracker.user %></td>
         <td class="col-1"><%= tracker.progress %></td>
         <td class="col-3"><%= distance_of_time_in_words tracker.created_at, tracker.updated_at, include_seconds: true if tracker.completed? || tracker.failed? %></td>
-        <td class="col-2"><%= t "reindexing_log.status.#{tracker.status}" %></td>
+        <td class="col-2"><%= link_to_if can?(:read, tracker), t("spotlight.job_trackers.status.#{tracker.status}"), [current_exhibit, tracker], data: { blacklight_modal: 'trigger' } %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/spotlight/job_trackers/show.html.erb
+++ b/app/views/spotlight/job_trackers/show.html.erb
@@ -1,0 +1,79 @@
+<%= page_title 'Job details' %>
+<% content_for(:sidebar) do %>
+  <%= render 'spotlight/shared/exhibit_sidebar' %>
+<% end %>
+
+<div data-blacklight-modal="container">
+
+  <div class="modal-header border-0">
+    <h2 class="modal-title"><%= job_status_icon(@job_tracker) %> <%= t @job_tracker.job_class, default: @job_tracker.job_class %> <small class="text-monospace font-weight-lighter"><%= @job_tracker.job_id&.truncate(8, omission: '') %></small></h2>
+
+    <button type="button" class="blacklight-modal-close close" data-dismiss="modal" aria-label="<%= t('blacklight.modal.close') %>">
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
+
+  <div class="modal-body row">
+    <p class="mx-2 text-small">
+      <%= t(:".summary.#{@job_tracker.status}", default: '', last_updated: time_ago_in_words(@job_tracker.updated_at, include_seconds: true), created_at: time_ago_in_words(@job_tracker.updated_at, include_seconds: true), duration: distance_of_time_in_words(@job_tracker.created_at, @job_tracker.updated_at)) %>
+    </p>
+
+    <table class="table table-striped">
+      <thead>
+        <th></th>
+        <th><%= t('.headers.message') %></th>
+        <th><%= t('.headers.details') %></th>
+      </thead>
+
+      <tbody>
+        <% row_number = 0 %>
+        <tr>
+          <th scope="row" title="<%= l @job_tracker.created_at, format: :long %>"><%= row_number += 1 %></th>
+          <td><%= t('.messages.started') %></td>
+          <td><%= l @job_tracker.updated_at, format: :long %></td>
+        </tr>
+
+        <% if @job_tracker.user %>
+        <tr>
+          <th scope="row" title="<%= l @job_tracker.created_at, format: :long %>"><%= row_number += 1 %></th>
+          <td><%= t('.messages.created_by', user: @job_tracker.user.email) %></td>
+          <td></td>
+        </tr>
+        <% end %>
+
+        <% @job_tracker.events.order(:created_at, :collation_key).find_each do |e| %>
+          <tr class="<%= job_tracker_event_table_row_class(e) %>">
+            <th scope="row" title="<%= l e.created_at, format: :long %>"><%= row_number += 1 %></th>
+            <td><%= e.data[:message] %></td>
+            <td><pre><%= JSON.pretty_generate(e.data.except(:message)) %></pre></td>
+          </tr>
+        <% end %>
+
+        <% @job_tracker.subevents.where.not(type: :summary).order(:created_at, :collation_key).find_each do |e| %>
+          <tr class="<%= job_tracker_event_table_row_class(e) %>">
+            <th scope="row" title="<%= l e.created_at, format: :long %>"><%= row_number += 1 %></th>
+            <td><%= e.data[:message] %></td>
+            <td><pre><%= JSON.pretty_generate(e.data.except(:message)) %></pre></td>
+          </tr>
+        <% end %>
+
+        <% error_count = @job_tracker.subevents.where(type: :summary).find_each.sum { |e| e.data[:errors] } %>
+        <tr>
+          <th scope="row" title="<%= l @job_tracker.updated_at, format: :long %>"><%= row_number += 1 %></th>
+          <td>
+            <%= t('.messages.progress', progress: @job_tracker.progress, total: @job_tracker.total, errors: (t('.messages.errors', count: error_count) if error_count.positive?)) %>
+          </td>
+          <td></td>
+        </tr>
+
+        <% unless @job_tracker.in_progress? %>
+          <tr>
+            <th scope="row" title="<%= l @job_tracker.updated_at, format: :long %>"><%= row_number += 1 %></th>
+            <td><%= t(@job_tracker.status, scope: 'spotlight.job_trackers.show.messages.status', default: :'spotlight.job_trackers.show.messages.status.missing') %></td>
+            <td><%= l @job_tracker.updated_at, format: :long %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -165,12 +165,6 @@ en:
     pt-BR: Portuguese - Brazil
     sq: Albanian
     zh: Chinese
-  reindexing_log:
-    status:
-      completed: Successful
-      enqueued: Not yet started
-      failed: Failed
-      in_progress: In progress
   shared:
     site_sidebar:
       documentation: Curator documentation
@@ -396,6 +390,7 @@ en:
       sidebar:
         appearance: Appearance
         header: Configuration
+        job_trackers: Job status
         metadata: Metadata
         search_configuration: Search
         settings: General
@@ -631,6 +626,37 @@ en:
         someone_invited_you: The Exhibits Administrator has invited you to help work on the "%{exhibit_name}" exhibit.
         subject: Invitation to manage \"%{exhibit_name}\"
         visit: Visit exhibit
+    job_trackers:
+      show:
+        headers:
+          details: Details
+          message: Message
+        messages:
+          created_by: job created by %{user}
+          errors:
+            one: "(%{count} error)"
+            other: "(%{count} errors)"
+          progress: processed %{progress} / %{total}
+          started: job started
+          status:
+            completed: job completed
+            enqueued: job enqueued
+            failed: job failed
+            in_progress: ''
+            missing: "(missing status)"
+            pending: job pending
+        summary:
+          completed: Completed %{last_updated} ago in %{duration}
+          enqueued: In progress for %{created_at}
+          failed: Failed %{last_updated} ago in %{duration}
+          in_progress: In progress for %{created_at}
+      status:
+        completed: Successful
+        enqueued: Not yet started
+        failed: Failed
+        in_progress: In progress
+        missing: Unknown
+        pending: Pending
     main_navigation:
       about: About
       browse: Browse

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -159,6 +159,7 @@ Spotlight::Engine.routes.draw do
     get '/pages' => 'pages#index', constraints: { format: 'json' }
 
     resources :lock, only: [:destroy]
+    resources :job_trackers, only: [:show]
 
     resources :roles, path: 'users', only: %i[index create destroy] do
       collection do

--- a/spec/controllers/spotlight/job_trackers_controller_spec.rb
+++ b/spec/controllers/spotlight/job_trackers_controller_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+describe Spotlight::JobTrackersController, type: :controller do
+  routes { Spotlight::Engine.routes }
+  let(:job_tracker) { FactoryBot.create(:job_tracker, on: exhibit) }
+  let(:exhibit) { FactoryBot.create(:exhibit) }
+
+  describe 'when the user is not authorized' do
+    before do
+      sign_in FactoryBot.create(:exhibit_visitor)
+    end
+
+    describe 'GET show' do
+      it 'denies access' do
+        get :show, params: { exhibit_id: exhibit, id: job_tracker }
+        expect(response).to redirect_to main_app.root_path
+        expect(flash[:alert]).to be_present
+      end
+    end
+  end
+
+  describe 'when signed in' do
+    let(:user) { FactoryBot.create(:exhibit_admin, exhibit: exhibit) }
+
+    before { sign_in user }
+
+    describe 'GET show' do
+      it 'assigns breadcrumbs' do
+        expect(controller).to receive(:add_breadcrumb).with('Home', exhibit)
+        expect(controller).to receive(:add_breadcrumb).with('Dashboard', exhibit_dashboard_path(exhibit))
+        expect(controller).to receive(:add_breadcrumb).with('Job status', [exhibit, job_tracker])
+        get :show, params: { exhibit_id: exhibit, id: job_tracker }
+        expect(response).to be_successful
+      end
+    end
+  end
+end

--- a/spec/views/spotlight/dashboards/_reindexing_activity.html.erb_spec.rb
+++ b/spec/views/spotlight/dashboards/_reindexing_activity.html.erb_spec.rb
@@ -2,9 +2,11 @@
 
 describe 'spotlight/dashboards/_reindexing_activity.html.erb', type: :view do
   let(:p) { 'spotlight/dashboards/reindexing_activity' }
+  let(:exhibit) { FactoryBot.build(:exhibit) }
 
   before do
     assign(:recent_reindexing, recent_reindexing)
+    allow(view).to receive(:current_exhibit).and_return(exhibit)
   end
 
   context 'the reindexing log is empty' do

--- a/spec/views/spotlight/job_trackers/show.html.erb_spec.rb
+++ b/spec/views/spotlight/job_trackers/show.html.erb_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+describe 'spotlight/job_trackers/show', type: :view do
+  let(:exhibit) { FactoryBot.create(:exhibit) }
+  let(:job_tracker) { FactoryBot.create(:job_tracker, job_class: 'Spotlight::ReindexExhibitJob', on: exhibit, user: user) }
+  let(:user) { FactoryBot.create(:user) }
+
+  before do
+    assign(:exhibit, exhibit)
+    assign(:job_tracker, job_tracker)
+
+    allow(view).to receive_messages(current_exhibit: exhibit)
+  end
+
+  it 'displays the type of job' do
+    render
+    expect(rendered).to have_selector 'h2', text: 'Spotlight::ReindexExhibitJob'
+  end
+
+  it 'displays the job status for enqueued jobs' do
+    job_tracker.update(status: 'enqueued')
+    render
+    expect(rendered).to have_content '⏱'
+  end
+
+  it 'displays the job status for failed jobs' do
+    job_tracker.update(status: 'failed')
+    render
+    expect(rendered).to have_content '🟥'
+    expect(rendered).to have_content 'job failed'
+  end
+
+  it 'displays the job status for successful jobs' do
+    job_tracker.update(status: 'completed')
+    render
+    expect(rendered).to have_content '✅'
+    expect(rendered).to have_content 'job completed'
+  end
+
+  it 'display job started events' do
+    render
+    expect(rendered).to have_selector 'tr', text: '1 job started', normalize_ws: true
+  end
+
+  it 'records who started the job' do
+    render
+    expect(rendered).to have_selector 'tr', text: "2 job created by #{user.email}", normalize_ws: true
+  end
+
+  it 'displays logged messages' do
+    job_tracker.events.create(data: { message: 'this is a useful log message' })
+    job_tracker.events.create(data: { message: 'and so is this' })
+
+    render
+    expect(rendered).to have_selector 'tr', text: 'this is a useful log message'
+    expect(rendered).to have_selector 'tr', text: 'and so is this'
+  end
+
+  it 'displays job progress information' do
+    allow(job_tracker).to receive_messages(progress: 37, total: 51)
+
+    render
+    expect(rendered).to have_content 'processed 37 / 51'
+  end
+end


### PR DESCRIPTION
![Screen Shot 2021-02-26 at 09 45 51](https://user-images.githubusercontent.com/111218/109335822-6d674f00-7817-11eb-9382-111680322fae.png)

Put some information in a modal, linked to from the reindexing activity table's status label.