### PR TITLE
Remove active support for Blacklight 7

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -14,25 +14,20 @@ jobs:
         rails_version: ["~> 7.2"]
         ruby: ["3.2", "3.3"]
         bootstrap_version: ["~> 4.0"]
-        blacklight_version: ["~> 7.34"]
+        blacklight_version: ["~> 8.0"]
         additional_engine_cart_rails_options: ["-a propshaft -j esbuild"]
         additional_name: [""]
         include:
           - rails_version: "~> 7.2"
             ruby: "3.3"
-            blacklight_version: "~> 7.38"
+            blacklight_version: "~> 8.0"
             bootstrap_version: "~> 5.0"
             additional_name: Bootstrap 5
           - rails_version: "7.1.4"
             ruby: "3.2"
-            blacklight_version: "~> 7.38"
-            bootstrap_version: "~> 4.0"
-            additional_name: Rails 7.1
-          - rails_version: "~> 7.2"
-            ruby: "3.3"
             blacklight_version: "~> 8.0"
             bootstrap_version: "~> 4.0"
-            additional_name: Blacklight 8
+            additional_name: Rails 7.1
     env:
       RAILS_VERSION: ${{ matrix.rails_version }}
       BLACKLIGHT_VERSION: ${{ matrix.blacklight_version }}

--- a/blacklight-spotlight.gemspec
+++ b/blacklight-spotlight.gemspec
@@ -22,7 +22,7 @@ these collections.)
 
   s.add_dependency 'activejob-status'
   s.add_dependency 'acts-as-taggable-on', '>= 5.0', '< 12'
-  s.add_dependency 'blacklight', '>= 7.38', '< 9'
+  s.add_dependency 'blacklight', '~> 8.0'
   s.add_dependency 'blacklight-gallery', '>= 3.0', '< 5'
   s.add_dependency 'bootstrap_form', '>= 4.1', '< 6'
   s.add_dependency 'breadcrumbs_on_rails', '>= 3.0', '< 5'

--- a/lib/generators/spotlight/assets/propshaft_generator.rb
+++ b/lib/generators/spotlight/assets/propshaft_generator.rb
@@ -74,11 +74,6 @@ module Spotlight
         gsub_file 'app/javascript/application.js', 'import "controllers"', '// import "controllers"'
 
         append_to_file 'app/javascript/application.js', "\n// Bootstrap\nimport * as Bootstrap from 'bootstrap'\n"
-
-        if Blacklight::VERSION.start_with?('7')
-          append_to_file 'app/javascript/application.js', "\n// Blacklight\nimport \"blacklight-frontend/app/assets/javascripts/blacklight/blacklight.js\"\n"
-        end
-
         append_to_file 'app/javascript/application.js', "\n// Spotlight\nimport Spotlight from \"spotlight-frontend\"\n"
       end
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "not IE 11"
   ],
   "dependencies": {
-    "blacklight-frontend": ">= 7.38 < 9",
+    "blacklight-frontend": "^8.4.0",
     "bootstrap": ">=4.3.1 <6.0.0",
     "clipboard": "^2.0.11",
     "jquery": "^3.7.1",

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -10,7 +10,7 @@ class TestAppGenerator < Rails::Generators::Base
   end
 
   def add_gems
-    gem 'blacklight', ENV['BLACKLIGHT_VERSION'] || '~> 7.38' unless Bundler.locked_gems.dependencies.key? 'blacklight'
+    gem 'blacklight', ENV['BLACKLIGHT_VERSION'] || '~> 8.0' unless Bundler.locked_gems.dependencies.key? 'blacklight'
     gem 'blacklight-gallery', '~> 4.5' unless Bundler.locked_gems.dependencies.key? 'blacklight-gallery'
     gem 'cssbundling-rails' unless defined?(Sprockets)
 

--- a/template.rb
+++ b/template.rb
@@ -9,7 +9,7 @@ spotlight_options = ENV.fetch('SPOTLIGHT_INSTALL_OPTIONS', DEFAULT_SPOTLIGHT_OPT
 bootstrap_version = ENV.fetch('BOOTSTRAP_VERSION', '~> 5.3')
 
 # Add gem dependencies to the application
-gem 'blacklight', ' ~> 7.38'
+gem 'blacklight', '~> 8.0'
 gem 'blacklight-spotlight', ENV['SPOTLIGHT_GEM'] ? { path: ENV['SPOTLIGHT_GEM'] } : { github: 'projectblacklight/spotlight' }
 gem 'sidekiq'
 gem 'bootstrap_form', /(\d)(?:\.\d){0,2}/.match(bootstrap_version)[1].to_i == 5 ? '~> 5.4' : '~> 4.5'


### PR DESCRIPTION
This is for the `migrate-asset-pipeline` branch.

Removes testing for Blacklight 7 and switches the defaults to Blacklight 8.

It does not remove all the other Blacklight 7 related code. As we continue work on what is anticipated to be for Spotlight v5 we want to focus our efforts on Blacklight 8 but leave the option to pivot back to supporting Blacklight 7 if need be.