### PR TITLE
Support html-safe (BL7) and non-html-safe (BL8) versions of the title for breadcrumbs

### DIFF
--- a/spec/controllers/spotlight/catalog_controller_spec.rb
+++ b/spec/controllers/spotlight/catalog_controller_spec.rb
@@ -30,7 +30,10 @@ describe Spotlight::CatalogController, type: :controller do
 
       it 'shows the item' do
         expect(controller).to receive(:add_breadcrumb).with('Home', exhibit_path(exhibit))
-        expect(controller).to receive(:add_breadcrumb).with('L&#39;AMERIQUE', exhibit_solr_document_path(exhibit, document))
+        expect(controller).to receive(:add_breadcrumb) do |title, path|
+          expect(title).to eq(title.html_safe? ? 'L&#39;AMERIQUE' : "L'AMERIQUE")
+          expect(path).to eq exhibit_solr_document_path(exhibit, document)
+        end
         get :show, params: { exhibit_id: exhibit, id: 'dq287tq6352' }
         expect(response).to be_successful
       end
@@ -41,7 +44,10 @@ describe Spotlight::CatalogController, type: :controller do
         expect(controller).to receive(:add_breadcrumb).with('Home', exhibit_path(exhibit))
         expect(controller).to receive(:add_breadcrumb).with('Browse', exhibit_browse_index_path(exhibit))
         expect(controller).to receive(:add_breadcrumb).with(search.title, exhibit_browse_path(exhibit, search))
-        expect(controller).to receive(:add_breadcrumb).with('L&#39;AMERIQUE', exhibit_solr_document_path(exhibit, document))
+        expect(controller).to receive(:add_breadcrumb) do |title, path|
+          expect(title).to eq(title.html_safe? ? 'L&#39;AMERIQUE' : "L'AMERIQUE")
+          expect(path).to eq exhibit_solr_document_path(exhibit, document)
+        end
         get :show, params: { exhibit_id: exhibit, id: 'dq287tq6352' }
         expect(response).to be_successful
       end
@@ -52,7 +58,10 @@ describe Spotlight::CatalogController, type: :controller do
 
         expect(controller).to receive(:add_breadcrumb).with('Home', exhibit_path(exhibit))
         expect(controller).to receive(:add_breadcrumb).with(feature_page.title, [exhibit, feature_page])
-        expect(controller).to receive(:add_breadcrumb).with('L&#39;AMERIQUE', exhibit_solr_document_path(exhibit, document))
+        expect(controller).to receive(:add_breadcrumb) do |title, path|
+          expect(title).to eq(title.html_safe? ? 'L&#39;AMERIQUE' : "L'AMERIQUE")
+          expect(path).to eq exhibit_solr_document_path(exhibit, document)
+        end
         get :show, params: { exhibit_id: exhibit, id: 'dq287tq6352' }
         expect(response).to be_successful
       end
@@ -62,7 +71,10 @@ describe Spotlight::CatalogController, type: :controller do
         allow(controller).to receive_messages(current_page_context: home_page)
 
         expect(controller).to receive(:add_breadcrumb).with('Home', exhibit_path(exhibit))
-        expect(controller).to receive(:add_breadcrumb).with('L&#39;AMERIQUE', exhibit_solr_document_path(exhibit, document))
+        expect(controller).to receive(:add_breadcrumb) do |title, path|
+          expect(title).to eq(title.html_safe? ? 'L&#39;AMERIQUE' : "L'AMERIQUE")
+          expect(path).to eq exhibit_solr_document_path(exhibit, document)
+        end
         get :show, params: { exhibit_id: exhibit, id: 'dq287tq6352' }
         expect(response).to be_successful
       end


### PR DESCRIPTION
Blacklight 8 short-circuits some HTML safe-ing when it isn't necessary (and it isn't here.) At least for now, we can support either version 🤷‍♂️ 