### PR TITLE
Add prompt for URL slug to command line exhibit creation

### DIFF
--- a/lib/tasks/spotlight_tasks.rake
+++ b/lib/tasks/spotlight_tasks.rake
@@ -21,7 +21,10 @@ namespace :spotlight do
     print 'Exhibit title: '
     title = $stdin.gets.chomp
 
-    exhibit = Spotlight::Exhibit.create!(title: title)
+    print 'Exhibit URL slug: '
+    slug = @stdin.gets.chomp
+
+    exhibit = Spotlight::Exhibit.create!({ title: title, slug: slug })
 
     puts 'Who can admin this exhibit?'
 


### PR DESCRIPTION
This is a small PR to add the url slug to the command line prompt for exhibit creation. This will assist in automation of the initialization process - especially for local development via docker, etc.