### PR TITLE
Rename extension_whitelist to extension_allowlist

### DIFF
--- a/app/uploaders/spotlight/featured_image_uploader.rb
+++ b/app/uploaders/spotlight/featured_image_uploader.rb
@@ -6,7 +6,7 @@ module Spotlight
   class FeaturedImageUploader < CarrierWave::Uploader::Base
     storage Spotlight::Engine.config.uploader_storage
 
-    def extension_whitelist
+    def extension_allowlist
       Spotlight::Engine.config.allowed_upload_extensions
     end
 

--- a/blacklight-spotlight.gemspec
+++ b/blacklight-spotlight.gemspec
@@ -28,7 +28,7 @@ these collections.)
   s.add_dependency 'bootstrap_form', '~> 4.1'
   s.add_dependency 'breadcrumbs_on_rails', '~> 3.0'
   s.add_dependency 'cancancan'
-  s.add_dependency 'carrierwave'
+  s.add_dependency 'carrierwave', '~> 2.2'
   s.add_dependency 'clipboard-rails', '~> 1.5'
   s.add_dependency 'devise', '~> 4.1'
   s.add_dependency 'devise_invitable'

--- a/spec/uploaders/spotlight/featured_image_uploader_spec.rb
+++ b/spec/uploaders/spotlight/featured_image_uploader_spec.rb
@@ -5,9 +5,9 @@ describe Spotlight::FeaturedImageUploader do
 
   let(:mounter) { FactoryBot.create(:featured_image) }
 
-  describe '#extension_whitelist' do
+  describe '#extension_allowlist' do
     it 'is the configured array of approved extension to be uploaded' do
-      expect(featured_image_uploader.extension_whitelist).to eq Spotlight::Engine.config.allowed_upload_extensions
+      expect(featured_image_uploader.extension_allowlist).to eq Spotlight::Engine.config.allowed_upload_extensions
     end
   end
 


### PR DESCRIPTION
extension_whitelist has been deprecated upstream:
https://github.com/carrierwaveuploader/carrierwave/blob/13330a70323cde83b319520f5c1874227de79cdf/lib/carrierwave/uploader/extension_whitelist.rb#L35-L36