### PR TITLE
Use latest version of bundler

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -43,7 +43,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true
-        bundler: '2.4.22'
+        bundler: 'latest'
         ruby-version: ${{ matrix.ruby }}
     - name: Run tests
       run: bundle exec rake


### PR DESCRIPTION
We were using a specific version of bundler to support ruby 2, but we have since stopped supporting ruby 2, so we can use the latest version