### PR TITLE
Rename test helper save_page to save_page_changes

### DIFF
--- a/spec/features/javascript/blocks/browse_group_categories_block_spec.rb
+++ b/spec/features/javascript/blocks/browse_group_categories_block_spec.rb
@@ -28,7 +28,7 @@ describe 'Browse Group Categories', js: true, type: :feature do
       expect(page).to have_css '.title', text: 'Pets'
     end
 
-    save_page
+    save_page_changes
 
     expect(page).to have_css 'h2', text: 'Pets'
   end
@@ -39,7 +39,7 @@ describe 'Browse Group Categories', js: true, type: :feature do
       expect(page).to have_css '.title', text: 'Pets'
     end
 
-    save_page
+    save_page_changes
 
     expect(page).to have_css 'h2', text: 'Pets'
 
@@ -56,7 +56,7 @@ describe 'Browse Group Categories', js: true, type: :feature do
       expect(page).to have_css '.title', text: 'Pets'
     end
 
-    save_page
+    save_page_changes
 
     expect(page).to have_css 'h2', text: 'Pets'
     expect(page).to have_css '.box.category-1', count: 6, visible: false

--- a/spec/features/javascript/blocks/featured_browse_categories_block_spec.rb
+++ b/spec/features/javascript/blocks/featured_browse_categories_block_spec.rb
@@ -27,7 +27,7 @@ describe 'Featured Browse Category Block', js: true, type: :feature do
 
     fill_in_typeahead_field with: 'Title2'
 
-    save_page
+    save_page_changes
 
     # Documents should exist
     expect(page).to have_no_css('.category-title', text: search1.title)
@@ -39,7 +39,7 @@ describe 'Featured Browse Category Block', js: true, type: :feature do
     pending('Prefetched autocomplete does not work the same way as solr-backed autocompletes')
     uncheck 'Include item counts?'
     fill_in_typeahead_field with: 'Title1'
-    save_page
+    save_page_changes
 
     expect(page).to have_no_css('.item-count', text: /\d+ items/i)
   end

--- a/spec/features/javascript/blocks/featured_pages_block_spec.rb
+++ b/spec/features/javascript/blocks/featured_pages_block_spec.rb
@@ -35,7 +35,7 @@ describe 'Featured Pages Blocks', js: true, type: :feature do
 
     fill_in_typeahead_field with: feature_page2.title
 
-    save_page
+    save_page_changes
 
     expect(page).to have_content feature_page2.title
   end
@@ -51,7 +51,7 @@ describe 'Featured Pages Blocks', js: true, type: :feature do
     fill_in_typeahead_field with: feature_page1.title
     fill_in_typeahead_field with: feature_page2.title
 
-    save_page
+    save_page_changes
 
     feature_page1_position = page.body =~ /<p class="category-title">\s+#{feature_page1.title}/
     feature_page2_position = page.body =~ /<p class="category-title">\s+#{feature_page2.title}/

--- a/spec/features/javascript/blocks/link_to_search_block_spec.rb
+++ b/spec/features/javascript/blocks/link_to_search_block_spec.rb
@@ -27,7 +27,7 @@ describe 'Link to Search Block', js: true, type: :feature do
 
     fill_in_typeahead_field with: 'Title2'
 
-    save_page
+    save_page_changes
 
     # Documents should exist
     expect(page).to have_no_css('.category-title', text: search1.title)
@@ -39,7 +39,7 @@ describe 'Link to Search Block', js: true, type: :feature do
     pending('Prefetched autocomplete does not work the same way as solr-backed autocompletes')
     uncheck 'Include item counts?'
     fill_in_typeahead_field with: 'Title1'
-    save_page
+    save_page_changes
 
     expect(page).to have_no_css('.item-count', text: /\d+ items/i)
   end

--- a/spec/features/javascript/blocks/rule_block_spec.rb
+++ b/spec/features/javascript/blocks/rule_block_spec.rb
@@ -16,7 +16,7 @@ describe 'Horizontal rule block', js: true, type: :feature, versioning: true do
 
     add_widget 'rule'
 
-    save_page
+    save_page_changes
 
     expect(page).to have_css('hr')
   end

--- a/spec/features/javascript/blocks/search_result_block_spec.rb
+++ b/spec/features/javascript/blocks/search_result_block_spec.rb
@@ -28,7 +28,7 @@ describe 'Search Result Block', js: true, type: :feature do
     check 'Gallery'
     check 'Slideshow'
 
-    save_page
+    save_page_changes
 
     expect(page).to have_no_content 'per page'
     expect(page).to have_no_content 'Sort by'

--- a/spec/features/javascript/blocks/solr_documents_block_spec.rb
+++ b/spec/features/javascript/blocks/solr_documents_block_spec.rb
@@ -33,7 +33,7 @@ describe 'Solr Document Block', default_max_wait_time: 15, feature: true, versio
       expect(page).to have_content "L'AMERIQUE"
     end
 
-    save_page
+    save_page_changes
 
     # verify that the item + image widget is displaying an image from the document.
     within(:css, '.items-block', visible: true) do
@@ -47,7 +47,7 @@ describe 'Solr Document Block', default_max_wait_time: 15, feature: true, versio
     fill_in_solr_document_block_typeahead_field with: 'gk446cj2442'
     expect(page).to have_selector '.panels li', count: 2, visible: true
 
-    save_page
+    save_page_changes
 
     expect(page).to have_selector '.items-block .box', count: 2, visible: true
   end
@@ -62,7 +62,7 @@ describe 'Solr Document Block', default_max_wait_time: 15, feature: true, versio
     find('.thumbs-list li[data-index="1"]').click
     expect(page).to have_css('[data-panel-image-pagination]', text: /Image 2 of 2/, visible: true)
 
-    save_page
+    save_page_changes
 
     # The thumbnail on the rendered block should be correct
     thumb = find('.img-thumbnail')
@@ -76,7 +76,7 @@ describe 'Solr Document Block', default_max_wait_time: 15, feature: true, versio
     thumb = find('.pic .img-thumbnail')
     expect(thumb['src']).to match(%r{xd327cm9378_05_0002/full})
 
-    save_page
+    save_page_changes
 
     # Expect that the original image selection was retained
     thumb = find('.img-thumbnail')
@@ -104,7 +104,7 @@ describe 'Solr Document Block', default_max_wait_time: 15, feature: true, versio
       select('Title', from: 'primary-caption-field')
     end
 
-    save_page
+    save_page_changes
 
     expect(page).to have_selector '.items-block .box', count: 1, visible: true
     expect(page).to have_content '[World map]'
@@ -116,7 +116,7 @@ describe 'Solr Document Block', default_max_wait_time: 15, feature: true, versio
       uncheck('Primary caption')
     end
 
-    save_page
+    save_page_changes
 
     expect(page).to have_selector '.items-block .box', count: 1, visible: true
     expect(page).to have_no_content '[World map]'
@@ -136,7 +136,7 @@ describe 'Solr Document Block', default_max_wait_time: 15, feature: true, versio
       select('Language', from: 'secondary-caption-field')
     end
     # create the page
-    save_page
+    save_page_changes
 
     # verify that the item + image widget is displaying image and title from the requested document.
     within(:css, '.items-block', visible: true) do
@@ -154,7 +154,7 @@ describe 'Solr Document Block', default_max_wait_time: 15, feature: true, versio
 
     check 'Offer "View larger" option'
 
-    save_page
+    save_page_changes
 
     within '.contents' do
       click_button 'View [World map] larger'
@@ -170,7 +170,7 @@ describe 'Solr Document Block', default_max_wait_time: 15, feature: true, versio
     content_editable = find('.st-text-block')
     content_editable.set('zzz')
     # create the page
-    save_page
+    save_page_changes
 
     # visit the show page for the document we just saved
     # verify that the item + image widget is displaying image and title from the requested document.
@@ -193,7 +193,7 @@ describe 'Solr Document Block', default_max_wait_time: 15, feature: true, versio
     content_editable.set('zzz')
 
     # create the page
-    save_page
+    save_page_changes
 
     # verify that the item + image widget is displaying image and title from the requested document.
     within(:css, '.items-block') do
@@ -231,7 +231,7 @@ describe 'Solr Document Block', default_max_wait_time: 15, feature: true, versio
     # Select to align the text right
     choose 'Right'
 
-    save_page
+    save_page_changes
 
     click_on 'Edit'
 

--- a/spec/features/javascript/blocks/solr_documents_carousel_block_spec.rb
+++ b/spec/features/javascript/blocks/solr_documents_carousel_block_spec.rb
@@ -19,7 +19,7 @@ describe 'Solr Documents Carousel Block', js: true, type: :feature do
     check 'Primary caption'
     select 'Title', from: 'primary-caption-field'
 
-    save_page
+    save_page_changes
 
     within '.carousel-block' do
       expect(page).to have_css('.carousel-item', count: 1)

--- a/spec/features/javascript/blocks/uploaded_items_block_spec.rb
+++ b/spec/features/javascript/blocks/uploaded_items_block_spec.rb
@@ -36,7 +36,7 @@ describe 'Uploaded Items Block', feature: true, js: true, versioning: true do
       expect(page).to have_css('.card-title', text: 'avatar.png')
     end
 
-    save_page
+    save_page_changes
 
     expect(page).to have_css('h3', text: heading)
     expect(page).to have_css('p', text: text)
@@ -59,7 +59,7 @@ describe 'Uploaded Items Block', feature: true, js: true, versioning: true do
     # Uncheck the first checkbox
     all('input[type="checkbox"]').first.click
 
-    save_page
+    save_page_changes
 
     within('.uploaded-items-block') do
       expect(page).to have_css('img[alt=""]', count: 1)
@@ -76,7 +76,7 @@ describe 'Uploaded Items Block', feature: true, js: true, versioning: true do
     expect(page).to have_selector('li[data-id="file_0"] .img-thumbnail[src^="/"]')
     expect(page).to have_selector('li[data-id="file_1"] .img-thumbnail[src^="/"]')
 
-    save_page
+    save_page_changes
 
     within('.uploaded-items-block') do
       expect(page).to have_button('View larger', count: 2)

--- a/spec/features/javascript/multi_image_select_spec.rb
+++ b/spec/features/javascript/multi_image_select_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Multi image selector', default_max_wait_time: 5, js: true, type:
       expect(page).to have_link 'Change'
     end
 
-    save_page
+    save_page_changes
 
     visit spotlight.exhibit_feature_page_path(exhibit, feature_page)
     expect(page).to have_css("[data-id='xd327cm9378']")
@@ -41,7 +41,7 @@ RSpec.describe 'Multi image selector', default_max_wait_time: 5, js: true, type:
       all('li')[1].click
     end
 
-    save_page
+    save_page_changes
 
     expect(page).to have_css("[data-id='xd327cm9378']")
     expect(page).to have_no_css("img[src='https://stacks.stanford.edu/image/iiif/xd327cm9378/xd327cm9378_05_0001/full/!400,400/0/default.jpg']")

--- a/spec/support/features/test_features_helpers.rb
+++ b/spec/support/features/test_features_helpers.rb
@@ -54,7 +54,7 @@ module Spotlight
       first('.st-block-replacer').click
     end
 
-    def save_page
+    def save_page_changes
       page.execute_script <<-EOF
         SirTrevor.getInstance().onFormSubmit();
       EOF


### PR DESCRIPTION
This fixes a rubocop error and uses a clearer name.