### PR TITLE
Remove application.js after bundle in template

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -34,3 +34,10 @@ insert_into_file 'config/application.rb', after: "< Rails::Application\n" do
   config.active_job.queue_adapter = ENV["RAILS_QUEUE"]&.to_sym || :sidekiq
   CONFIG
 end
+
+after_bundle do
+  # Rails installed importmap by default, but we don't have importmap + Blacklight 7 working yet.
+  # Similar to step in Spotlight::Install#add_manifest, but this cleans up the file stimulus-rails
+  # creates afterward.
+  remove_file 'app/javascript/application.js'
+end


### PR DESCRIPTION
Fixes part of #3014. I believe the `manifest.js` issue is fixed, but unreleased, in blacklight-gallery so that would still require manually fixing that newline if testing this for real.

Moves the removal of `app/javascript/application.js` to the end of the end of the process. Steps that run after the install_generator, like stimulus-rails installing, recreate the file.

https://github.com/hotwired/stimulus-rails/blob/ae4b675473b71fdf01530c8a6a3bb277d3388ee2/lib/install/stimulus_with_importmap.rb#L11