### PR TITLE
setting json solr path to nil to prevent browse category query from s…

### DIFF
--- a/app/controllers/spotlight/browse_controller.rb
+++ b/app/controllers/spotlight/browse_controller.rb
@@ -36,6 +36,8 @@ module Spotlight
     end
 
     def show
+      # For Blacklight 8, @document_list will be nil but
+      # will be required for Blacklight 7 to work correctly. 
       @response, @document_list = search_service.search_results do |builder|
         builder.with(params.merge(browse_category_id: @search.id))
       end

--- a/app/controllers/spotlight/browse_controller.rb
+++ b/app/controllers/spotlight/browse_controller.rb
@@ -37,7 +37,7 @@ module Spotlight
 
     def show
       # For Blacklight 8, @document_list will be nil but
-      # will be required for Blacklight 7 to work correctly. 
+      # will be required for Blacklight 7 to work correctly.
       @response, @document_list = search_service.search_results do |builder|
         builder.with(params.merge(browse_category_id: @search.id))
       end

--- a/lib/generators/spotlight/templates/catalog_controller.rb
+++ b/lib/generators/spotlight/templates/catalog_controller.rb
@@ -13,6 +13,8 @@ class CatalogController < ApplicationController
       fl: '*'
     }
 
+    # Blacklight 8 sets a default value to 'advanced'
+    config.json_solr_path = nil
     config.document_solr_path = 'get'
     config.document_unique_id_param = 'ids'
 

--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -286,7 +286,7 @@ module Spotlight
         Blacklight::Configuration.default_values[:browse] ||= Blacklight::OpenStructWithHashAccess.new(document_actions: [])
 
         Blacklight::Configuration.default_values[:search_state_fields] ||= []
-        Blacklight::Configuration.default_values[:search_state_fields] += %i[id exhibit_id]
+        Blacklight::Configuration.default_values[:search_state_fields] += %i[id exhibit_id browse_category_id]
       end
     end
 

--- a/spec/test_app_templates/catalog_controller.rb
+++ b/spec/test_app_templates/catalog_controller.rb
@@ -19,6 +19,8 @@ class CatalogController < ApplicationController
       fl: '*'
     }
 
+    # Blacklight 8 sets a default value to 'advanced'
+    config.json_solr_path = nil
     ## Default parameters to send on single-document requests to Solr. These settings are the Blackligt defaults (see SolrHelper#solr_doc_params) or
     ## parameters included in the Blacklight document requestHandler.
     #


### PR DESCRIPTION
Context
Relates to having tests pass with Blacklight 8.3.  
Refer to https://github.com/projectblacklight/spotlight/issues/3047 and this comment which includes a checklist of tests to fix: https://github.com/projectblacklight/spotlight/issues/3047#issuecomment-2359456286

For 8.3, the following test is failing:
rspec ./spec/features/browse_category_spec.rb:163 # Browse pages with a search field based browse category conducts a search within the browse category

What this pull request does:
- Sets json_solr_path property to nil because Blacklight 8 sets the default value to "advanced".  (see https://github.com/projectblacklight/blacklight/blob/main/lib/blacklight/configuration.rb#L77).  The following code creates the actual query and decides the path: https://github.com/projectblacklight/blacklight/blob/main/lib/blacklight/solr/repository.rb#L136 .  With json_solr_path set to "advanced", and given that the browse category rspec query does translate to including a json component (i.e. {"query"=>{"bool"=>{"must"=>[{:edismax=>{:query=>"model"}}, {:edismax=>{:query=>"azimuthal"}}]}}} ), with Blacklight 8, the search path would add "advanced" to the Solr path where Spotlight has no configuration set for an advanced search handler.  In Blacklight 7, the solr path used was the regular select.  Setting "json_solr_path" to nil fixes this issue. 
- Blacklight 8 also is more strict about passing parameters through to the Solr query. There has already been an update to add "browse_category_id" to the allowed parameters for Blacklight 8.  I added it also to the Blacklight 7 list (since it shouldn't break anything and just appears consistent). 
- I left a comment for the  browse controller "show" method.  The "search_service.search_results" method returns only @response in Blacklight 8 and sets @document_list to nil as a result.  In Blacklight 7, both "@response" and "@document_list" is required for the return values for the "search_service.search_results" method to work correctly. I left a comment there to explain what needs to be done there when we move to Blacklight 8.  

How to test
These tests should still pass in Blacklight 7.

How to test with Blacklight 8: Generate test app (.internal_test_app). Update the internal test app's Gemfile to use Blacklight 8.3. Run bundle install for the internal test app. Then run rspec ./spec/features/browse_category_spec.rb:163.