### PR TITLE
Pass the block context through to the embed component

### DIFF
--- a/app/components/spotlight/solr_document_legacy_embed_component.rb
+++ b/app/components/spotlight/solr_document_legacy_embed_component.rb
@@ -1,7 +1,20 @@
 # frozen_string_literal: true
 
-# Render an document suitable for embedding on a feature page.
 module Spotlight
+  # Render an document suitable for embedding on a feature page.
   class SolrDocumentLegacyEmbedComponent < Blacklight::DocumentComponent
+    attr_reader :block_context
+
+    def initialize(*args, block: nil, **kwargs)
+      super
+
+      @block_context = block
+    end
+
+    def before_render
+      set_slot(:embed, nil, block_context: block_context) unless embed
+
+      super
+    end
   end
 end


### PR DESCRIPTION
This is an extension on #3244; now that we're passing the block to the document component, we might as well keep track of it and make it available to the embed component at least.