### PR TITLE
Allow acts-as-taggable 11 and Rails < 8

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -38,6 +38,11 @@ jobs:
             blacklight_version: ~> 7.34
             bootstrap_version: ~> 4.0
             additional_name: Ruby 3.1
+          - rails_version: "~> 7.2"
+            ruby: "3.2"
+            blacklight_version: "~> 7.34"
+            bootstrap_version: ~> 4.0
+            additional_name: Rails 7.2
     env:
       RAILS_VERSION: ${{ matrix.rails_version }}
       BLACKLIGHT_VERSION: ${{ matrix.blacklight_version }}

--- a/blacklight-spotlight.gemspec
+++ b/blacklight-spotlight.gemspec
@@ -21,7 +21,7 @@ these collections.)
   s.required_ruby_version = '>= 2.6'
 
   s.add_dependency 'activejob-status'
-  s.add_dependency 'acts-as-taggable-on', '>= 5.0', '< 11'
+  s.add_dependency 'acts-as-taggable-on', '>= 5.0', '< 12'
   s.add_dependency 'autoprefixer-rails'
   s.add_dependency 'blacklight', '>= 7.18', '< 9'
   s.add_dependency 'blacklight-gallery', '>= 3.0', '< 5'
@@ -48,7 +48,7 @@ these collections.)
   s.add_dependency 'openseadragon'
   s.add_dependency 'ostruct', '!= 0.3.0', '!= 0.3.1', '!= 0.3.2'
   s.add_dependency 'paper_trail', '>= 11.0', '< 16'
-  s.add_dependency 'rails', '>= 6.1', '< 7.2'
+  s.add_dependency 'rails', '>= 6.1', '< 8'
   s.add_dependency 'redcarpet', '>= 2.0.1', '< 4'
   s.add_dependency 'riiif', '~> 2.0'
   s.add_dependency 'roar', '~> 1.1'

--- a/spec/jobs/spotlight/reindex_job_spec.rb
+++ b/spec/jobs/spotlight/reindex_job_spec.rb
@@ -32,7 +32,10 @@ describe Spotlight::ReindexJob do
     before do
       allow(described_class).to receive(:validity_checker).and_return(mock_checker)
       allow(mock_checker).to receive(:mint).with(anything).and_return('xyz')
+      ActiveJob::Base.queue_adapter = :test
     end
+
+    after { ActiveJob::Base.queue_adapter = :inline }
 
     it 'mints a new validity token' do
       expect { described_class.perform_later(resource) }.to have_enqueued_job(described_class).with(resource, 'validity_token' => 'xyz')


### PR DESCRIPTION
`acts-as-taggable` 11 is released and supports ActiveRecord versions `< 8`. This will let us update spotlight apps to Rails 7.2

We need a new release of riiif too with these changes: https://github.com/sul-dlss/riiif/pull/146 I think.