### PR TITLE
Add mb-3 to bulk download form group labels to even out spacing for BS5

### DIFF
--- a/app/views/spotlight/bulk_updates/_download.html.erb
+++ b/app/views/spotlight/bulk_updates/_download.html.erb
@@ -3,13 +3,13 @@
 <%= bootstrap_form_with(url: download_template_exhibit_bulk_updates_path, local: true, target: '_blank') do |f| %>
   <div class="row">
     <div class="col col-sm-3">
-      <%= f.form_group(:reference_fields, label: { text: t('.reference_fields.heading'), class: 'font-weight-bold fw-bold' }) do %>
+      <%= f.form_group(:reference_fields, label: { text: t('.reference_fields.heading'), class: 'font-weight-bold fw-bold mb-3' }) do %>
         <%= f.check_box('reference_fields[item_id]', label: t('.item_id'), checked: true, disabled: true) %>
         <%= f.check_box('reference_fields[item_title]', label: t('.item_title')) %>
       <% end %>
     </div>
     <div class="col col-sm-3">
-      <%= f.form_group(:updatable_fields, label: { text: t('.updatable_fields.heading'), class: 'font-weight-bold fw-bold' }) do %>
+      <%= f.form_group(:updatable_fields, label: { text: t('.updatable_fields.heading'), class: 'font-weight-bold fw-bold mb-3' }) do %>
         <%= f.check_box('updatable_fields[visibility]', checked: true, label: t('.visibility')) %>
         <%= f.check_box('updatable_fields[tags]', label: t('.tags')) %>
       <% end %>


### PR DESCRIPTION
Fixes #3087 

Before:
<img width="795" alt="bulk-download-csv-bs5" src="https://github.com/user-attachments/assets/820356ef-00c8-4ae7-800c-0041d49aec72">

After:
<img width="968" alt="Screenshot 2024-08-21 at 9 48 28 AM" src="https://github.com/user-attachments/assets/6bc077d6-e9b9-4416-b3da-9b628830eb76">
