### PR TITLE
Try a work-around for streaming that may work for passenger + puma at…

### DIFF
--- a/app/controllers/spotlight/bulk_updates_controller.rb
+++ b/app/controllers/spotlight/bulk_updates_controller.rb
@@ -12,6 +12,7 @@ module Spotlight
     def edit; end
 
     def download_template
+      # Set Last-Modified as a work-around for https://github.com/rack/rack/issues/1619
       headers['Last-Modified'] = ''
       headers['Cache-Control'] = 'no-cache'
       headers['Content-Type'] = 'text/csv'

--- a/app/controllers/spotlight/bulk_updates_controller.rb
+++ b/app/controllers/spotlight/bulk_updates_controller.rb
@@ -6,14 +6,13 @@ module Spotlight
   ##
   # Controller enabling bulk functionality for items defined in a spreadsheet.
   class BulkUpdatesController < Spotlight::ApplicationController
-    include ActionController::Live unless ENV['CI']
-
     before_action :authenticate_user!
     before_action :check_authorization
 
     def edit; end
 
     def download_template
+      headers['Last-Modified'] = ''
       headers['Cache-Control'] = 'no-cache'
       headers['Content-Type'] = 'text/csv'
       headers['Content-Disposition'] = "attachment; filename=\"#{current_exhibit.slug}-bulk-update-template.csv\""


### PR DESCRIPTION
… the same time?

It seems like `ActionController::Live` just doesn't work with puma at all (even if you copy their example code into a brand new rails app...). The `Last-Modified` header trick seems to be the recommended work-around for some sort of Rack "feature" that breaks streaming. 🤷‍♂️ 