### PR TITLE
Use div instead of small for form-text

### DIFF
--- a/app/assets/stylesheets/spotlight/_bootstrap_overrides.scss
+++ b/app/assets/stylesheets/spotlight/_bootstrap_overrides.scss
@@ -89,11 +89,6 @@ legend {
   margin-bottom: $spacer;
 }
 
-small.form-text {
-  margin-bottom: $spacer;
-  margin-top: $spacer * 0.3125;
-}
-
 div.form-check + input[type="file"] {
   margin-top: $spacer;
 }

--- a/app/views/spotlight/contacts/_form.html.erb
+++ b/app/views/spotlight/contacts/_form.html.erb
@@ -14,9 +14,9 @@
       <div>
         <%= af.radio_button(:source, :remote, label: t(:'.source.remote.label')) %>
         <%= iiif_upload_tag(af) %>
-        <small class="form-text text-muted">
+        <div class="form-text text-muted mb-3">
           <%= t(:'.source.remote.help') %>
-        </small>
+        </div>
       </div>
 
       <%= iiif_cropper_tags af, initial_crop_selection: Spotlight::Engine.config.contact_square_size %>

--- a/app/views/spotlight/exhibits/_contact.html.erb
+++ b/app/views/spotlight/exhibits/_contact.html.erb
@@ -3,7 +3,7 @@
           <div class="col-md-8<%= ' has-error' if contact.object.errors[:email].present? %>">
             <%= text_field_tag "#{contact.object_name}[email]", contact.object.email, class: 'exhibit-contact form-control', id: "exhibit_contact_email_#{contact.index}", 'aria-label': t('.email_input_aria_label', index: contact.index + 1) %>
             <% if contact.object.errors[:email].present? %>
-              <small class="form-text text-muted"><%=contact.object.errors[:email].join(", ".html_safe) %></small>
+              <div class="form-text text-muted mb-3"><%=contact.object.errors[:email].join(", ".html_safe) %></div>
             <% end %>
             <p>
               <span class="contact-email-delete-error text-danger bg-danger" style="display: none;"><%= t('.email_delete_error') %> <span class="error-msg"></span></span>

--- a/app/views/spotlight/exhibits/_form.html.erb
+++ b/app/views/spotlight/exhibits/_form.html.erb
@@ -9,11 +9,11 @@
       <%= render partial: 'contact', locals: {exhibit: @exhibit, contact: contact} %>
     <% end %>
     <button id='another-email' class="btn btn-sm btn-info"><%= t('.add_contact_email_button') %></button>
-    <small class="form-text text-muted"><%= t(:'.fields.contact_emails.help_block') %></small>
+    <div class="form-text text-muted mb-3"><%= t(:'.fields.contact_emails.help_block') %></div>
   <% end %>
   <%= f.form_group :published, label: { text: nil, class: 'pt-0' }, help: nil do %>
     <%= f.check_box :published, label: "" %>
-    <small class="form-text text-muted"><%= t(:'.fields.published.help_block') %></small>
+    <div class="form-text text-muted mb-3"><%= t(:'.fields.published.help_block') %></div>
   <% end %>
 
   <div class="form-actions">

--- a/app/views/spotlight/featured_images/_form.html.erb
+++ b/app/views/spotlight/featured_images/_form.html.erb
@@ -18,15 +18,15 @@
           <div data-panel-image-pagination="true"></div>
         </div>
       </div>
-      <small class="form-text text-muted"><%= t(:'.source.exhibit.help') %></small>
+      <div class="form-text text-muted mb-3"><%= t(:'.source.exhibit.help') %></div>
     </div>
   </div>
   <div>
     <%= f.radio_button(:source, :remote, label: t(:'.source.remote.label')) %>
     <%= iiif_upload_tag(f) %>
-    <small class="form-text text-muted">
+    <div class="form-text text-muted mb-3">
       <%= t(:'.source.remote.help') %>
-    </small>
+    </div>
   </div>
 <% end %>
 <%= field_set_tag(t(:'.source.remote.header')) do %>

--- a/app/views/spotlight/featured_images/_upload_form.html.erb
+++ b/app/views/spotlight/featured_images/_upload_form.html.erb
@@ -6,9 +6,9 @@
   <div>
     <%= f.hidden_field(:source, value: :remote, label: t(:'.source.remote.label')) %>
     <%= iiif_upload_tag(f) %>
-    <small class="form-text text-muted">
+    <div class="form-text text-muted mb-3">
       <%= t(:'.source.remote.help') %>
-    </small>
+    </div>
   </div>
 <% end %>
 <%= field_set_tag(t(:'.source.remote.header')) do %>

--- a/app/views/spotlight/translations/_browse_categories.html.erb
+++ b/app/views/spotlight/translations/_browse_categories.html.erb
@@ -49,7 +49,7 @@
             <%= translation_fields.hidden_field :locale %>
             <div id="browse_category_subtitle_<%= search.id %>" class="card card-body collapse panel-translation">
               <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
-              <small class="form-text text-muted"><%= search[:subtitle] %></small>
+              <div class="form-text text-muted mb-3"><%= search[:subtitle] %></div>
             </div>
           <% end %>
         </div>
@@ -75,7 +75,7 @@
             <%= translation_fields.hidden_field :locale %>
             <div id="browse_category_description_<%= search.id %>" class="card card-body collapse panel-translation">
               <%= translation_fields.text_area_without_bootstrap :value, class: 'form-control' %>
-              <small class="form-text text-muted"><%= search[:long_description] %></small>
+              <div class="form-text text-muted mb-3"><%= search[:long_description] %></div>
             </div>
           <% end %>
         </div>

--- a/app/views/spotlight/translations/_general.html.erb
+++ b/app/views/spotlight/translations/_general.html.erb
@@ -16,9 +16,9 @@
           <%= translation_fields.label :value, t('.basic_settings.title'), class: 'col-form-label col-12 col-sm-2' %>
           <div class='col-11 col-sm-9 card card-body panel-translation'>
             <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
-            <small class="form-text text-muted">
+            <div class="form-text text-muted mb-3">
               <%= current_exhibit[:title] %>
-            </small>
+            </div>
           </div>
           <div class='col-1'>
             <% if translation.value.present? %>
@@ -37,9 +37,9 @@
           <%= translation_fields.label :value, t('.basic_settings.subtitle'), class: 'col-form-label col-12 col-sm-2' %>
           <div class='col-11 col-sm-9 card card-body panel-translation'>
             <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
-            <small class="form-text text-muted">
+            <div class="form-text text-muted mb-3">
               <%= current_exhibit[:subtitle] %>
-            </small>
+            </div>
           </div>
           <div class='col-1'>
             <% if translation.value.present? %>
@@ -58,9 +58,9 @@
           <%= translation_fields.label :value, t('.basic_settings.description'), class: 'col-form-label col-12 col-sm-2' %>
           <div class='col-11 col-sm-9 card card-body panel-translation'>
             <%= translation_fields.text_area_without_bootstrap :value, class: 'form-control' %>
-            <small class="form-text text-muted">
+            <div class="form-text text-muted mb-3">
               <%= current_exhibit.description %>
-            </small>
+            </div>
           </div>
           <div class='col-1'>
             <% if translation.value.present? %>
@@ -85,9 +85,9 @@
           <%= translation_fields.label :value, t('.main_menu.home'), class: 'col-form-label col-12 col-sm-2' %>
           <div class='col-11 col-sm-9 card card-body panel-translation'>
             <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
-            <small class="form-text text-muted">
+            <div class="form-text text-muted mb-3">
               <%= t(:'spotlight.curation.nav.home', locale: I18n.default_locale) %>
-            </small>
+            </div>
           </div>
           <div class='col-1'>
             <% if translation.value.present? %>
@@ -108,9 +108,9 @@
             <%= translation_fields.label :value, t(".main_menu.#{navigation.nav_type}", default: navigation.default_label), class: 'col-form-label col-12 col-sm-2' %>
             <div class='col-11 col-sm-9 card card-body panel-translation'>
               <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
-              <small class="form-text text-muted">
+              <div class="form-text text-muted mb-3">
                 <%= navigation[:label].presence || navigation.default_label %>
-              </small>
+              </div>
             </div>
             <div class='col-1'>
               <% if translation.value.present? %>
@@ -131,9 +131,9 @@
           <%= translation_fields.label :value, t('spotlight.catalog.breadcrumb.index'), class: 'col-form-label col-12 col-sm-2' %>
           <div class='col-11 col-sm-9 card card-body panel-translation'>
             <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
-            <small class="form-text text-muted">
+            <div class="form-text text-muted mb-3">
               <%= t(:'spotlight.catalog.breadcrumb.index', locale: I18n.default_locale) %>
-            </small>
+            </div>
           </div>
           <div class='col-1'>
             <% if translation.value.present? %>

--- a/app/views/spotlight/translations/_metadata.html.erb
+++ b/app/views/spotlight/translations/_metadata.html.erb
@@ -14,9 +14,9 @@
           <%= translation_fields.label :value, t("spotlight.search.fields.#{key}", default: field_config.label, locale: I18n.default_locale), class: 'col-form-label col-12 col-sm-2' %>
           <div class='col-11 col-sm-9 card card-body panel-translation'>
             <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
-            <small class="form-text text-muted">
+            <div class="form-text text-muted mb-3">
               <%= field_config.label %>
-            </small>
+            </div>
           </div>
           <div class='col-1'>
             <% if translation.value.present? %>
@@ -45,9 +45,9 @@
               <%= translation_fields.label :value, t("spotlight.search.fields.#{custom_field.field}", default: custom_field.configuration['label'], locale: I18n.default_locale), class: 'col-form-label col-12 col-sm-2' %>
               <div class='col-11 col-sm-9 card card-body panel-translation'>
                 <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
-                <small class="form-text text-muted">
+                <div class="form-text text-muted mb-3">
                   <%= custom_field.configuration['label'] %>
-                </small>
+                </div>
               </div>
               <div class='col-1'>
                 <% if translation.value.present? %>

--- a/app/views/spotlight/translations/_search_fields.html.erb
+++ b/app/views/spotlight/translations/_search_fields.html.erb
@@ -18,9 +18,9 @@
             <%= translation_fields.label :value, t("spotlight.search.fields.search.#{key}", locale: I18n.default_locale), class: 'col-form-label col-12 col-sm-2' %>
             <div class='col-11 col-sm-9 card card-body panel-translation'>
               <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
-              <small class="form-text text-muted">
+              <div class="form-text text-muted mb-3">
                 <%= search_config.label %>
-              </small>
+              </div>
             </div>
             <div class='col-1'>
               <% if translation.value.present? %>
@@ -48,9 +48,9 @@
             <%= translation_fields.label :value, t("spotlight.search.fields.facet.#{key}", locale: I18n.default_locale), class: 'col-form-label col-12 col-sm-2' %>
             <div class='col-11 col-sm-9 card card-body panel-translation'>
               <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
-              <small class="form-text text-muted">
+              <div class="form-text text-muted mb-3">
                 <%= facet_config.label %>
-              </small>
+              </div>
             </div>
             <div class='col-1'>
               <% if translation.value.present? %>
@@ -78,9 +78,9 @@
             <%= translation_fields.label :value, t("spotlight.search.fields.sort.#{key}", locale: I18n.default_locale), class: 'col-form-label col-12 col-sm-2' %>
             <div class='col-11 col-sm-9 card card-body panel-translation'>
               <%= translation_fields.text_field_without_bootstrap :value, class: 'form-control' %>
-              <small class="form-text text-muted">
+              <div class="form-text text-muted mb-3">
                 <%= sort_config.label %>
-              </small>
+              </div>
             </div>
             <div class='col-1'>
               <% if translation.value.present? %>


### PR DESCRIPTION
Fixes: #3089
Fixes: #3086
Fixes: #3085

Fix does not change the BS4 display.

Before:
<img width="788" alt="Screenshot 2024-08-19 at 5 42 06 PM" src="https://github.com/user-attachments/assets/7522ddb0-b25e-4a50-bac9-fa28320c485d">

After:
<img width="878" alt="Screenshot 2024-08-19 at 5 41 47 PM" src="https://github.com/user-attachments/assets/166fb173-71c6-4411-8f53-20b79d381f00">
