### PR TITLE
Stop requiring bootstrap components

### DIFF
--- a/app/assets/javascripts/spotlight/application.js
+++ b/app/assets/javascripts/spotlight/application.js
@@ -1,9 +1,4 @@
 // This is the sprockets entrypoint.
-//= require bootstrap/util
-//= require bootstrap/tab
-//= require bootstrap/tooltip
-//= require bootstrap/popover
-//= require bootstrap/carousel
 //= require leaflet
 //= require sir-trevor
 //= require clipboard


### PR DESCRIPTION
Blacklight's installer already adds these. This prevents two copies from being initialized, which can result in popover toggle links bouncing (open then close).