### PR TITLE
Add margin to right/end of page publish checkbox

### DIFF
--- a/app/views/spotlight/shared/_dd3_item.html.erb
+++ b/app/views/spotlight/shared/_dd3_item.html.erb
@@ -22,7 +22,7 @@
           <div class="flex-grow-1 align-self-center">
             <h3 class="h6 card-title mb-0">
               <%= field.hidden_field :weight, value: index, 'data-property' => 'weight' %>
-              <%= field.check_box_without_bootstrap enabled_method, checked: field.object.public_send(enabled_method), hide_label: true, title: label %>
+              <%= field.check_box_without_bootstrap enabled_method, class: 'mr-3 me-3', checked: field.object.public_send(enabled_method), hide_label: true, title: label %>
               <span class="d-inline-block w-75" data-in-place-edit-target=".edit-in-place" data-in-place-edit-field-target="[data-edit-field-target='true']">
                 <a href="#edit-in-place" class="field-label edit-in-place"><%= label %></a>
                 <%= field.hidden_field label_method, value: label, class: 'form-control form-control-sm title-field', data: {:"edit-field-target" => 'true', default_value: default_value } %>


### PR DESCRIPTION
This fixes a layout regression from adding BS5 support

Before:
<img width="867" alt="Screenshot 2024-08-28 at 10 28 08 AM" src="https://github.com/user-attachments/assets/d15463c5-8777-441f-a8cd-0052903d89b9">


After:
<img width="871" alt="Screenshot 2024-08-28 at 10 27 51 AM" src="https://github.com/user-attachments/assets/7a7a1906-de77-4ba3-b11b-335c624b79dc">
