### PR TITLE
Remove unnecessary require

### DIFF
--- a/spec/models/spotlight/page_spec.rb
+++ b/spec/models/spotlight/page_spec.rb
@@ -69,8 +69,6 @@ describe Spotlight::Page, type: :model do
       end
 
       before do
-        # needed so we don't accidentally stub Spotlight::PageContent below
-        require 'spotlight/page_content'
         stub_const('Spotlight::PageContent::Static', fake_class)
       end
 


### PR DESCRIPTION
Rails 7.1 changes the autoloader behavior, and this require throws an error.

I don't think this require is needed any longer. Maybe in Rails 6.1 if using the classic autoloader?