### PR TITLE
Make it clear that Spotlight doesn't work with Rails 7.1

### DIFF
--- a/blacklight-spotlight.gemspec
+++ b/blacklight-spotlight.gemspec
@@ -48,7 +48,7 @@ these collections.)
   s.add_dependency 'openseadragon'
   s.add_dependency 'ostruct', '!= 0.3.0', '!= 0.3.1', '!= 0.3.2'
   s.add_dependency 'paper_trail', '>= 11.0', '< 16'
-  s.add_dependency 'rails', '>= 6.1', '< 8'
+  s.add_dependency 'rails', '>= 6.1', '< 7.1'
   s.add_dependency 'redcarpet', '>= 2.0.1', '< 4'
   s.add_dependency 'riiif', '~> 2.0'
   s.add_dependency 'roar', '~> 1.1'


### PR DESCRIPTION
Several people have been frustrated trying to install on Rails 7.1, so let's have bundler tell them it's not supported rather than figure it out with runtime errors.