### PR TITLE
Drop turbolinks dependency

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -40,7 +40,7 @@ jobs:
       RAILS_VERSION: ${{ matrix.rails_version }}
       BLACKLIGHT_VERSION: ${{ matrix.blacklight_version }}
       BOOTSTRAP_VERSION: ${{ matrix.bootstrap_version }}
-      ENGINE_CART_RAILS_OPTIONS: --skip-git --skip-listen --skip-spring --skip-keeps --skip-action-cable --skip-coffee --skip-test --skip-javascript
+      ENGINE_CART_RAILS_OPTIONS: --skip-git --skip-listen --skip-spring --skip-keeps --skip-action-cable --skip-coffee --skip-test
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby ${{ matrix.ruby }}

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -12,7 +12,6 @@ class TestAppGenerator < Rails::Generators::Base
   def add_gems
     gem 'blacklight', '~> 7.17' unless Bundler.locked_gems.dependencies.key? 'blacklight'
     gem 'blacklight-gallery', '~> 4.0' unless Bundler.locked_gems.dependencies.key? 'blacklight-gallery'
-    gem 'turbolinks', '~> 5'
 
     Bundler.with_clean_env do
       run 'bundle install'


### PR DESCRIPTION
It should work fine with turbo, which is the default in Rails now