### PR TITLE
Fix sort order in sir trevor displayable mixin

### DIFF
--- a/app/models/sir_trevor_rails/blocks/displayable.rb
+++ b/app/models/sir_trevor_rails/blocks/displayable.rb
@@ -14,7 +14,7 @@ module SirTrevorRails
       end
 
       def ordered_items
-        items.sort_by { |x| x[:weight] }.map { |x| x[:id] }
+        items.sort_by { |x| x[:weight].to_s.rjust(5, '0') }.map { |x| x[:id] }
       end
 
       private

--- a/app/models/sir_trevor_rails/blocks/displayable.rb
+++ b/app/models/sir_trevor_rails/blocks/displayable.rb
@@ -14,7 +14,7 @@ module SirTrevorRails
       end
 
       def ordered_items
-        items.sort_by { |x| x[:weight].to_s.rjust(5, '0') }.map { |x| x[:id] }
+        items.sort_by { |x| x[:weight].to_i) }.map { |x| x[:id] }
       end
 
       private


### PR DESCRIPTION
Solves #2820 

Several blocks of sir-trevor-rails display their items in a wrong order
(other than set in the backend) if there are more than ten items.
This bug concerns all blocks including the mixin Displayable:
- FeaturedPagesBlock
- BrowseBlock
- LinkToSearchBlock
- SearchResultsBlock
- SolrDocumentsBlock

The items are sorted in a non-natural order and thereby the item with a
weight of 10 is displayed between the ones with a weight of 1 and that
with a weight of 2.
As ruby does not provide a method for a natural sort order, fix this by
padding the weight with leading zeroes in Displayable#ordered_items