### PR TITLE
ReindexExhibitJob#perform: fix when object count is 0

### DIFF
--- a/app/jobs/spotlight/reindex_exhibit_job.rb
+++ b/app/jobs/spotlight/reindex_exhibit_job.rb
@@ -13,8 +13,13 @@ module Spotlight
       count = exhibit.resources.count
 
       # Use the provided batch size, or calculate a reasonable default
-      batch_count = (count.to_f / batch_size).ceil if batch_size
-      batch_count ||= 1 + Math.log(count).round # e.g. 10 => 3, 100 => 6, 1000 => 8
+      batch_count = if count.zero?
+                      1
+                    elsif batch_size
+                      (count.to_f / batch_size).ceil
+                    else
+                      1 + Math.log(count).round # e.g. 10 => 3, 100 => 6, 1000 => 8
+                    end
 
       return Spotlight::ReindexJob.perform_now(exhibit, reports_on: job_tracker) if batch_count == 1
 


### PR DESCRIPTION
```
irb(main):001:0> Math.log(0).round
Traceback (most recent call last):
        5: from /home/catalina/.nix-profile/bin/irb:23:in `<main>'
        4: from /home/catalina/.nix-profile/bin/irb:23:in `load'
        3: from /nix/store/gwy6vs99xyxv3f0kflvb8sclgbd81b0m-ruby-2.6.7/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
        2: from (irb):1
        1: from (irb):1:in `round'
FloatDomainError (-Infinity)
```