### PR TITLE
fix for import using :label instead of 'label' for some custom fields

### DIFF
--- a/app/models/spotlight/custom_field.rb
+++ b/app/models/spotlight/custom_field.rb
@@ -39,7 +39,7 @@ module Spotlight
              else
                configuration
              end
-      conf['label']
+      conf['label'] || conf[:label]
     end
 
     def short_description=(short_description)

--- a/app/services/spotlight/exhibit_import_export_service.rb
+++ b/app/services/spotlight/exhibit_import_export_service.rb
@@ -164,6 +164,7 @@ module Spotlight
 
       hash[:custom_fields].each do |attr|
         ar = exhibit.custom_fields.find_or_initialize_by(slug: attr[:slug])
+        attr[:configuration] = attr[:configuration].clone.transform_keys(&:to_s)
         ar.update(attr)
       end
 

--- a/spec/models/spotlight/custom_field_spec.rb
+++ b/spec/models/spotlight/custom_field_spec.rb
@@ -27,6 +27,14 @@ describe Spotlight::CustomField, type: :model do
     end
   end
 
+  describe ':label' do
+    subject { described_class.new configuration: { label: 'the configured label' }, field: 'foo_tesim' }
+
+    describe "when the exhibit doesn't have a config" do
+      its(:label) { is_expected.to eq 'the configured label' }
+    end
+  end
+
   describe '#label=' do
     subject { described_class.new field: 'foo_tesim' }
 


### PR DESCRIPTION
closes #2983


What I found with this is when update runs for the license field, it makes the config :label => 'License' not 'label' => 'License'. I checked the data. It looks exactly the same as all the other fields. 