### PR TITLE
Remove missing callback action

### DIFF
--- a/app/controllers/spotlight/resources/upload_controller.rb
+++ b/app/controllers/spotlight/resources/upload_controller.rb
@@ -9,7 +9,7 @@ module Spotlight
       helper :all
 
       before_action :authenticate_user!
-      before_action :set_tab, only: %i[new create]
+      before_action :set_tab, only: %i[create]
 
       load_and_authorize_resource :exhibit, class: Spotlight::Exhibit
       before_action :build_resource


### PR DESCRIPTION
Raising for missing callback actions is a new default in Rails 7.1.

We have `only: [:create]` for this.