### PR TITLE
Fix Sir Trevor Bootstrap 5 carousel blocks

### DIFF
--- a/app/models/sir_trevor_rails/blocks/solr_documents_carousel_block.rb
+++ b/app/models/sir_trevor_rails/blocks/solr_documents_carousel_block.rb
@@ -9,9 +9,12 @@ module SirTrevorRails
         send(:'max-height')
       end
 
+      def autoplay?
+        send(:'auto-play-images') == 'true'
+      end
+
       def interval
-        val = send(:'auto-play-images')
-        if val == 'true'
+        if autoplay?
           send(:'auto-play-images-interval')
         else
           false

--- a/app/views/spotlight/sir_trevor/blocks/_solr_documents_carousel_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_solr_documents_carousel_block.html.erb
@@ -3,7 +3,7 @@
 <% html_id = "carousel-#{solr_documents_carousel_block.object_id}" %>
 <div class="content-block carousel-block carousel-height-<%= solr_documents_carousel_block.max_height %>">
 <% if solr_documents_carousel_block.documents? %>
-  <div id="<%= html_id %>" class="carousel slide" data-ride="carousel" data-bs-ride="carousel" data-interval="<%= solr_documents_carousel_block.interval %>" data-bs-interval="<%= solr_documents_carousel_block.interval %>">
+  <div id="<%= html_id %>" class="carousel slide" data-ride="carousel" data-interval="<%= solr_documents_carousel_block.interval %>" <%= "data-bs-ride=carousel data-bs-interval=#{solr_documents_carousel_block.interval}" if solr_documents_carousel_block.autoplay? %>>
     <div class="carousel-inner text-center">
     <% solr_documents_carousel_block.each_document.each_with_index do |(block_options, document), index| %>
       <% doc_presenter = document_presenter(document) %>

--- a/app/views/spotlight/sir_trevor/blocks/_solr_documents_features_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_solr_documents_features_block.html.erb
@@ -4,7 +4,7 @@
 
 <div class="content-block carousel-block item-features">
   <% if solr_documents_features_block.documents? %>
-    <div id="<%= html_id %>" class="carousel" data-ride="carousel" data-bs-ride="carousel" data-interval="false" data-bs-interval="false">
+    <div id="<%= html_id %>" class="carousel" data-ride="carousel" data-interval="false">
       <div class="row">
         <div class="col-sm-6">
           <div class="carousel-inner">


### PR DESCRIPTION
'false' is no longer a valid value for interval in BS5 carousels (https://getbootstrap.com/docs/5.2/components/carousel/#options). If interval is set to false, the carousel goes crazy mode (Warning: rapid flashing):

https://github.com/user-attachments/assets/14c8eb02-57b1-461b-a847-d9d907ef2253

For the static carousel we can omit ride and interval because a static carousel is the default in BS5.