### PR TITLE
Require version of OSD rails that supports turbo

### DIFF
--- a/blacklight-spotlight.gemspec
+++ b/blacklight-spotlight.gemspec
@@ -43,7 +43,7 @@ these collections.)
   s.add_dependency 'mini_magick'
   s.add_dependency 'nokogiri'
   s.add_dependency 'oauth2'
-  s.add_dependency 'openseadragon', '>= 0.7.0'
+  s.add_dependency 'openseadragon', '>= 0.8.0'
   s.add_dependency 'ostruct', '!= 0.3.0', '!= 0.3.1', '!= 0.3.2'
   s.add_dependency 'paper_trail', '>= 11.0', '< 16'
   s.add_dependency 'rails', '>= 7.0', '< 8'


### PR DESCRIPTION
This clears up the failing test from the openseadragon rails issue.

Some configs will still fail because: `error Couldn't find any versions for "blacklight-frontend" that matches "7.39.0"`

The Docker build issue I'll work on in another PR.
