### PR TITLE
Use the actual configured facet limit to determine when to show the 'too many values' version of the count

### DIFF
--- a/app/views/spotlight/search_configurations/_facet_metadata.html.erb
+++ b/app/views/spotlight/search_configurations/_facet_metadata.html.erb
@@ -1,8 +1,10 @@
 <%= content_tag :span, t(:'.document_count', count: metadata[:document_count]) %>
 <% if metadata[:document_count] > 0 %>
   •
-  <% if metadata[:value_count] > Spotlight::FieldMetadata::FACET_LIMIT %>
-    <%= content_tag :span, t(:'.too_many_values_count', count: Spotlight::FieldMetadata::FACET_LIMIT) %>
+  <% limit = field_config&.limit || Spotlight::FieldMetadata::FACET_LIMIT %>
+  <% limit = blacklight_config.default_facet_limit if limit == true %>
+  <% if metadata[:value_count] >= limit %>
+    <%= content_tag :span, t(:'.too_many_values_count', count: limit) %>
   <% else %>
     <%= content_tag :span, t(:'.value_count', count: metadata[:value_count]) %>
   <% end %>

--- a/app/views/spotlight/search_configurations/_facets.html.erb
+++ b/app/views/spotlight/search_configurations/_facets.html.erb
@@ -16,7 +16,7 @@
               </div>
             <% when :additional_options  %>
               <div class="facet-metadata mr-3">
-                <%= render partial: 'facet_metadata', locals: { metadata: metadata } %>
+                <%= render partial: 'facet_metadata', locals: { blacklight_config: @blacklight_configuration.blacklight_config, field_config: config, metadata: metadata } %>
               </div>
             <% else %>
             <% end %>

--- a/spec/features/edit_search_fields_spec.rb
+++ b/spec/features/edit_search_fields_spec.rb
@@ -23,7 +23,7 @@ describe 'Search Administration', type: :feature do
         within("[data-id='genre_ssim']") do
           expect(page).to have_content('Genre')
           expect(page).to have_content(/\d+ items/)
-          expect(page).to have_content(/(\d+) unique values/)
+          expect(page).to have_content(/([\d+]+) unique values/)
         end
       end
 

--- a/spec/views/spotlight/search_configurations/_facet_metadata.html.erb_spec.rb
+++ b/spec/views/spotlight/search_configurations/_facet_metadata.html.erb_spec.rb
@@ -1,8 +1,15 @@
 # frozen_string_literal: true
 
 describe 'spotlight/search_configurations/_facet_metadata', type: :view do
+  let(:field_config) { nil }
+  let(:blacklight_config) { nil }
+
   before do
-    render partial: 'spotlight/search_configurations/facet_metadata', locals: { metadata: metadata }
+    render partial: 'spotlight/search_configurations/facet_metadata', locals: {
+      blacklight_config: blacklight_config,
+      field_config: field_config,
+      metadata: metadata
+    }
   end
 
   context 'with a facet without any documents' do
@@ -27,6 +34,25 @@ describe 'spotlight/search_configurations/_facet_metadata', type: :view do
 
     it 'shows there are many unique values' do
       expect(rendered).to have_content '20+ unique values'
+    end
+  end
+
+  context 'with a facet with a configured limit' do
+    let(:metadata) { { document_count: 1, value_count: 10, terms: %w[] } }
+    let(:field_config) { Blacklight::Configuration::FacetField.new(limit: 10) }
+
+    it 'shows there are many unique values' do
+      expect(rendered).to have_content '10+ unique values'
+    end
+  end
+
+  context 'with a facet with an implicit limit' do
+    let(:blacklight_config) { CatalogController.blacklight_config }
+    let(:metadata) { { document_count: 1, value_count: 13, terms: %w[] } }
+    let(:field_config) { Blacklight::Configuration::FacetField.new(limit: true) }
+
+    it 'shows there are many unique values' do
+      expect(rendered).to have_content '10+ unique values'
     end
   end
 end


### PR DESCRIPTION
Currently, we just assume no further facet limit has been set. Instead, we should see what limit is configured and apply the field-specific limit instead.

This should fix the misreported data for fields in DLME where field limits are configured: 
![Screen Shot 2022-02-15 at 10 13 48](https://user-images.githubusercontent.com/111218/154123495-c2132e74-e612-4cc6-a681-63dbf9043206.png)
.