### PR TITLE
Raw document upload broken: fixed to access Solr via blacklight_config

### DIFF
--- a/app/controllers/spotlight/solr_controller.rb
+++ b/app/controllers/spotlight/solr_controller.rb
@@ -20,7 +20,7 @@ module Spotlight
 
       data = solr_documents
 
-      repository.connection.update params: { commitWithin: 500 }, data: data.to_json, headers: { 'Content-Type' => 'application/json' } unless data.empty?
+      @exhibit.blacklight_config.repository.connection.update params: { commitWithin: 500 }, data: data.to_json, headers: { 'Content-Type' => 'application/json' } unless data.empty?
 
       if params[:resources_json_upload]
         redirect_back fallback_location: exhibit_resources_path(@exhibit)


### PR DESCRIPTION
Within the "Add items" function the "Upload raw documents" feature was broken because the code used "repository" which was not defined. Fix appears to behave, though obviously this is very much a feature for expert use, and I am not yet an expert.