### PR TITLE
Call the on_error handler with the correct number of arguments.

### DIFF
--- a/app/services/spotlight/etl/solr_loader.rb
+++ b/app/services/spotlight/etl/solr_loader.rb
@@ -53,7 +53,7 @@ module Spotlight
                                data: [document].to_json,
                                headers: { 'Content-Type' => 'application/json' }
       rescue StandardError => e
-        pipeline&.on_error(self, e, document.to_json)
+        pipeline&.on_error(e, document.to_json)
       end
 
       def blacklight_solr


### PR DESCRIPTION
Fixes an exception:
```
wrong number of arguments (given 3, expected 2)
```

Alternatively we could have called `pipeline&.context&.on_error` which takes 3 args.