### PR TITLE
Cast bool check to a string so that strip works effectively

### DIFF
--- a/app/jobs/spotlight/process_bulk_updates_csv_job.rb
+++ b/app/jobs/spotlight/process_bulk_updates_csv_job.rb
@@ -72,7 +72,7 @@ module Spotlight
     # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 
     def to_bool(value)
-      ActiveModel::Type::Boolean.new.cast(value.strip)
+      ActiveModel::Type::Boolean.new.cast(value.to_s.strip)
     end
 
     def config


### PR DESCRIPTION
Without this, `nil` can be present and raise errors in the csv processing job