### PR TITLE
do not show search buttons when catalog show comes from an image click in an exhibit

### DIFF
--- a/app/controllers/spotlight/concerns/catalog_search_context.rb
+++ b/app/controllers/spotlight/concerns/catalog_search_context.rb
@@ -5,6 +5,15 @@ module Spotlight
     ##
     # Search context helpers
     module CatalogSearchContext
+      extend ActiveSupport::Concern
+
+      # The following code is executed when someone includes Spotlight::Concerns::CatalogSearchContext in their
+      # own controller.
+      included do
+        # Provides access to the method in views as a helper method.
+        helper_method :current_search_session_from_page? if respond_to? :helper_method
+      end
+
       protected
 
       def current_page_context

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -1,0 +1,13 @@
+<% # Override conditional for rendering search buttons; all else is the same %>
+<% unless current_search_session_from_page? %>
+  <div id="appliedParams" class="clearfix constraints-container">
+    <%= render 'start_over' %>
+    <%= link_back_to_catalog class: 'btn btn-outline-secondary' %>
+  </div>
+<% end %>
+
+<%= render_document_main_content_partial %>
+
+<% content_for(:sidebar) do %>
+  <%= render_document_sidebar_partial @document %>
+<% end %>


### PR DESCRIPTION
Fixes Issue #2814 

In Spotlight 2.x & Blacklight 6.x, the search buttons and the pagination links were included in the same area of the page.  They were not rendered when `current_search_session_from_page?` returns `true`.

In Blacklight 7.x, the decision to show the search buttons and the pagination links are handles separately and displayed in separate areas of the page.  Spotlight 3.x overrides the code that determines whether or not to display the pagination in the [catalog controller](https://github.com/projectblacklight/spotlight/blob/v3.3.0/app/controllers/spotlight/catalog_controller.rb#L135-L146).  _NOTE: This same code is used in Spotlight 2.x._

In Blacklight 7.x determines whether to show the search buttons based on whether or not there is a search session.  This check is performed in the [catalog/show view](https://github.com/projectblacklight/blacklight/blob/v7.25.0/app/views/catalog/show.html.erb#L1-L6).

This PR overrides the catalog/show view and only displays the search buttons if `current_search_session_from_page?` returns `false`.