### PR TITLE
add controlled vocab functionality for tag_list

### DIFF
--- a/app/components/spotlight/tag_list_form_component.html.erb
+++ b/app/components/spotlight/tag_list_form_component.html.erb
@@ -1,0 +1,14 @@
+<% if Spotlight::Engine.config.site_tags %>
+  <div class="form-group row">
+  <label class="col-form-label col-md-2" for="tag_list">Tag list</label>
+  <div class="col-md-10">
+    <div class="overflow-scroll rounded border px-3 py-2 h-25" style="overflow: scroll; height: 25vh!important;">
+      <% Spotlight::Engine.config.site_tags.each do |tag| %>
+        <%= form.check_box :tag_list, { multiple: true, label: tag }, tag , nil %>
+      <% end %>
+    </div>
+  </div>
+  </div>
+<% else %>
+  <%= form.text_field :tag_list, value: form.object.tag_list.to_s %>
+<% end %>

--- a/app/components/spotlight/tag_list_form_component.rb
+++ b/app/components/spotlight/tag_list_form_component.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Spotlight
+  # Create tag list for exhibit general/create form
+  class TagListFormComponent < ViewComponent::Base
+    attr_reader :form
+
+    def initialize(form:)
+      @form = form
+      super
+    end
+  end
+end

--- a/app/controllers/spotlight/exhibits_controller.rb
+++ b/app/controllers/spotlight/exhibits_controller.rb
@@ -94,6 +94,7 @@ module Spotlight
         :description,
         :published,
         :tag_list,
+        tag_list: [],
         contact_emails_attributes: %i[id email],
         languages_attributes: %i[id public]
       )

--- a/app/views/spotlight/exhibits/_form.html.erb
+++ b/app/views/spotlight/exhibits/_form.html.erb
@@ -3,7 +3,7 @@
   <%= f.text_field :title, disabled: !default_language?, help: !default_language? ? t('.uneditable_non_default_language') : '' %>
   <%= f.text_field :subtitle %>
   <%= f.text_area :description %>
-  <%= f.text_field :tag_list, value: f.object.tag_list.to_s %>
+  <%= render Spotlight::TagListFormComponent.new(form: f) %>
   <%= f.form_group(:contact_emails, label: { text: nil, class: nil, for: 'exhibit_contact_email_0' }, class: 'form-group mb-3', help: nil) do %>
     <%= f.fields_for :contact_emails do |contact| %> 
       <%= render partial: 'contact', locals: {exhibit: @exhibit, contact: contact} %>

--- a/app/views/spotlight/exhibits/_new_exhibit_form.html.erb
+++ b/app/views/spotlight/exhibits/_new_exhibit_form.html.erb
@@ -1,7 +1,7 @@
 <%= bootstrap_form_for @exhibit, url: ((spotlight.exhibit_path(@exhibit) if @exhibit.persisted?) || spotlight.exhibits_path), layout: :horizontal, label_col: 'col-md-2', control_col: 'col-md-10' do |f| %>
   <%= f.text_field :title, label: t(:'.fields.title.label'), help: t(:'.fields.title.help_block') %>
   <%= f.text_field :slug, label: t(:'.fields.slug.label'), help: t(:'.fields.slug.help_block') %>
-  <%= f.text_field :tag_list %>
+  <%= render Spotlight::TagListFormComponent.new(form: f) %>
 
   <%= render 'initial_resources_form', locals: { f: f } %>
 

--- a/lib/generators/spotlight/templates/config/initializers/spotlight_initializer.rb
+++ b/lib/generators/spotlight/templates/config/initializers/spotlight_initializer.rb
@@ -83,6 +83,10 @@
 #   Spotlight::Engine.config.ga_debug_mode = false
 # end
 
+# ==> Customizable settings for site tags
+# When set the free text tag list field becomes multiple selection checklist
+# Spotlight::Engine.config.site_tags = []
+
 # ==> Sir Trevor Widget Configuration
 # These are set by default by Spotlight's configuration,
 # but you can customize them here, or in the SirTrevorRails::Block#custom_block_types method

--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -145,6 +145,8 @@ module Spotlight
     config.full_image_field = :full_image_url_ssm
     config.thumbnail_field = :thumbnail_url_ssm
 
+    Spotlight::Engine.config.site_tags = nil
+
     # Defaults to the blacklight_config.index.title_field:
     config.upload_title_field = nil # UploadFieldConfig.new(...)
     config.upload_description_field = :spotlight_upload_description_tesim

--- a/spec/features/exhibits/administration_spec.rb
+++ b/spec/features/exhibits/administration_spec.rb
@@ -138,4 +138,39 @@ describe 'Exhibit Administration', type: :feature do
       expect(page).to have_css("##{hidden_input_id_0}~div span.contact-email-delete-error", text: 'Problem deleting recipient: Not Found')
     end
   end
+
+  describe 'Tag list' do
+    before do
+      allow(Spotlight::Engine.config).to receive(:site_tags).and_return(site_tags)
+    end
+
+    context 'site_tags are set to a list' do
+      let(:site_tags) { ['tag 1', 'tag 2', 'tag 3'] }
+
+      it 'site_tags listed on the page', js: true do
+        visit spotlight.edit_exhibit_path(exhibit)
+        expect(page).to have_css('#exhibit_tag_list_tag_1')
+        find('label', text: 'tag 1').click
+        find('label', text: 'tag 3').click
+        click_button 'Save changes'
+        expect(page).to have_content('The exhibit was successfully updated.')
+        expect(find_field('exhibit_tag_list_tag_1').checked?).to be true
+        expect(find_field('exhibit_tag_list_tag_2').checked?).to be false
+        expect(find_field('exhibit_tag_list_tag_3').checked?).to be true
+      end
+    end
+
+    context 'site_tags are set to nil' do
+      let(:site_tags) { nil }
+
+      it 'has free text tag_list field', js: true do
+        visit spotlight.edit_exhibit_path(exhibit)
+        expect(page).to have_css('#exhibit_tag_list')
+        fill_in 'exhibit_tag_list', with: 'tag 1, tag 2'
+        click_button 'Save changes'
+        expect(page).to have_content('The exhibit was successfully updated.')
+        expect(find_field('exhibit_tag_list').value).to eq 'tag 1, tag 2'
+      end
+    end
+  end
 end


### PR DESCRIPTION
closes https://github.com/sul-dlss/exhibits/issues/2492

screenshot is for when ```Spotlight::Engine.config.site_tags = ['tag 1', 'tag 2', 'tag 3', 'tag 4', 'tag 5', 'tag 6', 'tag 7', 'tag 8', 'tag 9', 'tag 10', 'tag 11', 'tag 12']```

![Screenshot 2024-10-04 at 1 03 41 PM](https://github.com/user-attachments/assets/7d88468a-5c60-4454-a3e7-57e7afa7f09b)
![Screenshot 2024-10-04 at 1 03 17 PM](https://github.com/user-attachments/assets/ded8cc93-f1f3-4a7d-af64-25b9fbda3f24)
