### PR TITLE
Unpin solr_wrapper version

### DIFF
--- a/.solr_wrapper
+++ b/.solr_wrapper
@@ -3,4 +3,3 @@
 collection:
   dir: lib/generators/spotlight/templates/solr/conf
   name: blacklight-core
-version: 9.6.1


### PR DESCRIPTION
With https://github.com/cbeer/solr_wrapper/pull/154 in, I think this pin can be removed.