### PR TITLE
Remove unnecessary include of bootstrap/variables

### DIFF
--- a/app/assets/stylesheets/spotlight/_spotlight.scss
+++ b/app/assets/stylesheets/spotlight/_spotlight.scss
@@ -1,7 +1,5 @@
 @import "spotlight/variables";
 @import "spotlight/mixins";
-@import "bootstrap/variables";
-
 @import "spotlight/sir-trevor_overrides";
 @import "spotlight/attachments";
 @import "spotlight/pages";


### PR DESCRIPTION
This is already imported via the spotlight.scss in template