### PR TITLE
Set col-md-9 on bulk upload help div

### DIFF
--- a/app/views/spotlight/bulk_updates/_upload.html.erb
+++ b/app/views/spotlight/bulk_updates/_upload.html.erb
@@ -16,7 +16,7 @@
   </div>
 <% end %>
 <div class="row">
-  <div class="offset-md-3">
+  <div class="col-12 col-md-9 offset-md-3">
     <p id="bulk-update-form-help" class="form-text text-muted ml-3"><%= t('.form_help') %></p>
   </div>
 </div>


### PR DESCRIPTION
With `offset-md-3` set on the help `div` without `col-md-9` it was breaking out of the main container.

Before:
<img width="764" alt="Screenshot 2024-08-21 at 12 59 57 PM" src="https://github.com/user-attachments/assets/35e03d55-6d61-4afe-95e1-7ccb0d565774">

After:
<img width="754" alt="Screenshot 2024-08-21 at 12 59 33 PM" src="https://github.com/user-attachments/assets/920ea36d-1d59-4fda-9b92-9b09bfc9e6a8">
