### PR TITLE
Use Blacklight::Configuration.default_configuration for Blacklight 8

### DIFF
--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -248,17 +248,30 @@ module Spotlight
 
     config.spambot_honeypot_email_field = :email_address
 
-    config.to_prepare do
-      Blacklight::Configuration.try(:initialize_default_configuration) unless Blacklight::Configuration.try(:initialized_default_configuration?)
+    if Blacklight::VERSION > '8'
+      Blacklight::Configuration.default_configuration do
+        # Field containing the last modified date for a Solr document
+        Blacklight::Configuration.default_values[:index].timestamp_field ||= 'timestamp'
 
-      # Field containing the last modified date for a Solr document
-      Blacklight::Configuration.default_values[:index].timestamp_field ||= 'timestamp'
+        # Default configuration for the browse view
+        Blacklight::Configuration.property :browse, default: Blacklight::OpenStructWithHashAccess.new(document_actions: [])
 
-      # Default configuration for the browse view
-      Blacklight::Configuration.default_values[:browse] ||= Blacklight::OpenStructWithHashAccess.new(document_actions: [])
+        Blacklight::Configuration.default_values[:search_state_fields] ||= []
+        Blacklight::Configuration.default_values[:search_state_fields] += %i[id exhibit_id]
+      end
+    else
+      config.to_prepare do
+        Blacklight::Configuration.try(:initialize_default_configuration) unless Blacklight::Configuration.try(:initialized_default_configuration?)
 
-      Blacklight::Configuration.default_values[:search_state_fields] ||= []
-      Blacklight::Configuration.default_values[:search_state_fields] += %i[id exhibit_id]
+        # Field containing the last modified date for a Solr document
+        Blacklight::Configuration.default_values[:index].timestamp_field ||= 'timestamp'
+
+        # Default configuration for the browse view
+        Blacklight::Configuration.default_values[:browse] ||= Blacklight::OpenStructWithHashAccess.new(document_actions: [])
+
+        Blacklight::Configuration.default_values[:search_state_fields] ||= []
+        Blacklight::Configuration.default_values[:search_state_fields] += %i[id exhibit_id]
+      end
     end
 
     # make blacklight configuration play nice with bootstrap_form


### PR DESCRIPTION
Blacklight 8 refactored how configuration defaults are set, so Spotlight needed to be adjusted to use the appropriate method depending on the version of Blacklight.