### PR TITLE
Make Cancel link styling consistent across all pages

### DIFF
--- a/app/views/spotlight/catalog/_edit_default.html.erb
+++ b/app/views/spotlight/catalog/_edit_default.html.erb
@@ -18,7 +18,7 @@
   <% end %>
   <div class="form-actions">
     <div class="primary-actions">
-      <%= cancel_link document, spotlight.polymorphic_path([current_exhibit, document]) %>
+      <%= cancel_link document, spotlight.polymorphic_path([current_exhibit, document]), class: 'btn-sizing' %>
       <%= f.submit nil, class: 'btn btn-primary' %>
       </div>
   </div>

--- a/app/views/spotlight/custom_fields/_form.html.erb
+++ b/app/views/spotlight/custom_fields/_form.html.erb
@@ -15,7 +15,7 @@
 
   <div class="form-actions">
     <div class="primary-actions">
-      <%= link_to t(:"cancel"), edit_exhibit_metadata_configuration_path(current_exhibit) %>
+      <%= link_to t(:"cancel"), edit_exhibit_metadata_configuration_path(current_exhibit), class: 'btn-sizing' %>
       <%= f.submit nil, class: 'btn btn-primary' %>
     </div>
   </div>

--- a/app/views/spotlight/custom_search_fields/_form.html.erb
+++ b/app/views/spotlight/custom_search_fields/_form.html.erb
@@ -6,7 +6,7 @@
 
   <div class="form-actions">
     <div class="primary-actions">
-      <%= link_to t(:"cancel"), edit_exhibit_search_configuration_path(current_exhibit) %>
+      <%= link_to t(:"cancel"), edit_exhibit_search_configuration_path(current_exhibit), class: 'btn-sizing' %>
       <%= f.submit nil, class: 'btn btn-primary' %>
     </div>
   </div>

--- a/app/views/spotlight/pages/_form.html.erb
+++ b/app/views/spotlight/pages/_form.html.erb
@@ -61,7 +61,7 @@
 
   <div class="form-actions">
     <div class="primary-actions">
-      <%= link_to(t('cancel'), :back, data: (@page.lock && @page.lock.current_session? ? { lock: url_for([spotlight, @page.exhibit, @page.lock]) } : {})) %>
+      <%= link_to(t('cancel'), :back, data: (@page.lock && @page.lock.current_session? ? { lock: url_for([spotlight, @page.exhibit, @page.lock]) } : {}), class: 'btn-sizing') %>
       <%= f.submit class: 'btn btn-primary' %>
     </div>
   </div>

--- a/app/views/spotlight/resources/_form.html.erb
+++ b/app/views/spotlight/resources/_form.html.erb
@@ -2,7 +2,7 @@
   <%= f.text_field :url  %>
   <div class="form-actions">
     <div class="primary-actions">
-      <%= cancel_link @resource, :back, class: 'btn btn-secondary' %>
+      <%= cancel_link @resource, :back, class: 'btn-sizing' %>
       <%= f.submit t('.add_item'), class: 'btn btn-primary' %>
     </div>
   </div>

--- a/app/views/spotlight/resources/csv_upload/_form.html.erb
+++ b/app/views/spotlight/resources/csv_upload/_form.html.erb
@@ -2,7 +2,7 @@
   <%= f.url_field :url, type: "file", help: t('.help_html', link: link_to(t('.template'), template_exhibit_resources_csv_uploads_path)), label: t('.file_label') %>
   <div class="form-actions">
     <div class="primary-actions">
-      <%= cancel_link @resource, :back, class: 'btn btn-secondary' %>
+      <%= cancel_link @resource, :back, class: 'btn-sizing' %>
       <%= f.submit t('.add_item'), class: 'btn btn-primary' %>
     </div>
   </div>

--- a/app/views/spotlight/resources/iiif/_form.html.erb
+++ b/app/views/spotlight/resources/iiif/_form.html.erb
@@ -2,7 +2,7 @@
   <%= f.text_field :url, help: t('.url-field.help'), label: t('.manifest') %>
   <div class="form-actions">
     <div class="primary-actions">
-      <%= cancel_link @resource, :back, class: 'btn btn-secondary' %>
+      <%= cancel_link @resource, :back, class: 'btn-sizing' %>
       <%= f.submit t('.add_item'), class: 'btn btn-primary' %>
     </div>
   </div>

--- a/app/views/spotlight/resources/json_upload/_form.html.erb
+++ b/app/views/spotlight/resources/json_upload/_form.html.erb
@@ -3,7 +3,7 @@
     <%= f.url_field :json, type: "file", label: t('.file_label') %>
     <div class="form-actions">
       <div class="primary-actions">
-        <%= cancel_link @resource, :back, class: 'btn btn-secondary' %>
+        <%= cancel_link @resource, :back, class: 'btn-sizing' %>
         <%= f.submit t('.add_item'), class: 'btn btn-primary' %>
       </div>
     </div>

--- a/app/views/spotlight/resources/upload/_form.html.erb
+++ b/app/views/spotlight/resources/upload/_form.html.erb
@@ -12,7 +12,7 @@
   <div class="form-actions">
     <div class="primary-actions">
       <%= hidden_field_tag :tab, 'upload' %>
-      <%= cancel_link @resource, :back, class: 'btn btn-secondary' %>
+      <%= cancel_link @resource, :back, class: 'btn-sizing' %>
       <%= f.submit t('.add_item_and_continue'), name: 'add-and-continue', class: 'btn btn-secondary' %>
       <%= f.submit t('.add_item'), class: 'btn btn-primary' %>
     </div>


### PR DESCRIPTION
This is pretty minor and only affects admin pages, but currently our Cancel link styling is inconsistent across pages. In some cases the Cancel link is too close to the submit button, and in other cases the Cancel link is styled as a secondary button instead of a link as it elsewhere. 

This PR just adds the `btn-sizing` class to the non-conforming Cancel link cases to make those consistent with the styling elsewhere.

## Before example 1

<img width="627" alt="Screen Shot 2021-03-11 at 2 19 41 PM" src="https://user-images.githubusercontent.com/101482/110856839-60b21480-8275-11eb-8eee-5d173d55c670.png">

---

## Before example 2
<img width="627" alt="Screen Shot 2021-03-11 at 2 20 14 PM" src="https://user-images.githubusercontent.com/101482/110856857-660f5f00-8275-11eb-9786-6aa720e44473.png">


## After example 1

<img width="627" alt="Screen Shot 2021-03-11 at 2 18 53 PM" src="https://user-images.githubusercontent.com/101482/110856913-76bfd500-8275-11eb-8796-1a00b3f6767a.png">

---

## After example 2

<img width="870" alt="Screen Shot 2021-03-11 at 2 18 25 PM" src="https://user-images.githubusercontent.com/101482/110856893-6f98c700-8275-11eb-9cd6-17a29a39b62f.png">
