### PR TITLE
Allow as_json to accept arguments.

### DIFF
--- a/app/models/sir_trevor_rails/blocks/browse_block.rb
+++ b/app/models/sir_trevor_rails/blocks/browse_block.rb
@@ -31,7 +31,7 @@ module SirTrevorRails
         send(:'display-item-counts') == 'true'
       end
 
-      def as_json
+      def as_json(*)
         result = super
 
         result[:data][:item] ||= {}

--- a/app/models/sir_trevor_rails/blocks/featured_pages_block.rb
+++ b/app/models/sir_trevor_rails/blocks/featured_pages_block.rb
@@ -22,7 +22,7 @@ module SirTrevorRails
       end
 
       # rubocop:disable Metrics/MethodLength
-      def as_json
+      def as_json(*)
         result = super
         result[:data][:item] ||= {}
 

--- a/spec/models/spotlight/access_controls_enforcement_search_builder_spec.rb
+++ b/spec/models/spotlight/access_controls_enforcement_search_builder_spec.rb
@@ -42,8 +42,7 @@ describe Spotlight::AccessControlsEnforcementSearchBuilder do
     it 'does not filter resources to just those created by the exhibit' do
       allow(current_ability).to receive(:can?).and_return(true)
       subject.apply_permissive_visibility_filter(solr_request)
-      expect(solr_request).to include :fq
-      expect(solr_request[:fq]).not_to include "{!term f=spotlight_exhibit_slug_#{exhibit.slug}_bsi}true"
+      expect(solr_request[:fq]).to be_blank
     end
   end
 


### PR DESCRIPTION
This fixes an issue running the [caption value migration](https://github.com/projectblacklight/spotlight/blob/master/db/migrate/20210308090000_migrate_caption_values_for_title_key.rb#L5) with some versions of rails:

```
Caused by:
ArgumentError: wrong number of arguments (given 1, expected 0)
/opt/app/exhibits/exhibits/shared/bundle/ruby/2.7.0/gems/blacklight-spotlight-3.0.1/app/models/sir_trevor_rails/blocks/browse_block.rb:34:in `as_json'
/opt/app/exhibits/exhibits/shared/bundle/ruby/2.7.0/gems/activesupport-6.1.3.2/lib/active_support/core_ext/object/json.rb:154:in `block in as_json'
/opt/app/exhibits/exhibits/shared/bundle/ruby/2.7.0/gems/activesupport-6.1.3.2/lib/active_support/core_ext/object/json.rb:154:in `map'
/opt/app/exhibits/exhibits/shared/bundle/ruby/2.7.0/gems/activesupport-6.1.3.2/lib/active_support/core_ext/object/json.rb:154:in `as_json'
/opt/app/exhibits/exhibits/shared/bundle/ruby/2.7.0/gems/activesupport-6.1.3.2/lib/active_support/json/encoding.rb:35:in `encode'
/opt/app/exhibits/exhibits/shared/bundle/ruby/2.7.0/gems/activesupport-6.1.3.2/lib/active_support/json/encoding.rb:22:in `encode'
/opt/app/exhibits/exhibits/shared/bundle/ruby/2.7.0/gems/activesupport-6.1.3.2/lib/active_support/core_ext/object/json.rb:43:in `to_json'
/opt/app/exhibits/exhibits/shared/bundle/ruby/2.7.0/gems/blacklight-spotlight-3.0.1/app/models/spotlight/page.rb:63:in `content='
/opt/app/exhibits/exhibits/shared/bundle/ruby/2.7.0/gems/activemodel-6.1.3.2/lib/active_model/attribute_assignment.rb:49:in `public_send'
/opt/app/exhibits/exhibits/shared/bundle/ruby/2.7.0/gems/activemodel-6.1.3.2/lib/active_model/attribute_assignment.rb:49:in `_assign_attribute'
/opt/app/exhibits/exhibits/shared/bundle/ruby/2.7.0/gems/activerecord-6.1.3.2/lib/active_record/attribute_assignment.rb:21:in `block in _assign_attributes'
/opt/app/exhibits/exhibits/shared/bundle/ruby/2.7.0/gems/activerecord-6.1.3.2/lib/active_record/attribute_assignment.rb:13:in `each'
/opt/app/exhibits/exhibits/shared/bundle/ruby/2.7.0/gems/activerecord-6.1.3.2/lib/active_record/attribute_assignment.rb:13:in `_assign_attributes'
/opt/app/exhibits/exhibits/shared/bundle/ruby/2.7.0/gems/activemodel-6.1.3.2/lib/active_model/attribute_assignment.rb:34:in `assign_attributes'
/opt/app/exhibits/exhibits/shared/bundle/ruby/2.7.0/gems/activerecord-6.1.3.2/lib/active_record/persistence.rb:627:in `block in update'
/opt/app/exhibits/exhibits/shared/bundle/ruby/2.7.0/gems/activerecord-6.1.3.2/lib/active_record/transactions.rb:354:in `block in with_transaction_returning_status'
/opt/app/exhibits/exhibits/shared/bundle/ruby/2.7.0/gems/activerecord-6.1.3.2/lib/active_record/connection_adapters/abstract/database_statements.rb:320:in `block in transaction'
/opt/app/exhibits/exhibits/shared/bundle/ruby/2.7.0/gems/activerecord-6.1.3.2/lib/active_record/connection_adapters/abstract/transaction.rb:310:in `block in within_new_transaction'
/opt/app/exhibits/exhibits/shared/bundle/ruby/2.7.0/gems/activesupport-6.1.3.2/lib/active_support/concurrency/load_interlock_aware_monitor.rb:26:in `block (2 levels) in synchronize'
/opt/app/exhibits/exhibits/shared/bundle/ruby/2.7.0/gems/activesupport-6.1.3.2/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `handle_interrupt'
/opt/app/exhibits/exhibits/shared/bundle/ruby/2.7.0/gems/activesupport-6.1.3.2/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `block in synchronize'
/opt/app/exhibits/exhibits/shared/bundle/ruby/2.7.0/gems/activesupport-6.1.3.2/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `handle_interrupt'
/opt/app/exhibits/exhibits/shared/bundle/ruby/2.7.0/gems/activesupport-6.1.3.2/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `synchronize'
/opt/app/exhibits/exhibits/shared/bundle/ruby/2.7.0/gems/activerecord-6.1.3.2/lib/active_record/connection_adapters/abstract/transaction.rb:308:in `within_new_transaction'
/opt/app/exhibits/exhibits/shared/bundle/ruby/2.7.0/gems/activerecord-6.1.3.2/lib/active_record/connection_adapters/abstract/database_statements.rb:320:in `transaction'
/opt/app/exhibits/exhibits/shared/bundle/ruby/2.7.0/gems/activerecord-6.1.3.2/lib/active_record/transactions.rb:350:in `with_transaction_returning_status'
/opt/app/exhibits/exhibits/shared/bundle/ruby/2.7.0/gems/activerecord-6.1.3.2/lib/active_record/persistence.rb:626:in `update'
/opt/app/exhibits/exhibits/releases/20210513171619/db/migrate/20210510134811_migrate_caption_values_for_title_key.spotlight.rb:27:in `block in change_caption_field_of'

```