### PR TITLE
Fix ID handling in IIIF helper methods

### DIFF
--- a/app/models/spotlight/resources/upload.rb
+++ b/app/models/spotlight/resources/upload.rb
@@ -49,7 +49,7 @@ module Spotlight
           spotlight_full_image_width_ssm: dimensions.width,
           spotlight_full_image_height_ssm: dimensions.height,
           Spotlight::Engine.config.thumbnail_field => Spotlight::Engine.config.iiif_service.thumbnail_url(upload),
-          Spotlight::Engine.config.iiif_manifest_field => Spotlight::Engine.config.iiif_service.manifest_url(exhibit, upload)
+          Spotlight::Engine.config.iiif_manifest_field => Spotlight::Engine.config.iiif_service.manifest_url(exhibit, self)
         }
       end
 

--- a/app/models/spotlight/resources/upload.rb
+++ b/app/models/spotlight/resources/upload.rb
@@ -43,7 +43,7 @@ module Spotlight
       def to_solr
         return {} unless upload&.file_present?
 
-        dimensions = Spotlight::Engine.config.iiif_service.info(id)
+        dimensions = Spotlight::Engine.config.iiif_service.info(upload.id)
 
         {
           spotlight_full_image_width_ssm: dimensions.width,

--- a/lib/spotlight/riiif_service.rb
+++ b/lib/spotlight/riiif_service.rb
@@ -22,7 +22,7 @@ module Spotlight
       Spotlight::Engine.routes.url_helpers.manifest_exhibit_solr_document_path(exhibit, "#{exhibit.id}-#{resource.id}")
     end
 
-    # @param [String] id
+    # @param [String] id the ID string of a Spotlight::FeaturedImage
     # @return [Hash]
     def self.info(id)
       Riiif::Image.new(id).info

--- a/lib/spotlight/riiif_service.rb
+++ b/lib/spotlight/riiif_service.rb
@@ -16,10 +16,10 @@ module Spotlight
     end
 
     # @param [Spotlight::Exhibit] exhibit
-    # @param [Spotlight::FeaturedImage] image
+    # @param [Spotlight::Resource::Upload] resource
     # @return [String]
-    def self.manifest_url(exhibit, image)
-      Spotlight::Engine.routes.url_helpers.manifest_exhibit_solr_document_path(exhibit, "#{exhibit.id}-#{image.id}")
+    def self.manifest_url(exhibit, resource)
+      Spotlight::Engine.routes.url_helpers.manifest_exhibit_solr_document_path(exhibit, "#{exhibit.id}-#{resource.id}")
     end
 
     # @param [String] id

--- a/spec/controllers/spotlight/catalog_controller_spec.rb
+++ b/spec/controllers/spotlight/catalog_controller_spec.rb
@@ -152,7 +152,7 @@ describe Spotlight::CatalogController, type: :controller do
         it 'returns a 404 when called on something other than an uploaded resource' do
           get :manifest, params: { exhibit_id: exhibit, id: 'dx157dh4345' }
           expect(response).not_to be_successful
-          expect(response.status).to eq(404)
+          expect(response).to have_http_status(:not_found)
         end
       end
     end

--- a/spec/controllers/spotlight/contact_email_controller_spec.rb
+++ b/spec/controllers/spotlight/contact_email_controller_spec.rb
@@ -56,7 +56,7 @@ describe Spotlight::ContactEmailController, type: :controller do
         it 'gives a 404 with appropriate message when the record no longer exists' do
           contact_email.destroy
           delete :destroy, params: { id: contact_email, exhibit_id: contact_email.exhibit }
-          expect(response.status).to eq 404
+          expect(response).to have_http_status :not_found
           expect(response.parsed_body).to eq('success' => false, 'error' => 'Not Found')
         end
       end

--- a/spec/controllers/spotlight/solr_controller_spec.rb
+++ b/spec/controllers/spotlight/solr_controller_spec.rb
@@ -48,7 +48,7 @@ describe Spotlight::SolrController, type: :controller do
         it 'raises an error' do
           post_update_with_json_body(exhibit, a: 1)
 
-          expect(response.code).to eq '409'
+          expect(response).to have_http_status :conflict
         end
       end
 

--- a/spec/models/spotlight/resources/upload_spec.rb
+++ b/spec/models/spotlight/resources/upload_spec.rb
@@ -35,6 +35,24 @@ describe Spotlight::Resources::Upload, type: :model do
     end
   end
 
+  describe '#to_solr' do
+    subject(:solr_document) { upload.to_solr }
+
+    let(:featured_image) { instance_double(Spotlight::FeaturedImage, id: 1, file_present?: true) }
+
+    before do
+      allow(upload).to receive(:upload).and_return(featured_image)
+      allow(Spotlight::RiiifService).to receive(:thumbnail_url).with(featured_image).and_return('/a/thumbnail/url')
+      allow(Spotlight::RiiifService).to receive(:manifest_url).with(exhibit, upload).and_return('/a/manifest/url')
+    end
+
+    it 'returns a hash using the iiif service' do
+      expect(solr_document).to have_key(:iiif_manifest_url_ssi)
+      expect(solr_document).to have_key(:thumbnail_url_ssm)
+      expect(Spotlight::RiiifService).to have_received(:manifest_url).with(exhibit, upload)
+    end
+  end
+
   context 'when creating' do
     before do
       allow(upload).to receive(:write?).and_return(false)


### PR DESCRIPTION
The manifest controller expects the URL to include the exhibit ID and resource ID, but the indexer has been using the ID of the resource's `FeaturedImage` instead.  This doesn't always cause issues, because in many situations the ID of a resource's `FeaturedImage` and the ID of the resource itself have the same numerical representation.  But those numbers can fall out of sync, and manifests will fail to load.

Meanwhile, update the `iiif_service#info` method to expect the ID of a `FeaturedImage` rather than a `Resource`.  This brings it in line with the other `RIIIFService` helper methods and is how `Spotlight::CarrierwaveFileResolver` behaves.