### PR TITLE
Rename ZPR Viewer/Link to "View larger"

### DIFF
--- a/app/assets/javascripts/spotlight/admin/sir-trevor/locales.js
+++ b/app/assets/javascripts/spotlight/admin/sir-trevor/locales.js
@@ -72,7 +72,7 @@ SirTrevor.Locales.en.blocks = $.extend(SirTrevor.Locales.en.blocks, {
       secondary: "Secondary caption"
     },
     zpr: {
-      title: 'Display ZPR link'
+      title: 'Offer "View larger" option'
     }
   },
 

--- a/app/views/spotlight/sir_trevor/blocks/_solr_documents_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_solr_documents_block.html.erb
@@ -26,7 +26,7 @@
               </div>
             <% end %>
             <% if solr_documents_block.zpr_link? && block_options[:iiif_tilesource].present? %>
-              <button class="btn btn-secondary zpr-link" data-iiif-tilesource="<%= block_options[:iiif_tilesource] %>">Show in ZPR viewer</button>
+              <button class="btn btn-secondary zpr-link" data-iiif-tilesource="<%= block_options[:iiif_tilesource] %>"><%= t('.zpr_link') %></button>
             <% end %>
           </div>
         </div>

--- a/app/views/spotlight/sir_trevor/blocks/_solr_documents_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_solr_documents_block.html.erb
@@ -26,7 +26,7 @@
               </div>
             <% end %>
             <% if solr_documents_block.zpr_link? && block_options[:iiif_tilesource].present? %>
-              <button class="btn btn-secondary zpr-link" data-iiif-tilesource="<%= block_options[:iiif_tilesource] %>"><%= t('.zpr_link') %></button>
+              <button class="btn btn-secondary zpr-link" data-iiif-tilesource="<%= block_options[:iiif_tilesource] %>"><%= t('.zpr_link_html', title: doc_presenter.heading) %></button>
             <% end %>
           </div>
         </div>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -889,6 +889,8 @@ en:
           items:
             one: "%{count} item"
             other: "%{count} items"
+        solr_documents_block:
+          zpr_link: View larger
     sites:
       edit:
         basic_settings:

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -890,7 +890,7 @@ en:
             one: "%{count} item"
             other: "%{count} items"
         solr_documents_block:
-          zpr_link: View larger
+          zpr_link_html: View <span class="sr-only">%{title}</span> larger
     sites:
       edit:
         basic_settings:

--- a/spec/features/javascript/blocks/solr_documents_block_spec.rb
+++ b/spec/features/javascript/blocks/solr_documents_block_spec.rb
@@ -149,7 +149,7 @@ describe 'Solr Document Block', feature: true, versioning: true, default_max_wai
     save_page
 
     within '.contents' do
-      click_button 'View larger'
+      click_button 'View [World map] larger'
     end
 
     within '.modal-content' do

--- a/spec/features/javascript/blocks/solr_documents_block_spec.rb
+++ b/spec/features/javascript/blocks/solr_documents_block_spec.rb
@@ -142,14 +142,14 @@ describe 'Solr Document Block', feature: true, versioning: true, default_max_wai
   it 'allows you to optionally display a ZPR link with the image', js: true do
     fill_in_solr_document_block_typeahead_field with: 'gk446cj2442'
 
-    check 'Display ZPR link'
+    check 'Offer "View larger" option'
     # this seems silly, but also seems to help with the flappy-ness of this spec
-    expect(find_field('Display ZPR link', checked: true)).to be_checked
+    expect(find_field('Offer "View larger" option', checked: true)).to be_checked
 
     save_page
 
     within '.contents' do
-      click_button 'Show in ZPR viewer'
+      click_button 'View larger'
     end
 
     within '.modal-content' do


### PR DESCRIPTION
Closes #2709

## Widget
<img width="1103" alt="Screen Shot 2021-03-09 at 11 27 54 AM" src="https://user-images.githubusercontent.com/96776/110529275-e85d1f00-80cd-11eb-9003-79e20b2d9814.png">

## Page
<img width="836" alt="Screen Shot 2021-03-09 at 11 28 06 AM" src="https://user-images.githubusercontent.com/96776/110529299-f01cc380-80cd-11eb-9dba-c4752b2bf8f1.png">
