### PR TITLE
add css for btn blacklight icons

### DIFF
--- a/app/assets/stylesheets/spotlight/_spotlight.scss
+++ b/app/assets/stylesheets/spotlight/_spotlight.scss
@@ -46,3 +46,7 @@ html {
 body {
   margin-bottom: $footer-height + $footer-top-margin;
 }
+
+.btn .blacklight-icons svg {
+  fill: var(--bs-btn-color);
+}


### PR DESCRIPTION
closes #3228 

https://github.com/projectblacklight/blacklight/blob/v7.39.0/app/assets/stylesheets/blacklight/_icons.scss#L2-L7 got removed in blacklight 8. I added a variation in _spotlight.scss.