### PR TITLE
Defer configuration until the script is loaded

### DIFF
--- a/app/views/layouts/spotlight/base.html.erb
+++ b/app/views/layouts/spotlight/base.html.erb
@@ -19,7 +19,7 @@
     <%= description %>
     <%= twitter_card %>
     <%= opengraph %>
-    <%= javascript_tag "Spotlight.sirTrevorIcon = '#{asset_path('spotlight/blocks/sir-trevor-icons.svg')}'" %>
+    <%= javascript_tag "window.addEventListener('load', () => Spotlight.sirTrevorIcon = '#{asset_path('spotlight/blocks/sir-trevor-icons.svg')}')" %>
     <%= javascript_tag '$.fx.off = true;' if Rails.env.test? %>
   </head>
   <body class="<%= render_body_class %>">


### PR DESCRIPTION
This is critical when using module based javascript, because the inline scripts occur ahead of deferred scripts. All module scripts are deferred by default. Script tags without a src attribute can not be deferred.