### PR TITLE
Fix Upload CSV form layout for BS5

### DIFF
--- a/app/views/spotlight/bulk_updates/_upload.html.erb
+++ b/app/views/spotlight/bulk_updates/_upload.html.erb
@@ -1,12 +1,22 @@
-<p class="instructions"><%= t('.instructions') %></p>
+<p class="instructions mb-4"><%= t('.instructions') %></p>
 
-<%= bootstrap_form_with(url: exhibit_bulk_updates_path, method: :patch, multipart: true, layout: :inline) do |f| %>
-  <%= f.label :file, t('.file_label'), class: 'col-form-label col-md-3' %>
-  <%= file_field_tag :file, class: 'form-control', accept: '.csv,text/csv', 'aria-described-by': 'bulk-update-form-help' %>
-  <%= f.submit t('.submit'), class: 'btn btn-primary ml-2 ms-2' %>
+<%= bootstrap_form_with(url: exhibit_bulk_updates_path, method: :patch, html: { multipart: true }) do |f| %>
+  <div class="row">
+    <div class="col-12 col-md-3 text-md-right text-md-end">
+      <%= f.label :file, t('.file_label'), class: 'col-form-label' %>
+    </div>
+    <div class="col-12 col-md-9">
+      <div class="input-group">
+        <%= file_field_tag :file, class: 'form-control', accept: '.csv,text/csv', 'aria-described-by': 'bulk-update-form-help' %>
+        <div class="input-group-append">
+          <%= f.submit t('.submit'), class: 'btn btn-primary' %>
+        </div>
+      </div>
+    </div>
+  </div>
 <% end %>
 <div class="row">
   <div class="offset-md-3">
-    <p id="bulk-update-form-help" class="form-text text-muted ml-2 ms-2"><%= t('.form_help') %></p>
+    <p id="bulk-update-form-help" class="form-text text-muted ml-3"><%= t('.form_help') %></p>
   </div>
 </div>


### PR DESCRIPTION
Fixes #3088 

Before:
<img width="782" alt="bulk-upload-csv-bs5" src="https://github.com/user-attachments/assets/1b78040c-6008-405b-9d0d-a0073f8309e7">

After:
<img width="884" alt="Screenshot 2024-08-21 at 8 34 00 AM" src="https://github.com/user-attachments/assets/d2dc2fae-7abf-41c8-9fe4-6143aba29743">
