### PR TITLE
do not call deprecated render_search_bar helper

### DIFF
--- a/app/controllers/concerns/spotlight/catalog.rb
+++ b/app/controllers/concerns/spotlight/catalog.rb
@@ -10,6 +10,11 @@ module Spotlight
 
     included do
       before_action :add_facet_visibility_field
+
+      blacklight_config.search_state_fields.tap do |allowed_fields|
+        # if the blacklight config may be filtering params, add the required fields for exihibits, browse and search
+        allowed_fields&.concat(%i[browse_category_id exhibit_id id] - Array(allowed_fields))
+      end
     end
 
     # Adds a facet to display document visibility for the current exhibit

--- a/app/models/spotlight/blacklight_configuration.rb
+++ b/app/models/spotlight/blacklight_configuration.rb
@@ -224,6 +224,11 @@ module Spotlight
           config.navbar.partials[:search_history].if = false if config.navbar.partials.key? :search_history
         end
 
+        config.search_state_fields.tap do |allowed_fields|
+          # if the blacklight config may be filtering params, add the required fields for exihibits, browse and search
+          allowed_fields&.concat(%i[browse_category_id exhibit_id id] - Array(allowed_fields))
+        end
+
         config
       end
     end

--- a/app/views/shared/_exhibit_navbar.html.erb
+++ b/app/views/shared/_exhibit_navbar.html.erb
@@ -12,7 +12,15 @@
     </ul>
     <% if should_render_spotlight_search_bar? %>
       <div class="navbar-right navbar-nav exhibit-search-form mt-3 mt-md-0">
-        <%= render_search_bar %>
+        <%- exhibit_config = current_exhibit.blacklight_config %>
+        <%- renderable_search_fields = exhibit_config.search_fields.values.collect { |field_def| [field_def.display_label('search'), field_def.key] if should_render_field?(field_def)}.compact %>
+        <%= render((exhibit_config&.view_config(document_index_view_type)&.search_bar_component ||Blacklight::SearchBarComponent).new(
+          url: search_action_url,
+          advanced_search_url: search_action_url(action: 'advanced_search'),
+          search_fields: renderable_search_fields,
+          params: search_state.params_for_search.except(:qt),
+          autocomplete_path: search_action_path(action: :suggest))
+        ) %>
       </div>
     <% end %>
   </div>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -65,6 +65,7 @@ ignore_unused:
   - helpers.action.{edit,edit_long,new,view} # app/helpers/spotlight/crud_link_helpers.rb
   - helpers.action.spotlight/search.edit_long # app/views/spotlight/searches/_search.html.erb
   - spotlight.about_pages.page_options.published # app/views/spotlight/about_pages/_page_options.html.erb
+  - spotlight.job_trackers.show.messages.status.{completed,enqueued,failed,missing,pending} # app/views/spotlight/job_trackers/show.html.erb
   - helpers.submit.contact_form.create # app/views/spotlight/shared/_report_a_problem.html.erb
   - activerecord.help.spotlight/exhibit.tag_list # app/views/spotlight/exhibits/_form.html.erb
   - helpers.label.solr_document.exhibit_tag_list # app/views/spotlight/catalog/_edit_default.html.erb

--- a/spec/features/autocomplete_typeahead_spec.rb
+++ b/spec/features/autocomplete_typeahead_spec.rb
@@ -25,8 +25,9 @@ describe 'Autocomplete typeahead', type: :feature, js: true do
         featured_image = Spotlight::FeaturedImage.last
 
         expect(featured_image.iiif_manifest_url).to eq 'https://purl.stanford.edu/gk446cj2442/iiif/manifest.json'
-        expect(featured_image.iiif_canvas_id).to eq 'https://purl.stanford.edu/gk446cj2442/iiif/canvas/gk446cj2442_1'
-        expect(featured_image.iiif_image_id).to eq 'https://purl.stanford.edu/gk446cj2442/iiif/annotation/gk446cj2442_1'
+        # TODO: this data is fetched by a javascript widget and thus isn't captured by webmock see #2817
+        expect(featured_image.iiif_canvas_id).to eq 'https://purl.stanford.edu/gk446cj2442/iiif/canvas/cocina-fileSet-gk446cj2442-gk446cj2442_1'
+        expect(featured_image.iiif_image_id).to eq 'https://purl.stanford.edu/gk446cj2442/iiif/annotation/cocina-fileSet-gk446cj2442-gk446cj2442_1'
         expect(featured_image.iiif_tilesource).to eq 'https://stacks.stanford.edu/image/iiif/gk446cj2442%2Fgk446cj2442_05_0001/info.json'
       end
 

--- a/spec/helpers/spotlight/application_helper_spec.rb
+++ b/spec/helpers/spotlight/application_helper_spec.rb
@@ -55,9 +55,15 @@ describe Spotlight::ApplicationHelper, type: :helper do
   end
 
   describe '#url_to_tag_facet' do
+    let(:blacklight_config) do
+      Blacklight::Configuration.new.configure do |config|
+        config.add_facet_field :exhibit_tags # this is added to exhibit configurations by model
+      end
+    end
+
     before do
       allow(helper).to receive_messages(current_exhibit: FactoryBot.create(:exhibit))
-      allow(helper).to receive_messages(blacklight_config: Blacklight::Configuration.new)
+      allow(helper).to receive_messages(blacklight_config: blacklight_config)
 
       # controller provided helper.
       allow(helper).to receive(:search_action_url) do |*args|

--- a/spec/models/spotlight/browse_category_search_builder_spec.rb
+++ b/spec/models/spotlight/browse_category_search_builder_spec.rb
@@ -15,8 +15,14 @@ describe Spotlight::BrowseCategorySearchBuilder do
   let(:search) { FactoryBot.create(:search, exhibit: exhibit, query_params: { sort: 'type', f: { genre_ssim: ['term'] }, q: 'search query' }) }
 
   describe '#restrict_to_browse_category' do
+    before do
+      exhibit.blacklight_config.configure do |config|
+        config.search_state_fields << :browse_category_id
+      end
+    end
+
     it 'adds the search query parameters from the browse category' do
-      params = subject.to_hash.with_indifferent_access
+      params = subject.to_hash.symbolize_keys
 
       expect(params).to include(
         q: 'search query',

--- a/spec/models/spotlight/search_spec.rb
+++ b/spec/models/spotlight/search_spec.rb
@@ -94,6 +94,10 @@ describe Spotlight::Search, type: :model do
   end
 
   describe '#merge_params_for_search' do
+    before do
+      blacklight_config.search_state_fields&.concat [:view] # Blacklight 7.25+ will sanitize
+    end
+
     it 'merges user-supplied parameters into the search query' do
       user_params = { view: 'x' }
       search_params = subject.merge_params_for_search(user_params, blacklight_config)

--- a/spec/services/spotlight/etl/pipeline_spec.rb
+++ b/spec/services/spotlight/etl/pipeline_spec.rb
@@ -14,7 +14,7 @@ describe Spotlight::Etl::Pipeline do
 
   describe '#estimated_size' do
     it 'forwards the call to the executor' do
-      allow(Spotlight::Etl::Executor).to receive(:new).with(subject, context).and_return(mock_executor)
+      allow(Spotlight::Etl::Executor).to receive(:new).with(subject, context, any_args).and_return(mock_executor)
 
       expect(subject.estimated_size(context)).to eq 10
     end

--- a/spec/views/shared/_exhibit_navbar.html.erb_spec.rb
+++ b/spec/views/shared/_exhibit_navbar.html.erb_spec.rb
@@ -11,8 +11,16 @@ describe 'shared/_exhibit_navbar', type: :view do
     allow(view).to receive_messages(resource_masthead?: false)
     allow(view).to receive_messages(current_exhibit: current_exhibit)
     allow(view).to receive_messages(on_browse_page?: false, on_about_page?: false)
-    allow(view).to receive_messages(render_search_bar: 'Search Bar')
+    allow(view).to receive_messages(should_render_field?: true)
+    allow(view).to receive_messages(document_index_view_type: :list)
     allow(view).to receive_messages(exhibit_path: spotlight.exhibit_path(current_exhibit))
+    allow(view).to receive_messages(blacklight_config: current_exhibit.blacklight_config)
+    allow(view).to receive(:search_action_url) do |*args|
+      spotlight.search_exhibit_catalog_path(current_exhibit, *args)
+    end
+    allow(view).to receive(:search_action_path) do |*args|
+      spotlight.search_exhibit_catalog_path(current_exhibit, *args)
+    end
   end
 
   it 'links to the exhibit home page (as branding) when there is a current search masthead' do
@@ -109,13 +117,13 @@ describe 'shared/_exhibit_navbar', type: :view do
   it 'includes the search bar when the exhibit is searchable' do
     expect(current_exhibit).to receive(:searchable?).and_return(true)
     render
-    expect(response).to have_content 'Search Bar'
+    expect(response).to have_selector('button#search')
   end
 
   it 'does not include the search bar when the exhibit is not searchable' do
     expect(current_exhibit).to receive(:searchable?).and_return(false)
     render
-    expect(response).not_to have_content 'Search Bar'
+    expect(response).not_to have_selector('button#search')
   end
 
   it 'does not include any navigation menu items that are not configured' do


### PR DESCRIPTION
The `render_search_bar` helper is deprecated. There is also a bug around the deprecation warning in 7.25.1 that will be fixed in a patch release, but avoiding the helper entirely is preferable.