### PR TITLE
Pin devise >= v4.9 for turbo compatibility

### DIFF
--- a/blacklight-spotlight.gemspec
+++ b/blacklight-spotlight.gemspec
@@ -30,7 +30,7 @@ these collections.)
   s.add_dependency 'cancancan'
   s.add_dependency 'carrierwave', '~> 2.2'
   s.add_dependency 'clipboard-rails', '~> 1.5'
-  s.add_dependency 'devise', '~> 4.1'
+  s.add_dependency 'devise', '~> 4.9'
   s.add_dependency 'devise_invitable'
   s.add_dependency 'faraday'
   s.add_dependency 'faraday-follow_redirects'


### PR DESCRIPTION
running tests locally with fresh bundle on main was throwing:
```
Failure/Error: EngineCart.load_application!

NoMethodError:
  undefined method `responder' for Devise:Module
```
there seems to have been a bunch of recent work in devise to support turbo, culminating (possibly?) in v4.9.0.