### PR TITLE
Adding further hints for fields

### DIFF
--- a/app/views/spotlight/custom_search_fields/_form.html.erb
+++ b/app/views/spotlight/custom_search_fields/_form.html.erb
@@ -1,8 +1,8 @@
 <%= bootstrap_form_for @custom_search_field.new_record? ? [current_exhibit, @custom_search_field] : [@custom_search_field.exhibit, @custom_search_field], layout: :horizontal, label_col: 'col-md-3', control_col: 'col-md-9', html: {class: 'col-md-9', id: 'edit-search-field'} do |f| %>
 
-  <%= f.text_field :slug %>
+  <%= f.text_field :slug, help: t('.slug.help') %>
   <%= f.text_field :field, help: t('.field.help') %>
-  <%= f.text_field :label %>
+  <%= f.text_field :label, help: t('.label.help') %>
 
   <div class="form-actions">
     <div class="primary-actions">

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -475,8 +475,12 @@ en:
       edit:
         header: Edit exhibit-specific field
       form:
+        slug:
+          help: A machine friendly name for the Solr specification.  See https://github.com/projectblacklight/blacklight/wiki/Blacklight-configuration#search-fields
         field:
           help: Specify fields to be searched and their boost values (e.g., full_title_tesim^100 personal_name_tesim^50).
+        label:
+          help: A human friendly label for the Solr specification.
       new:
         header: Add exhibit-specific field
     dashboards:


### PR DESCRIPTION
Prior to this commit, we did not describe the `slug` and `label`.  Given that we use `slug` to "name" an Exhibit, this can create ambiguity.

After this commit, we're providing some way finding to what we mean by `slug` and `label`.
