### PR TITLE
For accessibility, allow aria-label and title in iFrames

### DIFF
--- a/app/views/spotlight/sir_trevor/blocks/_iframe_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_iframe_block.html.erb
@@ -1,1 +1,1 @@
-<%= sanitize iframe_block.code, tags: %w(iframe), attributes: %w(id width height marginwidth marginheight src frameborder allowfullscreen sandbox seamless srcdoc scrolling) %>
+<%= sanitize iframe_block.code, tags: %w(iframe), attributes: %w(id aria-label title width height marginwidth marginheight src frameborder allowfullscreen sandbox seamless srcdoc scrolling) %>


### PR DESCRIPTION
Allow aria-label and title in iFrames to allow curators to fix iFrame accessibility errors.

![image](https://user-images.githubusercontent.com/6855473/128539065-99c5fbfb-4def-4254-825f-b127ad4c14c0.png)

![image](https://user-images.githubusercontent.com/6855473/128539170-57223995-b94a-4d4b-976d-0ed143f79d7a.png)
