### PR TITLE
Don't scope exhibit_navbar_component setting to view type

### DIFF
--- a/app/views/shared/_exhibit_navbar.html.erb
+++ b/app/views/shared/_exhibit_navbar.html.erb
@@ -1,2 +1,2 @@
-<%= render (blacklight_config&.view_config(document_index_view_type)&.exhibit_navbar_component || Spotlight::ExhibitNavbarComponent).new %>
-<% Spotlight.deprecator.warn("_exhibit_navbar.html.erb will be removed.  Customize the exhibit navbar using components instead.") %>
+<%- Spotlight.deprecator.warn("_exhibit_navbar.html.erb will be removed.  Customize the exhibit navbar using components instead.") %>
+<%= render (blacklight_config&.exhibit_navbar_component || Spotlight::ExhibitNavbarComponent).new %>

--- a/lib/generators/spotlight/templates/catalog_controller.rb
+++ b/lib/generators/spotlight/templates/catalog_controller.rb
@@ -16,7 +16,7 @@ class CatalogController < ApplicationController
     # Blacklight 8 sets a default value to 'advanced'
     config.json_solr_path = nil
     config.header_component = Spotlight::HeaderComponent
-    config.index.exhibit_navbar_component = Spotlight::ExhibitNavbarComponent
+    config.exhibit_navbar_component = Spotlight::ExhibitNavbarComponent
     config.document_solr_path = 'get'
     config.document_unique_id_param = 'ids'
 

--- a/spec/test_app_templates/catalog_controller.rb
+++ b/spec/test_app_templates/catalog_controller.rb
@@ -7,7 +7,7 @@ class CatalogController < ApplicationController
 
   configure_blacklight do |config|
     config.header_component = Spotlight::HeaderComponent
-    config.index.exhibit_navbar_component = Spotlight::ExhibitNavbarComponent
+    config.exhibit_navbar_component = Spotlight::ExhibitNavbarComponent
     config.view.gallery(document_component: Blacklight::Gallery::DocumentComponent, icon: Blacklight::Gallery::Icons::GalleryComponent)
     # config.view.gallery.classes = 'row-cols-2 row-cols-md-3'
     config.view.masonry(document_component: Blacklight::Gallery::DocumentComponent, icon: Blacklight::Gallery::Icons::MasonryComponent)


### PR DESCRIPTION
https://github.com/projectblacklight/spotlight/commit/5fd1d64bbd2e7e9281830fb0fb72d6b50c0f5c15 set this config at `blacklight_config.index`. However, the previous implementation with the navbar set in a partial instead of a component assumed there'd just be one exhibit navbar.