### PR TITLE
Work around upstream i18n-active-record behavior that's incompatible …

### DIFF
--- a/app/models/translation.rb
+++ b/app/models/translation.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+unless defined?(Translation)
+  Translation = I18n::Backend::ActiveRecord::Translation
+  Translation.include Spotlight::CustomTranslationExtension
+
+  # Work-around for https://github.com/svenfuchs/i18n-active_record/pull/133
+  if Translation.respond_to?(:to_hash)
+    class << Translation
+      alias to_h to_hash
+      remove_method :to_hash
+    end
+
+    I18n::Backend::ActiveRecord.define_method(:init_translations) do
+      @translations = Translation.to_h
+    end
+  end
+end

--- a/lib/generators/spotlight/templates/config/initializers/translation.rb
+++ b/lib/generators/spotlight/templates/config/initializers/translation.rb
@@ -3,8 +3,6 @@
 require 'i18n/backend/active_record'
 require 'i18n/backend/fallbacks'
 
-Translation = I18n::Backend::ActiveRecord::Translation
-
 ActiveSupport::Reloader.to_prepare do
   # Don't allow initializer to break if DB doesn't exist yet
   # see: https://github.com/projectblacklight/spotlight/issues/2133
@@ -16,7 +14,6 @@ ActiveSupport::Reloader.to_prepare do
     # turn on the ActiveRecord backend, uncomment the following lines.
     I18n.backend = I18n::Backend::ActiveRecord.new
     I18n::Backend::ActiveRecord.include I18n::Backend::Memoize
-    Translation.include Spotlight::CustomTranslationExtension
     I18n::Backend::Simple.include I18n::Backend::Memoize
     I18n::Backend::Simple.include I18n::Backend::Pluralization
     I18n::Backend::Simple.include I18n::Backend::Fallbacks

--- a/spec/models/translation_spec.rb
+++ b/spec/models/translation_spec.rb
@@ -11,4 +11,16 @@ describe Translation, type: :model do
       end.to raise_error(ActiveRecord::RecordNotUnique)
     end
   end
+
+  describe '.to_h' do
+    it 'dumps the translations' do
+      expect(described_class.to_h).to be_a(Hash)
+    end
+  end
+
+  describe '.to_hash' do
+    it 'is not defined' do
+      expect(described_class).not_to respond_to(:to_hash)
+    end
+  end
 end


### PR DESCRIPTION
…with ruby 2.7