### PR TITLE
make each exhibit card have a single link to fix Accessibility complaint about missing ALT text on images

### DIFF
--- a/app/views/spotlight/exhibits/_exhibit_card.html.erb
+++ b/app/views/spotlight/exhibits/_exhibit_card.html.erb
@@ -1,36 +1,36 @@
 <div class="col mb-4">
   <%= link_to exhibit, tabindex: '-1' do %>
-  <div class="card exhibit-card">
+    <div class="card exhibit-card">
       <% if exhibit.thumbnail.present? && exhibit.thumbnail.iiif_url %>
         <%= image_tag(exhibit.thumbnail.iiif_url, class: 'card-img',  alt: '', role: 'presentation', skip_pipeline: true, aria: { hidden: true  }) %>
       <% else %>
         <%= image_tag 'spotlight/default_thumbnail.jpg', class: 'card-img default-thumbnail',  alt: '', role: 'presentation', aria: { hidden: true  } %>
       <% end %>
-    <div class="card-img-overlay pb-0">
-      <% unless exhibit.published? %>
-        <div class="badge badge-warning unpublished"><%= t('.unpublished') %></div>
-      <% end %>
+      <div class="card-img-overlay pb-0">
+        <% unless exhibit.published? %>
+          <div class="badge badge-warning unpublished"><%= t('.unpublished') %></div>
+        <% end %>
 
-      <%= content_tag :h2, class: 'card-title h5 text-center', aria: { describedby: "exhibit-description-#{exhibit.to_param}" } do %>
+        <%= content_tag :h2, class: 'card-title h5 text-center', aria: { describedby: "exhibit-description-#{exhibit.to_param}" } do %>
           <span><%= exhibit.title %></span>
-      <% end %>
+        <% end %>
 
-      <% if exhibit.subtitle || exhibit.description  %>
-        <%= content_tag :div, id: "exhibit-description-#{exhibit.to_param}", class: 'card-text exhibit-description' do %>
-          <% if exhibit.subtitle %>
-            <p class="subtitle">
-              <%= exhibit.subtitle %>
-            </p>
-          <% end %>
+        <% if exhibit.subtitle || exhibit.description  %>
+          <%= content_tag :div, id: "exhibit-description-#{exhibit.to_param}", class: 'card-text exhibit-description' do %>
+            <% if exhibit.subtitle %>
+              <p class="subtitle">
+                <%= exhibit.subtitle %>
+              </p>
+            <% end %>
 
-          <% if exhibit.description %>
-            <p class="description">
-              <%= exhibit.description %>
-            </p>
+            <% if exhibit.description %>
+              <p class="description">
+                <%= exhibit.description %>
+              </p>
+            <% end %>
           <% end %>
         <% end %>
-      <% end %>
+      </div>
     </div>
-  </div>
   <% end %>
 </div>

--- a/app/views/spotlight/exhibits/_exhibit_card.html.erb
+++ b/app/views/spotlight/exhibits/_exhibit_card.html.erb
@@ -1,21 +1,18 @@
 <div class="col mb-4">
+  <%= link_to exhibit, tabindex: '-1' do %>
   <div class="card exhibit-card">
-    <%= link_to exhibit, aria: { hidden: true  }, tabindex: '-1' do %>
       <% if exhibit.thumbnail.present? && exhibit.thumbnail.iiif_url %>
-        <%= image_tag(exhibit.thumbnail.iiif_url, class: 'card-img',  alt: '', role: 'presentation', skip_pipeline: true) %>
+        <%= image_tag(exhibit.thumbnail.iiif_url, class: 'card-img',  alt: '', role: 'presentation', skip_pipeline: true, aria: { hidden: true  }) %>
       <% else %>
-        <%= image_tag 'spotlight/default_thumbnail.jpg', class: 'card-img default-thumbnail',  alt: '', role: 'presentation' %>
+        <%= image_tag 'spotlight/default_thumbnail.jpg', class: 'card-img default-thumbnail',  alt: '', role: 'presentation', aria: { hidden: true  } %>
       <% end %>
-    <% end %>
     <div class="card-img-overlay pb-0">
       <% unless exhibit.published? %>
         <div class="badge badge-warning unpublished"><%= t('.unpublished') %></div>
       <% end %>
 
       <%= content_tag :h2, class: 'card-title h5 text-center', aria: { describedby: "exhibit-description-#{exhibit.to_param}" } do %>
-        <%= link_to exhibit, class: 'stretched-link' do %>
           <span><%= exhibit.title %></span>
-        <% end %>
       <% end %>
 
       <% if exhibit.subtitle || exhibit.description  %>
@@ -35,4 +32,5 @@
       <% end %>
     </div>
   </div>
+  <% end %>
 </div>


### PR DESCRIPTION
Fixes #2767

Moves the link outside the image and the title so there is only one link. This allows the role=presentation attribute on the image to allow for an empty alt attribute.

NOTE: First commit does not adjust indentations.  This makes it easier to see the code changes.  The second commit only modifies indentations.