### PR TITLE
rubocop: remove now-invalid cop definition

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -216,8 +216,6 @@ Rails/WhereExists: # (new in 2.7)
   Enabled: true
 Rails/WhereNot: # (new in 2.8)
   Enabled: true
-Gemspec/DeprecatedAttributeAssignment: # (new in 1.10)
-  Enabled: true
 Lint/NumberedParameterAssignment: # (new in 1.9)
   Enabled: true
 Lint/OrAssignmentToConstant: # (new in 1.9)


### PR DESCRIPTION
forgot to include this in https://github.com/projectblacklight/spotlight/pull/2848

```
alexandra@sys27-hp ~/c/spotlight (main)> bundle exec rake
Running RuboCop...
Error: unrecognized cop or department Gemspec/DeprecatedAttributeAssignment found in .rubocop.yml
Did you mean `Gemspec/OrderedDependencies`?
RuboCop failed!
```