### PR TITLE
Generate + test with the requested blacklight version.

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -14,32 +14,13 @@ jobs:
         rails_version: ['7.0.8.4']
         ruby: ['3.1', '3.2']
         bootstrap_version: ['~> 4.0']
-        blacklight_version: ['latest']
+        blacklight_version: ['~> 7.34']
         additional_engine_cart_rails_options: ['']
         additional_name: ['']
         include:
           - rails_version: '6.1.7.8'
             ruby: '3.0'
-            blacklight_version: '7.33.1'
-            bootstrap_version: ~> 4.0
-          - rails_version: '7.0.8.4'
-            ruby: '3.1'
-            blacklight_version: '8.0.0'
-            bootstrap_version: ~> 4.0
-          - rails_version: '7.0.8.4'
-            ruby: '3.2'
-            blacklight_version: '8.0.0'
-            bootstrap_version: ~> 4.0
-            additional_engine_cart_rails_options: -a propshaft
-            additional_name: '/ Propshaft'
-          - rails_version: '7.0.8'
-            ruby: '3.3'
-            blacklight_version: 'latest'
-            bootstrap_version: ~> 4.0
-            additional_engine_cart_rails_options: -a propshaft
-          - rails_version: '7.1.3.4'
-            ruby: '3.2'
-            blacklight_version: '8.0.0'
+            blacklight_version: '7.34'
             bootstrap_version: ~> 4.0
     env:
       RAILS_VERSION: ${{ matrix.rails_version }}

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -10,7 +10,7 @@ class TestAppGenerator < Rails::Generators::Base
   end
 
   def add_gems
-    gem 'blacklight', '~> 7.17' unless Bundler.locked_gems.dependencies.key? 'blacklight'
+    gem 'blacklight', ENV['BLACKLIGHT_VERSION'] || '~> 7.17' unless Bundler.locked_gems.dependencies.key? 'blacklight'
     gem 'blacklight-gallery', '~> 4.0' unless Bundler.locked_gems.dependencies.key? 'blacklight-gallery'
 
     Bundler.with_unbundled_env do


### PR DESCRIPTION
We're not actually testing with Blacklight 8 now. Maybe https://github.com/projectblacklight/spotlight/issues/3047 will get us there, but until then we should remove the misleading builds.