### PR TITLE
Add a test to check if the Sir Trevor icons loaded

### DIFF
--- a/spec/features/javascript/block_controls_spec.rb
+++ b/spec/features/javascript/block_controls_spec.rb
@@ -25,6 +25,12 @@ describe 'Block controls' do
     # click to add widget
     click_add_widget
 
+    # Check if the Sir Trevor icons are loading. They are in the same SVG so a single check should be sufficient.
+    within('.st-block-replacer') do
+      href_value = find('use')['xlink:href']
+      expect(href_value).to match(/.+\.svg#add-block$/)
+    end
+
     within('.spotlight-block-controls') do
       expect(page).to have_css('.st-controls-group', count: 2)
 


### PR DESCRIPTION
I think we should add a test for checking if the Sir Trevor icons were successfully loaded. They are currently broken.