### PR TITLE
Address upstream deprecation warnings

### DIFF
--- a/app/models/spotlight/page_configurations.rb
+++ b/app/models/spotlight/page_configurations.rb
@@ -57,7 +57,7 @@ module Spotlight
     end
 
     def available_view_configs
-      available_view_fields.map { |k, v| { key: k, label: v.display_label(k) } }
+      available_view_fields.map { |k, v| { key: k, label: v.display_label } }
     end
 
     def attachment_endpoint

--- a/app/views/spotlight/catalog/admin.html.erb
+++ b/app/views/spotlight/catalog/admin.html.erb
@@ -10,7 +10,7 @@
 <%- if @response.empty? %>
   <%= render "zero_results" %>
 <%- else %>
-  <%= render_document_index %>
+  <%= render_document_index(@response.documents) %>
 <%- end %>
 
 <%= render 'results_pagination' %>

--- a/app/views/spotlight/search_configurations/_document_index_view_types.html.erb
+++ b/app/views/spotlight/search_configurations/_document_index_view_types.html.erb
@@ -1,7 +1,7 @@
 <%= f.form_group :document_index_view_types, label: {text: t(:'.label'), class: 'pt-0'} do %>
   <%= f.fields_for :document_index_view_types, @blacklight_configuration.document_index_view_types_selected_hash do |vt| %>
     <% @blacklight_configuration.default_blacklight_config.view.select { |_k, v| v.if != false }.each do |key, view| %>
-      <%= vt.check_box key, label: view.display_label(key) %>
+      <%= vt.check_box key, label: view.display_label %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/spotlight/searches/_form.html.erb
+++ b/app/views/spotlight/searches/_form.html.erb
@@ -40,7 +40,7 @@
         <% end %>
         <%= f.form_group label: { text: t(:".default_index_view_type"), class: 'pt-0' } do %>
           <% available_document_index_views.each do |key, view| %>
-            <%= f.radio_button :default_index_view_type, key, label: view.display_label(key) %>
+            <%= f.radio_button :default_index_view_type, key, label: view.display_label %>
           <% end %>
         <% end %>
         <% unless @search.query_params.blank? %>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,7 +29,7 @@ Capybara.register_driver :headless_chrome do |app|
     opts.args << '--no-sandbox'
     opts.args << '--window-size=1280,1696'
   end
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options)
+  Capybara::Selenium::Driver.new(app, browser: :chrome, capabilities: [browser_options])
 end
 require 'webmock/rspec'
 allowed_sites = ['chromedriver.storage.googleapis.com']

--- a/spec/test_app_templates/catalog_controller.rb
+++ b/spec/test_app_templates/catalog_controller.rb
@@ -6,10 +6,10 @@ class CatalogController < ApplicationController
   before_action :set_paper_trail_whodunnit
 
   configure_blacklight do |config|
-    config.view.gallery.document_component = Blacklight::Gallery::DocumentComponent
+    config.view.gallery(document_component: Blacklight::Gallery::DocumentComponent)
     # config.view.gallery.classes = 'row-cols-2 row-cols-md-3'
-    config.view.masonry.document_component = Blacklight::Gallery::DocumentComponent
-    config.view.slideshow.document_component = Blacklight::Gallery::SlideshowComponent
+    config.view.masonry(document_component: Blacklight::Gallery::DocumentComponent)
+    config.view.slideshow(document_component: Blacklight::Gallery::SlideshowComponent)
     config.show.tile_source_field = :content_metadata_image_iiif_info_ssm
     config.show.partials.insert(1, :openseadragon)
     ## Default parameters to send to solr for all search-like requests. See also SolrHelper#solr_search_params


### PR DESCRIPTION
```
DEPRECATION WARNING: Initializing a Blacklight::Configuration::ViewConfig implicitly (by calling gallery) is deprecated. Call it as gallery! or pass initialize arguments. (called from block in <class:CatalogController> at 
[...]
DEPRECATION WARNING: Initializing a Blacklight::Configuration::ViewConfig implicitly (by calling masonry) is deprecated. Call it as masonry! or pass initialize arguments. (called from block in <class:CatalogController> at
[...]
DEPRECATION WARNING: Initializing a Blacklight::Configuration::ViewConfig implicitly (by calling slideshow) is deprecated. Call it as slideshow! or pass initialize arguments. (called from block in <class:CatalogController> at 
[...]
DEPRECATION WARNING: Passing the key argument to ViewConfig#display_label is deprecated. (called from block in available_view_configs at /home/runner/work/spotlight/spotlight/app/models/spotlight/page_configurations.rb:60) (196 times); e.g.: 
[...]
DEPRECATION WARNING: Calling render_document_index without documents is deprecated and will be removed in version 8. (called from __home_runner_work_spotlight_spotlight_app_views_spotlight_catalog_admin_html_erb___639682079725349543_735280 at /home/runner/work/spotlight/spotlight/app/views/spotlight/catalog/admin.html.erb:13) (17 times); e.g.: 
[...]
DEPRECATION WARNING: Passing the key argument to ViewConfig#display_label is deprecated. (called from block (3 levels) in __home_runner_work_spotlight_spotlight_app_views_spotlight_searches__form_html_erb__4232676025132663085_781120 at /home/runner/work/spotlight/spotlight/app/views/spotlight/searches/_form.html.erb:43) (34 times); e.g.: 
```