### PR TITLE
Switch to alert-info for "Reporting from" on the feedback form

### DIFF
--- a/app/views/spotlight/shared/_report_a_problem.html.erb
+++ b/app/views/spotlight/shared/_report_a_problem.html.erb
@@ -3,7 +3,7 @@
     <% contact_form ||= Spotlight::ContactForm.new current_url: request.original_url %>
     <%= bootstrap_form_for contact_form, url: spotlight.exhibit_contact_form_path(current_exhibit, contact_form), layout: :horizontal, label_col: 'col-sm-3', control_col: 'col-sm-9', html: { class: 'col-md-offset-2 col-md-8 my-3 '} do |f| %>
       <h2><%= t(:'.title') %></h2>
-      <div class="alert alert-primary"><%= t('.reporting_from', url: contact_form.current_url) %></div>
+      <div class="alert alert-info"><%= t('.reporting_from', url: contact_form.current_url) %></div>
       <%= f.text_area :message, rows: 4 %>
       <%= f.text_field :name %>
       <%= render '/spotlight/shared/honeypot_field', f: f %>

--- a/spec/features/report_a_problem_spec.rb
+++ b/spec/features/report_a_problem_spec.rb
@@ -34,7 +34,7 @@ describe 'Report a Problem', type: :feature do
     it 'accepts a problem report', js: true do
       visit spotlight.exhibit_solr_document_path(exhibit, id: 'dq287tq6352')
       click_on 'Feedback'
-      expect(page).to have_css('.alert-primary', text: '/dq287tq6352')
+      expect(page).to have_css('.alert-info', text: '/dq287tq6352')
       expect(find_by_id('contact_form_current_url', visible: false).value).to end_with spotlight.exhibit_solr_document_path(exhibit, id: 'dq287tq6352')
       fill_in 'Your name', with: 'Some Body'
       fill_in 'Your email', with: 'test@example.com'


### PR DESCRIPTION
alert-primary is based off the brand color where as alert-info is more generally about presenting information.