### PR TITLE
Update text and styling of bulk actions modals

### DIFF
--- a/app/assets/stylesheets/spotlight/_modals.scss
+++ b/app/assets/stylesheets/spotlight/_modals.scss
@@ -1,0 +1,3 @@
+.modal-body .form-check-label {
+  margin-bottom: 0.5rem;
+}

--- a/app/assets/stylesheets/spotlight/_spotlight.scss
+++ b/app/assets/stylesheets/spotlight/_spotlight.scss
@@ -19,6 +19,7 @@
 @import "spotlight/featured_browse_categories_block";
 @import "spotlight/item_text_block";
 @import "spotlight/uploaded_items_block";
+@import "spotlight/modals";
 @import "spotlight/multi_image_selector";
 @import "spotlight/multi_up_item_grid";
 @import "spotlight/slideshow_block";

--- a/app/views/catalog/_remove_tags.html.erb
+++ b/app/views/catalog/_remove_tags.html.erb
@@ -9,9 +9,7 @@
         </button>
       </div>
       <div class="modal-body">
-        <p>
-          <%= t(:'spotlight.bulk_actions.remove_tags.description_html', count: @response.total) %>
-        </p>
+        <%= t(:'spotlight.bulk_actions.remove_tags.description_html', count: @response.total) %>
         <% facets = facets_from_request([search_state.blacklight_config.document_model.solr_field_for_tagger(current_exhibit)], @response) %>
         <% facets.each do |facet| %>
           <% if facet.items.any? %>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -244,33 +244,33 @@ en:
           one: Tags are being added for %{count} item.
           other: Tags are being added for %{count} items.
         description:
-          one: There is %{count} item in the current search result set. Tags entered below will be added to all items in the current result set. This won’t affect any tags already assigned to items.
-          other: There are %{count} items in the current search result set. Tags entered below will be added to all items in the current result set. This won’t affect any tags already assigned to items.
+          one: There is %{count} item in the current search result set. Tags entered below will be added to this item. This action won’t affect any tags already assigned to this item.
+          other: There are %{count} items in the current search result set. Tags entered below will be added to all %{count} items in the result set. This action won’t affect any tags already assigned to these items.
         heading: Add tags
-        label: Tags
+        label: Enter tags to add
       change: Change
       change_visibility:
         changed:
           one: Visibility of %{count} item is being updated.
           other: Visibility of %{count} items is being updated.
         description:
-          one: There is %{count} item in the current search result set. This change will be applied to all items.
-          other: There are %{count} items in the current search result set. This change will be applied to all items.
+          one: There is %{count} item in the current search result set. A visibility change will be applied to this item.
+          other: There are %{count} items in the current search result set. A visibility change will be applied to all items in the result set.
         heading: Change item visibility
         label: Item visibility
         private: Private
         public: Public
-      confirm: Are you sure?
+      confirm: All items in the result set will be updated. Are you sure?
       label: Bulk actions
       remove: Remove
       remove_tags:
-        assigned: Assigned tags
+        assigned: Currently assigned tags
         changed:
           one: Tags are being removed for %{count} item.
           other: Tags are being removed for %{count} items.
         description_html:
-          one: "<p>There is %{count} item in the current search result set. Tags shown below are assigned to one or more of those items.</p><p>When you delete a tag below it will be removed from any item in the current result set to which that tag is assigned.</p>"
-          other: "<p>There are %{count} items in the current search result set. Tags shown below are assigned to one or more of those items.</p><p>When you delete a tag below it will be removed from any item in the current result set to which that tag is assigned.</p>"
+          one: "<p>There is %{count} item in the current search result set. Tags shown below are assigned to this item.</p><p>When you remove a tag below it will be unassigned from this item.</p>"
+          other: "<p>There are %{count} items in the current search result set. Tags shown below are assigned to one or more of those items.</p><p>When you remove a tag below it will be unassigned from any item in the result set to which that tag is currently assigned.</p>"
         heading: Remove tags
         label: Enter tags to remove
     catalog:

--- a/spec/features/bulk_actions_spec.rb
+++ b/spec/features/bulk_actions_spec.rb
@@ -29,7 +29,7 @@ describe 'Bulk actions', type: :feature do
     click_link 'Change item visibility'
     expect(page).to have_css 'h4', text: 'Change item visibility', visible: true
     choose 'Private'
-    accept_confirm 'Are you sure?' do
+    accept_confirm 'All items in the result set will be updated. Are you sure?' do
       click_button 'Change'
     end
     expect(page).to have_css '.alert', text: 'Visibility of 1 item is being updated.'
@@ -46,7 +46,7 @@ describe 'Bulk actions', type: :feature do
       find('[data-autocomplete-fetched="true"]', visible: false)
       find('.tt-input').set('good,stuff')
     end
-    accept_confirm 'Are you sure?' do
+    accept_confirm 'All items in the result set will be updated. Are you sure?' do
       click_button 'Add'
     end
     expect(page).to have_css '.alert', text: 'Tags are being added for 1 item.'
@@ -63,7 +63,7 @@ describe 'Bulk actions', type: :feature do
       find('[data-autocomplete-fetched="true"]', visible: false)
       find('.tt-input').set('foo')
     end
-    accept_confirm 'Are you sure?' do
+    accept_confirm 'All items in the result set will be updated. Are you sure?' do
       click_button 'Remove'
     end
     expect(page).to have_css '.alert', text: 'Tags are being removed for 1 item.'


### PR DESCRIPTION
There are kind of a lot of text changes but it is pretty straightforward. I just customized the singular case strings and the plural case strings bit more, and updated a few words here and there. 

I also added a sentence to the confirmation dialog, but used the same wording for all confirmation cases to keep it simple.

Also made a couple of very small styling updates. I created a new SCSS partial for the modals because I can foresee downstream implementers wanting to do a bit more styling customization on them.

### Examples with one result item
<img width="513" alt="Screen Shot 2021-03-03 at 5 59 50 PM" src="https://user-images.githubusercontent.com/101482/109895400-6348b480-7c4c-11eb-90ea-b2de3244e888.png">

<img width="513" alt="Screen Shot 2021-03-03 at 5 59 35 PM" src="https://user-images.githubusercontent.com/101482/109895396-62b01e00-7c4c-11eb-849e-29a9ffbabee9.png">

<img width="513" alt="Screen Shot 2021-03-03 at 6 00 07 PM" src="https://user-images.githubusercontent.com/101482/109895404-6479e180-7c4c-11eb-91e9-8a441359fe1b.png">

### Examples with more than one result item
<img width="513" alt="Screen Shot 2021-03-03 at 6 00 57 PM" src="https://user-images.githubusercontent.com/101482/109895473-7f4c5600-7c4c-11eb-976d-0b887029a8f1.png">
<img width="513" alt="Screen Shot 2021-03-03 at 6 00 46 PM" src="https://user-images.githubusercontent.com/101482/109895472-7f4c5600-7c4c-11eb-9d3b-c78b4d5ff0a2.png">
<img width="513" alt="Screen Shot 2021-03-03 at 6 00 30 PM" src="https://user-images.githubusercontent.com/101482/109895468-7eb3bf80-7c4c-11eb-92b8-7f83387e77d1.png">

### Confirmation dialog update
<img width="513" alt="Screen Shot 2021-03-03 at 6 01 11 PM" src="https://user-images.githubusercontent.com/101482/109895518-95f2ad00-7c4c-11eb-8c6d-a3d30c375123.png">

