### PR TITLE
Unpin uri; v1.0.1 fixes carrierwave issue

### DIFF
--- a/blacklight-spotlight.gemspec
+++ b/blacklight-spotlight.gemspec
@@ -55,8 +55,6 @@ these collections.)
   s.add_dependency 'roar-rails'
   s.add_dependency 'signet'
   s.add_dependency 'tophat'
-  # pinned so CI will pass until https://github.com/carrierwaveuploader/carrierwave/issues/2759 is fixed
-  s.add_dependency 'uri', '< 1'
   s.add_dependency 'view_component', '>= 2.66', '< 4'
 
   s.add_development_dependency 'capybara', '~> 3.31'


### PR DESCRIPTION
See https://github.com/ruby/uri/issues/125