### PR TITLE
Do a better job handling e.g. hash data structures in sidecar data

### DIFF
--- a/app/models/spotlight/solr_document_sidecar.rb
+++ b/app/models/spotlight/solr_document_sidecar.rb
@@ -101,8 +101,10 @@ module Spotlight
     def convert_stored_value_to_solr(value)
       if value.blank?
         nil
-      elsif value.is_a? Enumerable
+      elsif value.is_a? Array
         value.reject(&:blank?)
+      elsif value.is_a? Hash
+        value.values.reject(&:blank?)
       else
         value
       end

--- a/spec/models/spotlight/solr_document_sidecar_spec.rb
+++ b/spec/models/spotlight/solr_document_sidecar_spec.rb
@@ -44,5 +44,15 @@ describe Spotlight::SolrDocumentSidecar, type: :model do
       its(:to_solr) { is_expected.to include 'a_blank_multivalued_field' => [] }
       its(:to_solr) { is_expected.to include 'a_multivalued_field_with_some_blanks' => ['a'] }
     end
+
+    context 'with other data structures' do
+      before do
+        subject.data = {
+          'a_hash_field' => { 'a' => 'b' }
+        }
+      end
+
+      its(:to_solr) { is_expected.to include 'a_hash_field' => ['b'] }
+    end
   end
 end


### PR DESCRIPTION
If you happen to have data structures in the sidecar (besides `configured_fields`), things break when you try to convert them to an indexable solr value.  