### PR TITLE
fix view link to work correctly

### DIFF
--- a/app/components/spotlight/document_admin_table_component.html.erb
+++ b/app/components/spotlight/document_admin_table_component.html.erb
@@ -21,7 +21,7 @@
       </div>
 
       <div class="page-links">
-        <%= helpers.view_link presenter.document, helpers.link_to_document(presenter.document) %> &middot;
+        <%= helpers.view_link presenter.document, helpers.search_state.url_for_document(presenter.document) %> &middot;
         <%= helpers.exhibit_edit_link presenter.document, [:edit, helpers.current_exhibit, presenter.document] %>
       </div>
     </td>


### PR DESCRIPTION
Before this fix, when clicking on the link the url will look like this: http://localhost:3000/test-f71f4f09-8669-4b2f-8121-23ff6ceaaa30/catalog/%3Ca%20href=%22/test-f71f4f09-8669-4b2f-8121-23ff6ceaaa30/catalog/7-113%22%3ESHEPARD'S%20ALABAMA%20CITATIONS%3C/a%3E

![Screenshot 2024-11-04 at 1 36 00 PM](https://github.com/user-attachments/assets/21086099-82b1-4768-8231-89e3fec5c9c1)

