### PR TITLE
Restore item thumbnails in admin view

### DIFF
--- a/app/views/spotlight/catalog/_index_compact_default.html.erb
+++ b/app/views/spotlight/catalog/_index_compact_default.html.erb
@@ -1,6 +1,6 @@
 <% # header bar for doc items in index view -%>
 <td>
-  <%= render_document_partial document, 'spotlight/catalog/admin_thumbnail', document_counter: document_counter %>
+  <%= render_document_partial document, 'admin_thumbnail', document_counter: document_counter %>
 </td>
 <td>
   <%= render_document_partial document, 'admin_index_header', document_counter: document_counter %>

--- a/spec/features/item_admin_spec.rb
+++ b/spec/features/item_admin_spec.rb
@@ -20,6 +20,7 @@ describe 'Item Administration', type: :feature do
       expect(page).to have_css('h1 small', text: 'Items')
       expect(page).to have_css('table#documents')
       expect(page).to have_css('.pagination')
+      expect(page).to have_css('.spotlight-admin-thumbnail')
 
       item = first('tr[itemscope]')
       expect(item).to have_link 'View'


### PR DESCRIPTION
Part of #2992

`render_document_partial` isn't able to find the `_admin_thumbnail_default.html.erb` partial with the full path specified.