### PR TITLE
Target the typeahead css for thumbnails so typeaheads without thumbs …

### DIFF
--- a/app/assets/stylesheets/spotlight/typeahead.css
+++ b/app/assets/stylesheets/spotlight/typeahead.css
@@ -51,6 +51,12 @@
   }
 }
 
+.tt-dataset-tags {
+  p {
+    white-space: nowrap !important;
+  }
+}
+
 .autocomplete-item {
   display: flex;
 

--- a/app/assets/stylesheets/spotlight/typeahead.css
+++ b/app/assets/stylesheets/spotlight/typeahead.css
@@ -41,37 +41,31 @@
   .tt-suggestion {
     font-size: 18px;
     line-height: 24px;
-    padding: 3px 20px 3px 100px;
+    padding: 3px 1rem 3px 1rem;
     margin-bottom: 1em;
 
     &.tt-cursor {
       color: #fff;
       background-color: #0097cf;
     }
-    p {
-      margin: 0;
-    }
-    .document-thumbnail {
-      float: left;
-      width: 60px;
-      padding: 0;
-      margin: 0;
-      margin-left: -80px;
-      position: relative;
+  }
+}
 
-      img {
-        max-width: 60px;
-        max-height: 60px;
-      }
+.autocomplete-item {
+  display: flex;
 
-      img:hover {
-        position: absolute;
-        right: -3px;
-        top: -3px;
-        max-width: 160px;
-        max-height: 100px;
-        border: 3px solid theme-colors("info");
-      }
+  p {
+    margin: 0;
+  }
+  .document-thumbnail {
+    margin-right: 1rem;
+    min-width: 60px;
+    padding: 0;
+    width: 60px;
+
+    img {
+      max-width: 60px;
+      max-height: 60px;
     }
   }
 }


### PR DESCRIPTION
…don't have excess padding; fixes #2723.

Also, drop the "zoom on mouseover" feature. It's no longer working as it once did, and the clever shenanigans caused the display issues in #2723.
<img width="296" alt="Screen Shot 2021-03-31 at 13 58 34" src="https://user-images.githubusercontent.com/111218/113210517-3080e480-9229-11eb-972e-5c6611c4098d.png">

<img width="210" alt="Screen Shot 2021-03-31 at 14 00 55" src="https://user-images.githubusercontent.com/111218/113210813-85245f80-9229-11eb-8869-2828afca3be8.png">

