### PR TITLE
Use global ids for attachment information to work around a compatibil…

### DIFF
--- a/app/models/spotlight/attachment.rb
+++ b/app/models/spotlight/attachment.rb
@@ -8,7 +8,7 @@ module Spotlight
     mount_uploader :file, Spotlight::AttachmentUploader
 
     def as_json(options = nil)
-      file.as_json(options).merge(name: name, uid: uid, id: id, class: self.class.to_s)
+      file.as_json(options).merge(name: name, uid: uid, attachment: to_global_id)
     end
   end
 end

--- a/spec/features/javascript/blocks/uploaded_items_block_spec.rb
+++ b/spec/features/javascript/blocks/uploaded_items_block_spec.rb
@@ -54,7 +54,7 @@ describe 'Uploaded Items Block', feature: true, js: true, versioning: true do
     attach_file('uploaded_item_url', fixture_file2)
 
     # This line blocks until the javascript has added the file to the page:
-    expect(find('#st-block-3_display-checkbox_2')).to be_present
+    expect(find('input[name="item[file_0][display]"]')).to be_present
 
     # Uncheck the first checkbox
     all('input[type="checkbox"]').first.click


### PR DESCRIPTION
…ity issue with sir trevor + openstruct.

afaict, we're only using this information for bookkeeping and nothing else.

Stops https://github.com/sul-dlss/exhibits/issues/2021 from happening (although some data may need remediating)