### PR TITLE
ensure string is passed to truncate since errors with integers

### DIFF
--- a/app/views/spotlight/sir_trevor/blocks/_solr_documents_features_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_solr_documents_features_block.html.erb
@@ -25,7 +25,7 @@
                   <% caption_text = solr_documents_features_block.document_caption(doc_presenter, solr_documents_features_block.primary_caption_field, default: Spotlight::PageConfigurations::DOCUMENT_TITLE_KEY) %>
 
                   <a href="#" title="<%= caption_text %>">
-                    <%= truncate(caption_text, length: 95) %>
+                    <%= truncate(caption_text.to_s, length: 95) %>
                   </a>
                   <% if solr_documents_features_block.secondary_caption? %>
                     <p><%= solr_documents_features_block.document_caption(doc_presenter, solr_documents_features_block.secondary_caption_field) %></p>


### PR DESCRIPTION
Relates to having tests pass with Blacklight 8 (specially 8.3).

For 8.3, the following test is failing:
rspec ./spec/views/spotlight/sir_trevor/blocks/_solr_documents_features_block.html.erb_spec.rb:48 # spotlight/sir_trevor/blocks/_solr_documents_features_block.html.erb without a primary caption falls back to the regular document title for the caption

The reason appears to be when the truncate method is passed an integer, e.g. truncate(1, length:95), it throws an error.  However, truncate("1", length:95) will work just fine. Adding a "to_s" ensures the caption text truncation does not throw an error. 

This test should still pass in Blacklight 7. 

How to test with Blacklight 8: Generate test app (.internal_test_app). Update the internal test app's Gemfile to use Blacklight 8.3.  Run bundle install for the internal test app. Then run rspec ./spec/views/spotlight/sir_trevor/blocks/_solr_documents_features_block.html.erb_spec.rb:48.

Relates to #3047 and this comment which includes a checklist of tests to fix: https://github.com/projectblacklight/spotlight/issues/3047#issuecomment-2359456286