### PR TITLE
Update CI configuration

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -39,6 +39,13 @@ jobs:
       ENGINE_CART_RAILS_OPTIONS: "--skip-git --skip-listen --skip-spring --skip-keeps --skip-coffee --skip-test ${{ matrix.additional_engine_cart_rails_options }}"
     steps:
       - uses: actions/checkout@v4
+      # Remove this Chrome step after https://issues.chromium.org/issues/351858989 is fixed
+      - name: Setup a specific version of Chrome
+        uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: 126
+          install-chromedriver: true
+          install-dependencies: true
       - name: Set up Ruby ${{ matrix.ruby }}
         uses: ruby/setup-ruby@v1
         with:
@@ -46,7 +53,7 @@ jobs:
           bundler: "latest"
           ruby-version: ${{ matrix.ruby }}
       - name: Change permissions
-        run: chmod -R o-w /opt/hostedtoolcache/Ruby/3.2.4/x64/lib/ruby/gems/3.2.0/gems
+        run: chmod -R o-w /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems
       - name: Install dependencies
         run: bundle install
       - name: Run tests


### PR DESCRIPTION
Ruby 3.2.5 was released, so bump our permissions change.

Chrome broke alert handling which causes some tests to fail.
https://issues.chromium.org/issues/351858989
Pin to a working version, 126, until they release a fix.