### PR TITLE
Preventing exhibit navb deprecation messages when not needed

### DIFF
--- a/app/views/shared/_exhibit_navbar.html.erb
+++ b/app/views/shared/_exhibit_navbar.html.erb
@@ -1,2 +1,2 @@
-<%- Spotlight.deprecator.warn("_exhibit_navbar.html.erb will be removed.  Customize the exhibit navbar using components instead.") %>
+<%- Spotlight.deprecator.warn("_exhibit_navbar.html.erb will be removed.  Customize the exhibit navbar using components instead.") if !blacklight_config.key?(:exhibit_navbar_component) %>
 <%= render (blacklight_config&.exhibit_navbar_component || Spotlight::ExhibitNavbarComponent).new %>


### PR DESCRIPTION
Closes #3200 .

What this PR does:
Updates the code to only throw a deprecation warning if the exhibit navbar component is not set in the configuration. 