### PR TITLE
Render Analytics link in sidebar when enabled

### DIFF
--- a/app/views/spotlight/shared/_exhibit_sidebar.html.erb
+++ b/app/views/spotlight/shared/_exhibit_sidebar.html.erb
@@ -1,7 +1,9 @@
 <h2 class="sr-only"><%= t(:'.header') %></h2>
 <ul class="nav sidenav top-level flex-column">
   <%= nav_link t(:'spotlight.curation.sidebar.dashboard'), spotlight.exhibit_dashboard_path(current_exhibit) %>
+  <% if current_exhibit.analytics_provider&.enabled? %>
   <%= nav_link t(:'spotlight.curation.sidebar.analytics'), spotlight.analytics_exhibit_dashboard_path(current_exhibit) %>
+  <% end %>
 </ul>
 <%= render 'spotlight/shared/configuration_sidebar' if can? :update, current_exhibit %>
 <%= render 'spotlight/shared/curation_sidebar' %>

--- a/spec/views/spotlight/shared/_exhibit_sidebar.html.erb_spec.rb
+++ b/spec/views/spotlight/shared/_exhibit_sidebar.html.erb_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+describe 'spotlight/shared/_exhibit_sidebar', type: :view do
+  let(:current_exhibit) { FactoryBot.create(:exhibit) }
+
+  before do
+    allow(view).to receive_messages(current_exhibit: current_exhibit, exhibit_root_path: '/some/path')
+  end
+
+  context 'with a configured analytics integration' do
+    before do
+      allow(current_exhibit).to receive(:analytics_provider).and_return(double(Spotlight::Analytics::Ga, enabled?: true))
+    end
+
+    it 'has an analytics link in the sidebar' do
+      render
+
+      expect(rendered).to have_link 'Analytics'
+    end
+  end
+
+  context 'without a configured analytics integration' do
+    it 'does not have an analytics link in the sidebar' do
+      render
+
+      expect(rendered).not_to have_link 'Analytics'
+    end
+  end
+end


### PR DESCRIPTION
If Analytics is not enabled, we should not show an Analytics link in the
sidebar for an Exhibit.