### PR TITLE
Do not render the bulk_actions UI on Browse groups

### DIFF
--- a/app/controllers/spotlight/browse_controller.rb
+++ b/app/controllers/spotlight/browse_controller.rb
@@ -134,5 +134,9 @@ module Spotlight
     def render_save_this_search?
       false
     end
+
+    def render_bulk_actions?
+      false
+    end
   end
 end


### PR DESCRIPTION
I'm not sure what the intention should be, my guess would be to not show it.. but lets disable it until we determine how to get the search injected.