### PR TITLE
Explicitly re-enable p tags for text all of  our custom blocks

### DIFF
--- a/app/assets/javascripts/spotlight/admin/blocks/block.js
+++ b/app/assets/javascripts/spotlight/admin/blocks/block.js
@@ -1,5 +1,9 @@
 (function ($){
   Spotlight.Block = SirTrevor.Block.extend({
+    scribeOptions: {
+      allowBlockElements: true,
+      tags: { p: true }
+    },
     formable: true,
     editorHTML: function() {
       return _.template(this.template)(this);


### PR DESCRIPTION
This fixes a weird sir-trevor bug where having a heading block on the page breaks any custom block that has `p`  markup in it.