### PR TITLE
Add a default document component for the admin table + blacklight 7.

### DIFF
--- a/app/controllers/spotlight/catalog_controller.rb
+++ b/app/controllers/spotlight/catalog_controller.rb
@@ -42,6 +42,8 @@ module Spotlight
                                            partials: [:index_compact],
                                            document_actions: [])
       end
+      blacklight_config.view.admin_table.document_component ||= Spotlight::DocumentAdminTableComponent
+
       if Blacklight::VERSION > '8'
         blacklight_config.track_search_session.storage = false
       else

--- a/app/views/spotlight/catalog/_document_admin_table.html.erb
+++ b/app/views/spotlight/catalog/_document_admin_table.html.erb
@@ -11,7 +11,7 @@
   </thead>
 
   <% if Blacklight.version < '8.0' %>
-    <%= render view_config.document_component.with_collection(documents) %>
+    <%= render (view_config.document_component || Spotlight::DocumentAdminTableComponent).with_collection(documents) %>
   <% else %>
     <% document_presenters = documents.map { |doc| document_presenter(doc) } -%>
     <%= render view_config.document_component.with_collection(document_presenters) %>


### PR DESCRIPTION
It's possible downstream application:

- render the document admin table partial outside the `catalog#admin` action, or
- customized the `admin_table` view but haven't updated it to use view components yet.

A little more defensive programming should help avoid breaking things 🤷‍♂️ 