### PR TITLE
Add a silly hack so the search results breadcrumb is marked as active

### DIFF
--- a/app/builders/spotlight/bootstrap_breadcrumbs_builder.rb
+++ b/app/builders/spotlight/bootstrap_breadcrumbs_builder.rb
@@ -21,10 +21,12 @@ module Spotlight
     end
 
     def render_element(element)
-      html_class = 'active' if @context.current_page?(compute_path(element))
+      current = @context.current_page?(compute_path(element)) || element.options&.dig(:current)
+
+      html_class = 'active' if current
 
       @context.content_tag(:li, class: "breadcrumb-item #{html_class}") do
-        @context.link_to_unless_current(element_label(element), compute_path(element), element.options)
+        @context.link_to_unless(current, element_label(element), compute_path(element), element.options&.except(:current))
       end
     end
 

--- a/app/controllers/spotlight/catalog_controller.rb
+++ b/app/controllers/spotlight/catalog_controller.rb
@@ -200,7 +200,9 @@ module Spotlight
     end
 
     def add_breadcrumb_with_search_params
-      add_breadcrumb t(:'spotlight.catalog.breadcrumb.index'), spotlight.search_exhibit_catalog_path(params.to_unsafe_h) if has_search_parameters?
+      return unless has_search_parameters?
+
+      add_breadcrumb t(:'spotlight.catalog.breadcrumb.index'), spotlight.search_exhibit_catalog_path(params.to_unsafe_h), current: action_name == 'index'
     end
 
     # rubocop:disable Metrics/AbcSize

--- a/blacklight-spotlight.gemspec
+++ b/blacklight-spotlight.gemspec
@@ -26,7 +26,7 @@ these collections.)
   s.add_dependency 'autoprefixer-rails'
   s.add_dependency 'blacklight', '~> 7.0'
   s.add_dependency 'bootstrap_form', '~> 4.1'
-  s.add_dependency 'breadcrumbs_on_rails', '~> 3.0'
+  s.add_dependency 'breadcrumbs_on_rails', '>= 3.0', '< 5'
   s.add_dependency 'cancancan'
   s.add_dependency 'carrierwave'
   s.add_dependency 'clipboard-rails', '~> 1.5'

--- a/spec/controllers/spotlight/catalog_controller_spec.rb
+++ b/spec/controllers/spotlight/catalog_controller_spec.rb
@@ -81,7 +81,7 @@ describe Spotlight::CatalogController, type: :controller do
     describe 'GET index' do
       it 'shows the index when there are parameters' do
         expect(controller).to receive(:add_breadcrumb).with('Home', exhibit_path(exhibit))
-        expect(controller).to receive(:add_breadcrumb).with('Search results', search_exhibit_catalog_path(exhibit, q: 'map'))
+        expect(controller).to receive(:add_breadcrumb).with('Search results', search_exhibit_catalog_path(exhibit, q: 'map'), current: true)
         get :index, params: { exhibit_id: exhibit, q: 'map' }
         expect(response).to be_successful
       end

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -30,6 +30,7 @@ describe 'Catalog', type: :feature do
   it 'has breadcrumbs' do
     visit spotlight.search_exhibit_catalog_path(exhibit, q: 'xyz')
     expect(page).to have_breadcrumbs 'Home', 'Search results'
+    expect(page).to have_selector '.breadcrumb-item.active', text: 'Search results'
   end
 
   describe 'Non-spotlight #show' do


### PR DESCRIPTION
The parameter order ends up not matching because rails does something internally to re-order them on us, so we can just tell breadcrumbs_on_rails that it is the current url and bypass the whole thing 🤷 . 