### PR TITLE
Pass the tile_source_field to blacklight-gallery

### DIFF
--- a/app/models/spotlight/blacklight_configuration.rb
+++ b/app/models/spotlight/blacklight_configuration.rb
@@ -121,8 +121,12 @@ module Spotlight
         config.default_per_page = default_per_page if default_per_page
 
         config.view.embed!
+        # This is blacklight-gallery's openseadragon partial
         config.view.embed.partials ||= ['openseadragon']
         config.view.embed.if = false
+
+        # blacklight-gallery requires tile_source_field
+        config.view.embed.tile_source_field ||= config.show.tile_source_field
         config.view.embed.locals ||= { osd_container_class: '' }
 
         # Add any custom fields

--- a/app/views/spotlight/sir_trevor/blocks/_solr_documents_embed_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_solr_documents_embed_block.html.erb
@@ -11,12 +11,15 @@
         <% end %>
       <% end %>
       <div class="spotlight-flexbox">
+      <%# Render the openseadragon viewer from blacklight-gallery.
+        # Settings in blacklight_configuration.rb %>
         <% solr_documents_embed_block.each_document do |block_options, document| %>
           <div class="box" data-id="<%= document.id %>">
-            <%= render_document_partials document, blacklight_config.view.embed.partials, (blacklight_config.view.embed.locals || {}).reverse_merge(block: solr_documents_embed_block) %>
+            <% view_config = blacklight_config.view_config(:embed) %>
+            <%= render_document_partials document, view_config.partials, (view_config.locals || {}).reverse_merge(block: solr_documents_embed_block, view_config: view_config) %>
           </div>
-        <% end %>
-      </div>
+          <% end %>
+        </div>
     </div>
   <% end %>
 

--- a/spec/features/javascript/blocks/solr_documents_embed_block_spec.rb
+++ b/spec/features/javascript/blocks/solr_documents_embed_block_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+describe 'Solr Documents Embed Block', js: true, type: :feature do
+  let(:exhibit) { FactoryBot.create(:exhibit) }
+  let(:exhibit_curator) { FactoryBot.create(:exhibit_curator, exhibit: exhibit) }
+
+  let!(:feature_page) { FactoryBot.create(:feature_page, exhibit: exhibit) }
+
+  before do
+    login_as exhibit_curator
+
+    visit spotlight.edit_exhibit_feature_page_path(exhibit, feature_page)
+    add_widget 'solr_documents_embed'
+  end
+
+  it 'allows you to add a solr documents embed block widget', js: true do
+    fill_in_solr_document_block_typeahead_field with: 'dq287tq6352'
+
+    save_page_changes
+
+    expect(page).to have_css('.openseadragon-container')
+    expect(page).to have_css('picture')
+    within('picture') do
+      expect(html).to have_css('source[media="openseadragon"][src="https://stacks.stanford.edu/image/iiif/dq287tq6352%2Fdq287tq6352_05_0001/info.json"]')
+    end
+  end
+end

--- a/spec/test_app_templates/catalog_controller.rb
+++ b/spec/test_app_templates/catalog_controller.rb
@@ -35,9 +35,6 @@ class CatalogController < ApplicationController
     config.index.display_type_field = 'content_metadata_type_ssm'
     config.index.thumbnail_field = Spotlight::Engine.config.thumbnail_field
 
-    # config.show.document_component = Spotlight::DocumentComponent
-    config.show.tile_source_field = :content_metadata_image_iiif_info_ssm
-
     config.add_results_collection_tool(:sort_widget)
     config.add_results_collection_tool(:per_page_widget)
     config.add_results_collection_tool(:view_type_group)


### PR DESCRIPTION
Blocked by https://github.com/projectblacklight/blacklight-gallery/pull/151

Closes ##3111

We now see the viewer: 
<img width="928" alt="Screenshot 2024-09-11 at 13 47 48" src="https://github.com/user-attachments/assets/a4671119-0037-4c39-b708-4d341aa353ef">
