### PR TITLE
Fixing broken rake spotlight:export[exhibit_slug] task.

### DIFF
--- a/lib/tasks/spotlight_tasks.rake
+++ b/lib/tasks/spotlight_tasks.rake
@@ -70,7 +70,7 @@ namespace :spotlight do
   task :export, [:exhibit_slug] => :environment do |_, args|
     exhibit = Spotlight::Exhibit.find_by(slug: args[:exhibit_slug])
 
-    puts Spotlight::ExhibitExportSerializer.new(exhibit).to_json
+    puts Spotlight::ExhibitImportExportService.new(exhibit).to_json
   end
 
   desc 'Migrate to IIIF'


### PR DESCRIPTION
The Spotlight rake task for exporting exhibits is currently broken. When you run it, the result is similar to this:

```
$ bundle exec rake spotlight:export[contagion] > export.json
rake aborted!
NameError: uninitialized constant Spotlight::ExhibitExportSerializer
```

It looks like back in April 2020  `ExhibitExportSerializer` was replaced with `ExhibitImportExportService` and the rake task was not updated to use the new service:

https://github.com/projectblacklight/spotlight/commit/1c61dff3d4dfe6694ac8a26bd3ade11784aae717

This PR updates `spotlight_tasks.rake` to use the new service.