### PR TITLE
add breadcrumbs to bulk_updates page

### DIFF
--- a/app/controllers/spotlight/bulk_updates_controller.rb
+++ b/app/controllers/spotlight/bulk_updates_controller.rb
@@ -8,8 +8,13 @@ module Spotlight
   class BulkUpdatesController < Spotlight::ApplicationController
     before_action :authenticate_user!
     before_action :check_authorization
+    load_and_authorize_resource :exhibit, class: 'Spotlight::Exhibit'
 
-    def edit; end
+    def edit
+      add_breadcrumb(t(:'spotlight.exhibits.breadcrumb', title: @exhibit.title), @exhibit)
+      add_breadcrumb(t(:'spotlight.curation.sidebar.header'), exhibit_dashboard_path(@exhibit))
+      add_breadcrumb(t(:'spotlight.pages.index.bulk_updates.header'), edit_exhibit_bulk_updates_path(@exhibit))
+    end
 
     def download_template
       # Set Last-Modified as a work-around for https://github.com/rack/rack/issues/1619

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -723,6 +723,8 @@ en:
       index:
         about_pages:
           header: About pages
+        bulk_updates:
+          header: Bulk updates
         feature_pages:
           header: Feature pages
           home_pages_header: Homepage


### PR DESCRIPTION
<img width="1042" alt="Screenshot 2024-10-07 at 10 47 15 AM" src="https://github.com/user-attachments/assets/fdd15a0a-1604-4f88-90d7-4e4698cc9a95">


closes https://github.com/sul-dlss/exhibits/issues/2595