### PR TITLE
pin view_component to < 2.74

### DIFF
--- a/blacklight-spotlight.gemspec
+++ b/blacklight-spotlight.gemspec
@@ -60,6 +60,7 @@ these collections.)
   s.add_dependency 'thor'
   s.add_dependency 'tophat'
   s.add_dependency 'underscore-rails', '~> 1.6'
+  s.add_dependency 'view_component', '< 2.74' # until a release includes https://github.com/projectblacklight/blacklight/pull/2818/files
 
   s.add_development_dependency 'capybara', '~> 3.31'
   s.add_development_dependency 'engine_cart', '~> 2.0'


### PR DESCRIPTION
until there's a tagged blacklight release including https://github.com/projectblacklight/blacklight/pull/2818