### PR TITLE
Changing permission of gem directory is no longer needed

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -57,8 +57,6 @@ jobs:
           bundler-cache: false
           bundler: "latest"
           ruby-version: ${{ matrix.ruby }}
-      - name: Change permissions
-        run: chmod -R o-w /opt/hostedtoolcache/Ruby/3.2.5/x64/lib/ruby/gems/3.2.0/gems
       - name: Install dependencies
         run: bundle install
       - name: Run tests


### PR DESCRIPTION
It was also causing CI to fail since ruby 3.2.6 was released