### PR TITLE
Make the edit button display in the right location on Blacklight 8

### DIFF
--- a/app/components/spotlight/document_component.rb
+++ b/app/components/spotlight/document_component.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Spotlight
+  # Displays the document
+  # This overrides the title method to provide an edit link.
+  class DocumentComponent < Blacklight::DocumentComponent
+    def title
+      safe_join([exhibit_edit_link, super, add_document_meta_content(@document)])
+    end
+
+    attr_reader :document
+
+    delegate :current_exhibit, :can?, :add_document_meta_content, to: :helpers
+
+    def exhibit_edit_link
+      helpers.exhibit_edit_link document, [:edit, current_exhibit, document], class: 'float-right btn btn-primary' if can?(:curate, current_exhibit)
+    end
+  end
+end

--- a/app/controllers/spotlight/catalog_controller.rb
+++ b/app/controllers/spotlight/catalog_controller.rb
@@ -23,8 +23,7 @@ module Spotlight
     before_action :load_document, only: %i[edit update make_private make_public manifest]
 
     before_action only: :show do
-      blacklight_config.show.partials.unshift 'tophat'
-      blacklight_config.show.partials.unshift 'curation_mode_toggle'
+      blacklight_config.show.document_component = Spotlight::DocumentComponent
     end
 
     before_action only: :admin do

--- a/app/views/spotlight/catalog/_curation_mode_toggle_default.html.erb
+++ b/app/views/spotlight/catalog/_curation_mode_toggle_default.html.erb
@@ -1,1 +1,0 @@
-<%= exhibit_edit_link document, [:edit, current_exhibit, document], class: 'float-right btn btn-primary' if can?(:curate, current_exhibit) and !current_page? [:edit, current_exhibit, document]  %>

--- a/app/views/spotlight/catalog/_tophat_default.html.erb
+++ b/app/views/spotlight/catalog/_tophat_default.html.erb
@@ -1,1 +1,0 @@
-<% add_document_meta_content(@document) %>

--- a/spec/controllers/spotlight/catalog_controller_spec.rb
+++ b/spec/controllers/spotlight/catalog_controller_spec.rb
@@ -67,11 +67,6 @@ describe Spotlight::CatalogController, type: :controller do
         expect(response).to be_successful
       end
 
-      it 'adds the curation widget' do
-        get :show, params: { exhibit_id: exhibit, id: 'dq287tq6352' }
-        expect(controller.blacklight_config.show.partials.first).to eq 'curation_mode_toggle'
-      end
-
       it 'does not have a solr_json serialization' do
         get :show, params: { exhibit_id: exhibit, id: 'dq287tq6352', format: :solr_json }
         expect(response).not_to be_successful


### PR DESCRIPTION
On Blacklight 8 the partials render at the bottom of the component, but we want the edit button in the header.