### PR TITLE
Introducing GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/accessibility.md
+++ b/.github/ISSUE_TEMPLATE/accessibility.md
@@ -1,0 +1,21 @@
+---
+name: Accessibility bug
+about: Report an accessibility issue
+title: 'Accessibility: '
+labels: 'accessibility, bug'
+assignees: ''
+
+---
+
+### Issue Description - WCAG standard
+
+
+### Method of discovery
+Siteimprove, Wave, keyboard navigation, VoiceOver etc.
+
+
+### Steps to Reproduce
+
+
+### Suggested solution
+

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,17 @@
+---
+name: Bug
+about: Report a bug
+title: 'Bug: '
+labels: 'bug'
+assignees: ''
+
+---
+
+### Description
+
+
+### Steps to reproduce
+
+
+### Expected behavior
+

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -2,7 +2,7 @@
 name: Documentation
 about: Request new documentation or changes to existing documentation
 title: 'Documentation: '
-labels: 'documentation'
+labels: 'Documentation'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,11 @@
+---
+name: Documentation
+about: Request new documentation or changes to existing documentation
+title: 'Documentation: '
+labels: 'documentation'
+assignees: ''
+
+---
+
+### Description
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Request a new feature or enhancement
+title: 'Feature: '
+labels: 'Feature, enhancement'
+assignees: ''
+
+---
+
+### Problem being solved
+
+
+### Feature details
+
+
+### Acceptance criteria
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,8 +1,8 @@
 ---
 name: Feature request
-about: Request a new feature or enhancement
+about: Request a new feature
 title: 'Feature: '
-labels: 'Feature, enhancement'
+labels: 'Feature'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/maintenance.md
+++ b/.github/ISSUE_TEMPLATE/maintenance.md
@@ -1,0 +1,11 @@
+---
+name: Maintenance
+about: Report a maintenance task
+title: 'Maintenance: '
+labels: 'maintenance'
+assignees: ''
+
+---
+
+### Description
+


### PR DESCRIPTION
To help organize issues through the use of consistent labels as well as title prefix. 

The title prefix could be useful in email notifications.  If this is not preferred, I can take them out. 

5 templates are suggested in this PR, the labels are chosen from existing labels. 

Any changes and thoughts welcome. 