### PR TITLE
Revert "Defer configuration until the script is loaded"

### DIFF
--- a/app/views/layouts/spotlight/base.html.erb
+++ b/app/views/layouts/spotlight/base.html.erb
@@ -19,7 +19,7 @@
     <%= description %>
     <%= twitter_card %>
     <%= opengraph %>
-    <%= javascript_tag "window.addEventListener('load', () => Spotlight.sirTrevorIcon = '#{asset_path('spotlight/blocks/sir-trevor-icons.svg')}')" %>
+    <%= javascript_tag "Spotlight.sirTrevorIcon = '#{asset_path('spotlight/blocks/sir-trevor-icons.svg')}'" %>
     <%= javascript_tag '$.fx.off = true;' if Rails.env.test? %>
   </head>
   <body class="<%= render_body_class %>">


### PR DESCRIPTION
This reverts commit 17ca2998f5386c39ecd54c6b2d80feffc9a8b6b4.

From https://github.com/projectblacklight/spotlight/pull/2919

This breaks Sir Trevor icons for Exhibits.