### PR TITLE
Update confirmation email text

### DIFF
--- a/app/mailers/spotlight/confirmation_mailer.rb
+++ b/app/mailers/spotlight/confirmation_mailer.rb
@@ -6,8 +6,9 @@ module Spotlight
   class ConfirmationMailer < ActionMailer::Base
     include Devise::Mailers::Helpers
 
-    def confirmation_instructions(record, token, opts)
+    def confirmation_instructions(record, token, opts, exhibit: nil)
       @token = token
+      @exhibit = exhibit
       initialize_from_record(record)
       mail headers_for(:confirmation_instructions, opts)
     end

--- a/app/models/spotlight/contact_email.rb
+++ b/app/models/spotlight/contact_email.rb
@@ -33,7 +33,7 @@ module Spotlight
     end
 
     def send_devise_notification(notification, *args)
-      notice = notification_mailer.send(notification, self, *args)
+      notice = notification_mailer.send(notification, self, *args, exhibit: exhibit)
       if notice.respond_to? :deliver_now
         notice.deliver_now
       else

--- a/app/views/spotlight/confirmation_mailer/confirmation_instructions.html.erb
+++ b/app/views/spotlight/confirmation_mailer/confirmation_instructions.html.erb
@@ -1,5 +1,5 @@
 <p><%= t(:'.welcome', email: @email) %></p>
-
-<p><%= t(:'.instructions') %></p>
-
+<br /><br />
+<%= simple_format t(:'.instructions', exhibit_title: @exhibit&.title) %>
+<br /><br />
 <p><%= link_to t(:'.confirm'), spotlight.contact_email_confirmation_url(:confirmation_token => @token) %></p>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -77,7 +77,7 @@ ignore_unused:
   # TODO Look into these as its unclear
   - activerecord.models.spotlight.page
   #- # perhaps removed here? https://github.com/projectblacklight/spotlight/commit/d4fdf04565ab3d648f0cb2a1238d84f262509fcd
-  - devise.mailer.invitation_instructions.subject # Does this even work? https://github.com/projectblacklight/spotlight/blob/master/app/mailers/spotlight/invitation_mailer.rb#L16
+  - devise.mailer.*.* # Does this even work? https://github.com/projectblacklight/spotlight/blob/master/app/mailers/spotlight/invitation_mailer.rb#L16
   - helpers.submit.solr_document.{batch_error,batch_updated,create,created,destroyed,submit,update,updated} # Do we need this?
   - helpers.submit.user.{batch_error,batch_updated,create,created,destroyed,submit,update,updated} # Do we need this?
   - helpers.action.destroy # no idea here

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -27,6 +27,10 @@ en:
       spotlight/group: Browse group
       spotlight/search: Browse category
   cancel: Cancel
+  devise:
+    mailer:
+      confirmation_instructions:
+        contact_email_subject: Exhibit feedback confirmation
   drag: Drag
   helpers:
     action:
@@ -408,9 +412,14 @@ en:
         users: Users
     confirmation_mailer:
       confirmation_instructions:
-        confirm: Confirm my account
-        instructions: 'You can confirm your account email through the link below:'
-        welcome: Welcome %{email}!
+        confirm: Yes, add me to the list of feedback form recipients
+        instructions: |
+          An administrator of the %{exhibit_title} exhibit has added your email address to the list of feedback form recipients.
+          This will enable you to receive any feedback submitted through the feedback form by visitors to the %{exhibit_title} exhibit.
+
+          To receive feedback from this exhibit, confirm your decision through the link below. If you do not want to
+          receive feedback form submissions from this exhibit, you can ignore this email.
+        welcome: Hello %{email},
     contact_form:
       subject: "%{application_name} exhibit feedback"
     contacts:


### PR DESCRIPTION
fixes #2779

```html
Date: Fri, 25 Feb 2022 09:42:02 -0800
From: please-change-me-at-config-initializers-devise@example.com
Reply-To: please-change-me-at-config-initializers-devise@example.com
To: user@example.com
Subject: Exhibit feedback confirmation

<p>Hello user@example.com,</p>
<br /><br />
<p>An administrator of the asdfasd exhibit has added your email address to the list of feedback form recipients.
<br />This will enable you to receive any feedback submitted through the feedback form by visitors to the asdfasd exhibit.</p>

<p>To receive feedback from this exhibit, confirm your decision through the link below. If you do not want to
<br />receive feedback form submissions from this exhibit, you can ignore this email.
</p>
<br /><br />
<p><a href="http://localhost:3000/spotlight/contact_email/confirmation?confirmation_token=J8v5wAktEqBqR31MAaC8&amp;from=noreply%40example.com">Yes, add me to the list of feedback form recipients</a></p>
```