### PR TITLE
Update build matrix.

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,33 +11,23 @@ jobs:
     name: test (ruby ${{ matrix.ruby }} / rails ${{ matrix.rails_version }} / blacklight ${{ matrix.blacklight_version }} ${{ matrix.additional_name }})
     strategy:
       matrix:
-        rails_version: [7.1.3.4]
+        rails_version: ["~> 7.2"]
         ruby: ["3.2", "3.3"]
         bootstrap_version: ["~> 4.0"]
         blacklight_version: ["~> 7.34"]
         additional_engine_cart_rails_options: [""]
         additional_name: [""]
         include:
-          - rails_version: "7.0.8.4"
-            ruby: "3.2"
-            blacklight_version: "~> 7.34"
-            bootstrap_version: ~> 4.0
-            additional_name: Rails 7.0
-          - rails_version: "7.1.3.4"
-            ruby: "3.2"
+          - rails_version: "~> 7.2"
+            ruby: "3.3"
             blacklight_version: "~> 7.34"
             bootstrap_version: ~> 5.0
             additional_name: Bootstrap 5
-          - rails_version: 7.0.8.4
-            ruby: 3.1
-            blacklight_version: ~> 7.34
-            bootstrap_version: ~> 4.0
-            additional_name: Ruby 3.1
-          - rails_version: "~> 7.2"
+          - rails_version: "7.1.4"
             ruby: "3.2"
             blacklight_version: "~> 7.34"
             bootstrap_version: ~> 4.0
-            additional_name: Rails 7.2
+            additional_name: Rails 7.1
     env:
       RAILS_VERSION: ${{ matrix.rails_version }}
       BLACKLIGHT_VERSION: ${{ matrix.blacklight_version }}


### PR DESCRIPTION
Make Rails 7.2 our primary CI version and clean up other builds because:
- Rails 7.0 is out of active support upstream.
- Rails 7.1 is out of active support in another week (and has another year of security support)