### PR TITLE
Remove duplicate belongs_to from Spotlight::FeaturePage

### DIFF
--- a/app/models/spotlight/feature_page.rb
+++ b/app/models/spotlight/feature_page.rb
@@ -14,8 +14,6 @@ module Spotlight
 
     accepts_nested_attributes_for :child_pages
 
-    belongs_to :thumbnail, class_name: 'Spotlight::FeaturedImage', dependent: :destroy, optional: true
-
     before_validation unless: :top_level_page? do
       self.exhibit = top_level_page_or_self.exhibit
     end

--- a/app/views/spotlight/pages/_form.html.erb
+++ b/app/views/spotlight/pages/_form.html.erb
@@ -50,7 +50,7 @@
 
       <% if @page.respond_to? :thumbnail %>
       <div role="tabpanel" class="tab-pane" id="page-thumbnail">
-        <%= f.fields_for :thumbnail, (@page.thumbnail || @page.build_thumbnail) do |m| %>
+        <%= f.fields_for :thumbnail, (@page.thumbnail || @page.build_thumbnail), include_id: false do |m| %>
           <p class="instructions"><%= t(:'.thumbnail.help') %></p>
           <%= render '/spotlight/featured_images/form', f: m, initial_crop_selection: Spotlight::Engine.config.featured_image_thumb_size, crop_type: :thumbnail %>
         <% end %>


### PR DESCRIPTION
This was probably preventing feature images from being re-saved