### PR TITLE
Remove unused docker volumes

### DIFF
--- a/.env
+++ b/.env
@@ -12,7 +12,6 @@ RACK_ENV=development
 RAILS_ENV=development
 RAILS_LOG_TO_STDOUT=true
 RAILS_QUEUE=inline
-REDIS_HOST=redis
 SOLR_VERSION=latest
 SOLR_HOST=solr
 SOLR_PORT=8983

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: "3.7"
 
 services:
   web:
@@ -66,8 +66,6 @@ services:
 volumes:
   spotlight_app:
   spotlight_db:
-  spotlight_redis:
-  spotlight_solr:
 
 networks:
   spotlight:


### PR DESCRIPTION
These unused volumes are likely copypasta and are misleading about the use of redis.