### PR TITLE
Use icon components for gallery views.

### DIFF
--- a/app/views/spotlight/pages/_view_type_group.html.erb
+++ b/app/views/spotlight/pages/_view_type_group.html.erb
@@ -3,11 +3,8 @@
 <div class="view-type">
   <span class="sr-only visually-hidden"><%= t('blacklight.search.view_title') %></span>
   <div class="view-type-group btn-group">
-    <% views.each do |view, config| %>
-      <%= link_to url_for(search_state.to_h.merge(view: view)), :title => t("blacklight.search.view_title.#{view}", default: t("blacklight.search.view.#{view}", default: blacklight_config.view[view].title)), :class => "btn btn-outline-secondary view-type-#{ view.to_s.parameterize } #{"active" if block_document_index_view_type(block) == view}" do %>
-        <%= blacklight_icon config.icon || view %>
-        <span class="caption"><%= t("blacklight.search.view.#{view}") %></span>
-      <% end %>
+    <% views.each do |key, config| %>
+      <%= render Blacklight::Response::ViewTypeButtonComponent.new(key: key, view: config, selected: block_document_index_view_type(block) == key, search_state: search_state) %>
     <% end %>
   </div>
 </div>

--- a/spec/test_app_templates/catalog_controller.rb
+++ b/spec/test_app_templates/catalog_controller.rb
@@ -6,10 +6,10 @@ class CatalogController < ApplicationController
   before_action :set_paper_trail_whodunnit
 
   configure_blacklight do |config|
-    config.view.gallery(document_component: Blacklight::Gallery::DocumentComponent)
+    config.view.gallery(document_component: Blacklight::Gallery::DocumentComponent, icon: Blacklight::Gallery::Icons::GalleryComponent)
     # config.view.gallery.classes = 'row-cols-2 row-cols-md-3'
-    config.view.masonry(document_component: Blacklight::Gallery::DocumentComponent)
-    config.view.slideshow(document_component: Blacklight::Gallery::SlideshowComponent)
+    config.view.masonry(document_component: Blacklight::Gallery::DocumentComponent, icon: Blacklight::Gallery::Icons::MasonryComponent)
+    config.view.slideshow(document_component: Blacklight::Gallery::SlideshowComponent, icon: Blacklight::Gallery::Icons::SlideshowComponent)
     config.show.tile_source_field = :content_metadata_image_iiif_info_ssm
     config.show.partials.insert(1, :openseadragon)
     ## Default parameters to send to solr for all search-like requests. See also SolrHelper#solr_search_params


### PR DESCRIPTION
This updates our test catalog controller to match blacklight-gallery's (newer) generated configuration. The icon class configuration does require that we use the `ViewTypeButtonComponent` to render icons on feature pages, but it's been available since Blacklight 7.18.

