### PR TITLE
Add vertical space below browse group filter buttons

### DIFF
--- a/app/assets/stylesheets/spotlight/_browse.scss
+++ b/app/assets/stylesheets/spotlight/_browse.scss
@@ -38,6 +38,14 @@ $image-overlay-max-height: 300px;
   }
 }
 
+#main-container .browse-group-navigation.nav {
+  margin-bottom: $spacer;
+
+  .nav-link {
+    margin-bottom: $spacer * .75;
+  }
+}
+
 .browse-landing {
   text-align: center;
   // Placeholder for vertically alignment - might already be available from use in another feature


### PR DESCRIPTION
It isn't super obvious in the default Spotlight implementation, but when you style the browse group filter links to look like buttons, there isn't any vertical spacing between rows when you have enough group filters to wrap to a second row:

<img width="982" alt="Screen Shot 2021-03-11 at 11 16 13 AM" src="https://user-images.githubusercontent.com/101482/110835274-d1e4ce00-825b-11eb-85b7-1da7283f41d2.png">

---

<img width="982" alt="Screen Shot 2021-03-11 at 11 15 25 AM" src="https://user-images.githubusercontent.com/101482/110835327-e032ea00-825b-11eb-9450-cbc9548be9fc.png">

---

This PR adds some bottom margin to the browse group filter links to provide spacing between rows when the links wrap:

<img width="982" alt="Screen Shot 2021-03-11 at 11 12 53 AM" src="https://user-images.githubusercontent.com/101482/110835512-1f613b00-825c-11eb-936a-3f9982f3ef22.png">

---

<img width="1003" alt="Screen Shot 2021-03-11 at 11 12 10 AM" src="https://user-images.githubusercontent.com/101482/110835528-24be8580-825c-11eb-8087-74b7e677b34c.png">

---

(I had to be more specific with the selector here than ideal but it was either that or use `!important` to override the default styling for `.main-container .nav`)
