### PR TITLE
Prevent explicit require of class in the autoload paths

### DIFF
--- a/app/models/spotlight/page_content.rb
+++ b/app/models/spotlight/page_content.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spotlight/page_content/sir_trevor'
-
 module Spotlight
   # Factory for picking the right page content renderer
   module PageContent


### PR DESCRIPTION
In rails 7.1, this explicit load causes a LoadError from zeitwerk