### PR TITLE
Fix search results configuration layout for BS5

### DIFF
--- a/app/views/spotlight/search_configurations/_default_per_page.html.erb
+++ b/app/views/spotlight/search_configurations/_default_per_page.html.erb
@@ -1,4 +1,4 @@
-<%= f.form_group :default_per_page, label: { text: t(:'.label'), class: 'pt-0'} do %>
+<%= f.form_group :default_per_page, label: { text: t(:'.label'), class: 'pt-0 col-md-3 text-md-right text-md-end' } do %>
   <% @blacklight_configuration.default_blacklight_config.per_page.each do |key| %>
     <%= f.radio_button :default_per_page, key, label: key.to_s %>
   <% end %>

--- a/app/views/spotlight/search_configurations/_document_index_view_types.html.erb
+++ b/app/views/spotlight/search_configurations/_document_index_view_types.html.erb
@@ -1,7 +1,12 @@
-<%= f.form_group :document_index_view_types, label: {text: t(:'.label'), class: 'pt-0'} do %>
+<%= f.form_group :document_index_view_types, label: { text: t(:'.label'), class: 'pt-0 col-md-3 text-md-right text-md-end' } do %>
   <%= f.fields_for :document_index_view_types, @blacklight_configuration.document_index_view_types_selected_hash do |vt| %>
     <% @blacklight_configuration.default_blacklight_config.view.select { |_k, v| v.if != false }.each do |key, view| %>
-      <%= vt.check_box key, label: view.display_label %>
+      <div class="row">
+        <div class="col">
+          <%= vt.check_box_without_bootstrap key %>
+          <%= vt.label key, label: view.display_label %>
+        </div>
+      </div>
     <% end %>
   <% end %>
 <% end %>


### PR DESCRIPTION
Fixes #3090 

Before:
<img width="746" alt="search-results-bs5" src="https://github.com/user-attachments/assets/e6182cb7-0185-4ab9-a87d-44f183e048e5">

After:
<img width="749" alt="Screenshot 2024-08-21 at 11 11 54 AM" src="https://github.com/user-attachments/assets/713dc636-25e2-4e1c-b55a-b922743d15da">
