### PR TITLE
Fix translation export button layout for BS5

### DIFF
--- a/app/assets/stylesheets/spotlight/_translations.scss
+++ b/app/assets/stylesheets/spotlight/_translations.scss
@@ -78,9 +78,3 @@
   margin-top: $spacer;
   padding-bottom: 3px;
 }
-
-.translation-import-export-label {
-  @media (min-width: 576px) {
-    text-align: right;
-  }
-}

--- a/app/views/spotlight/translations/_import.html.erb
+++ b/app/views/spotlight/translations/_import.html.erb
@@ -1,24 +1,37 @@
 <% if can? :import_translations, Spotlight::Exhibit %>
-  <div class="row col-md-12 mb-5">
-    <h2><%= t(:'.header') %></h2>
-    <p class="instructions"><%= t(:'.description') %></p>
-
-    <%= bootstrap_form_for current_exhibit, url: spotlight.import_exhibit_translations_path(current_exhibit), html: { class: 'row col-md-12 align-items-center clearfix mb-3', multipart: true } do |f| %>
-      <%= f.label :value, t(".import_label"), class: 'col-form-label col-12 col-sm-3 pl-0 translation-import-export-label' %>
-
-      <div class="input-group col px-0">
-        <%= file_field_tag :file, class: 'form-control' %>
-        <%= hidden_field_tag :tab, 'import', id: nil %>
-        <div class="input-group-append">
-          <%= f.submit t(:'.import_submit'), class: 'btn btn-primary' %>
+  <div class="row">
+    <div class="col-md-12 mb-5">
+      <h2><%= t(:'.header') %></h2>
+      <p class="instructions"><%= t(:'.description') %></p>
+      <%= bootstrap_form_for current_exhibit, url: spotlight.import_exhibit_translations_path(current_exhibit), html: { class: 'mb-3', multipart: true } do |f| %>
+        <div class="container-fluid">
+          <div class="row">
+            <div class="col-12 col-md-3 text-md-right text-md-end">
+              <%= f.label :value, t(".import_label"), class: 'col-form-label' %>
+            </div>
+            <div class="col-12 col-md-9">
+              <div class="input-group">
+                <%= file_field_tag :file, class: 'form-control' %>
+                <%= hidden_field_tag :tab, 'import', id: nil %>
+                <div class="input-group-append">
+                  <%= f.submit t(:'.import_submit'), class: 'btn btn-primary' %>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      <% end %>
+      <div class="container-fluid">
+        <div class="row">
+          <div class="col-form-label col-12 col-md-3 text-md-right text-md-end">
+            <%= content_tag :span, t(".export_label") %>
+          </div>
+          <div class="col-12 col-md-9">
+            <%= link_to t(:'.export_current_locale', language: t(:"locales.#{@language}")), spotlight.exhibit_translations_path(current_exhibit, format: "yaml", locale: @language), class: 'btn btn-primary mr-3 me-3' %>
+            <%= link_to t(:'.export_default_locale', language: t(:"locales.#{I18n.default_locale}")), spotlight.exhibit_translations_path(current_exhibit, format: "yaml", locale: I18n.default_locale), class: 'btn btn-primary' %>
+          </div>
         </div>
       </div>
-    <% end %>
-    <div class="row col-md-12 align-items-center">
-      <%= content_tag :span, t(".export_label"), class: 'col-form-label col-12 col-sm-3 pl-0 ps-3 translation-import-export-label' %>
-
-      <%= link_to t(:'.export_current_locale', language: t(:"locales.#{@language}")), spotlight.exhibit_translations_path(current_exhibit, format: "yaml", locale: @language), class: 'btn btn-primary w-auto mr-3 me-3' %>
-      <%= link_to t(:'.export_default_locale', language: t(:"locales.#{I18n.default_locale}")), spotlight.exhibit_translations_path(current_exhibit, format: "yaml", locale: I18n.default_locale), class: 'btn btn-primary w-auto' %>
     </div>
   </div>
 <% end %>

--- a/app/views/spotlight/translations/_import.html.erb
+++ b/app/views/spotlight/translations/_import.html.erb
@@ -17,8 +17,8 @@
     <div class="row col-md-12 align-items-center">
       <%= content_tag :span, t(".export_label"), class: 'col-form-label col-12 col-sm-3 pl-0 ps-3 translation-import-export-label' %>
 
-      <%= link_to t(:'.export_current_locale', language: t(:"locales.#{@language}")), spotlight.exhibit_translations_path(current_exhibit, format: "yaml", locale: @language), class: 'btn btn-primary mr-3 me-3' %>
-      <%= link_to t(:'.export_default_locale', language: t(:"locales.#{I18n.default_locale}")), spotlight.exhibit_translations_path(current_exhibit, format: "yaml", locale: I18n.default_locale), class: 'btn btn-primary' %>
+      <%= link_to t(:'.export_current_locale', language: t(:"locales.#{@language}")), spotlight.exhibit_translations_path(current_exhibit, format: "yaml", locale: @language), class: 'btn btn-primary w-auto mr-3 me-3' %>
+      <%= link_to t(:'.export_default_locale', language: t(:"locales.#{I18n.default_locale}")), spotlight.exhibit_translations_path(current_exhibit, format: "yaml", locale: I18n.default_locale), class: 'btn btn-primary w-auto' %>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
Before:
<img width="871" alt="Screenshot 2024-08-20 at 7 59 15 AM" src="https://github.com/user-attachments/assets/52b5d4c1-42b9-4859-8132-2adcf85a96a5">

After:
<img width="957" alt="Screenshot 2024-08-20 at 9 05 09 AM" src="https://github.com/user-attachments/assets/b2ecf019-4611-43f1-98f0-1ffca9ab2c06">

No impact to Bootstrap 4 layout