### PR TITLE
Increase reliability of ZPR link test

### DIFF
--- a/spec/features/javascript/blocks/uploaded_items_block_spec.rb
+++ b/spec/features/javascript/blocks/uploaded_items_block_spec.rb
@@ -83,13 +83,11 @@ describe 'Uploaded Items Block', feature: true, js: true, versioning: true do
 
   it 'may have ZPR links' do
     attach_file('uploaded_item_url', fixture_file1)
+    expect(page).to have_selector('li[data-id="file_0"] .img-thumbnail[src^="/"]')
     attach_file('uploaded_item_url', fixture_file2)
+    expect(page).to have_selector('li[data-id="file_1"] .img-thumbnail[src^="/"]')
 
     check 'Offer "View larger" option'
-
-    # Flappy guards. Wait for the thumbnail src to be populated.
-    expect(page).to have_selector('li[data-id="file_0"] .img-thumbnail[src^="/"]')
-    expect(page).to have_selector('li[data-id="file_1"] .img-thumbnail[src^="/"]')
 
     save_page_changes
 


### PR DESCRIPTION
This test is flappy and has failed for me 10+ times today. For whatever reason it seems that sometimes the avatar fixture image precedes the 800x600 image when running on CI. Checking to see if moving the existing expect guards help with this.