### PR TITLE
Improve layout of the Download CSV options and button

### DIFF
--- a/app/assets/stylesheets/spotlight/_exhibit_admin.scss
+++ b/app/assets/stylesheets/spotlight/_exhibit_admin.scss
@@ -70,3 +70,12 @@
     display: inline;
   }
 }
+
+.download-csv {
+  align-items: flex-end;
+  display: flex;
+
+  .btn-primary {
+    margin-bottom: $spacer;
+  }
+}

--- a/app/views/spotlight/bulk_updates/_download.html.erb
+++ b/app/views/spotlight/bulk_updates/_download.html.erb
@@ -2,19 +2,19 @@
 
 <%= bootstrap_form_with(url: download_template_exhibit_bulk_updates_path, local: true, target: '_blank') do |f| %>
   <div class="row">
-    <div class="col col-3">
+    <div class="col col-sm-3">
       <%= f.form_group(:reference_fields, label: { text: t('.reference_fields.heading'), class: 'font-weight-bold' }) do %>
         <%= f.check_box('reference_fields[item_id]', label: t('.item_id'), checked: true, disabled: true) %>
         <%= f.check_box('reference_fields[item_title]', label: t('.item_title')) %>
       <% end %>
     </div>
-    <div class="col col-3">
+    <div class="col col-sm-3">
       <%= f.form_group(:updatable_fields, label: { text: t('.updatable_fields.heading'), class: 'font-weight-bold' }) do %>
         <%= f.check_box('updatable_fields[visibility]', checked: true, label: t('.visibility')) %>
         <%= f.check_box('updatable_fields[tags]', label: t('.tags')) %>
       <% end %>
     </div>
-    <div class="col col-3">
+    <div class="col col-sm-3 download-csv">
       <%= f.submit t('.submit'), class: 'btn btn-primary'  %>
     </div>
   </div>


### PR DESCRIPTION
Fixes a couple of styling issues. 

# 1. Download CSV button aligned with headers instead of other form options

### Before

---

<img width="696" alt="Screen Shot 2021-03-26 at 5 44 09 PM" src="https://user-images.githubusercontent.com/101482/112705259-26429d00-8e5b-11eb-98dd-ea265555ae7f.png">

### After

---

<img width="738" alt="Screen Shot 2021-03-26 at 5 40 08 PM" src="https://user-images.githubusercontent.com/101482/112705266-2e9ad800-8e5b-11eb-8804-564deb3c5f76.png">

---

# 2. Form options too narrow on `xs` viewport width

### Before

---

<img width="362" alt="Screen Shot 2021-03-26 at 5 43 47 PM" src="https://user-images.githubusercontent.com/101482/112705294-4c683d00-8e5b-11eb-8a5f-aa214854f676.png">

### After

---

<img width="350" alt="Screen Shot 2021-03-26 at 5 40 50 PM" src="https://user-images.githubusercontent.com/101482/112705303-54c07800-8e5b-11eb-9b05-47094ed3fd4c.png">
