### PR TITLE
add alt-text dashboard

### DIFF
--- a/app/components/spotlight/edit_view_links_component.html.erb
+++ b/app/components/spotlight/edit_view_links_component.html.erb
@@ -1,0 +1,13 @@
+<div class="<%= classes %>">
+  <% if page.is_a?(Spotlight::HomePage) %>
+    <%= helpers.exhibit_view_link page, helpers.exhibit_root_path(page.exhibit) %> &middot;
+    <%= helpers.exhibit_edit_link page, helpers.edit_exhibit_home_page_path(page.exhibit), data: { turbolinks: false,
+        turbo: false } %>
+  <% else %>
+    <%= helpers.exhibit_view_link page %> &middot;
+    <%= helpers.exhibit_edit_link page, data: { turbolinks: false, turbo: false } %>
+  <% end %>
+  <% if delete_link %>
+    &middot; <%= helpers.exhibit_delete_link page %>
+  <% end %>
+</div>

--- a/app/components/spotlight/edit_view_links_component.rb
+++ b/app/components/spotlight/edit_view_links_component.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Spotlight
+  # Allows component addition to exhibit navbar
+  class EditViewLinksComponent < ViewComponent::Base
+    attr_reader :page, :classes, :delete_link
+
+    def initialize(page:, classes: 'page-links', delete_link: false)
+      super
+
+      @page = page
+      @classes = classes
+      @delete_link = delete_link
+    end
+  end
+end

--- a/app/components/spotlight/solr_document_legacy_embed_component.rb
+++ b/app/components/spotlight/solr_document_legacy_embed_component.rb
@@ -12,7 +12,7 @@ module Spotlight
     end
 
     def before_render
-      set_slot(:embed, nil, block_context: block_context) unless embed
+      set_slot(:embed, nil, block_context:) unless embed
 
       super
     end

--- a/app/controllers/spotlight/accessibility_controller.rb
+++ b/app/controllers/spotlight/accessibility_controller.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Spotlight
+  ##
+  # Exhibit dashboard controller
+  class AccessibilityController < Spotlight::ApplicationController
+    before_action :authenticate_user!
+    load_and_authorize_resource :exhibit, class: Spotlight::Exhibit
+
+    include Spotlight::Base
+    include Spotlight::SearchHelper
+
+    def alt_text
+      authorize! :curate, @exhibit
+
+      @limit = 5
+      # Sort by newest except for the homepage, which is always first
+      pages_with_alt = @exhibit.pages.order(Arel.sql('id = 1 DESC, created_at DESC')).select { |elem| elem.content.any?(&:alt_text?) }
+      pages = params[:show_all] ? pages_with_alt : pages_with_alt.first(@limit)
+      @pages = pages.map { |page| get_alt_info(page) }
+      @has_alt_text = @pages.sum { |page| page[:has_alt_text] }
+      @total_alt_items = @pages.sum { |page| page[:can_have_alt_text] }
+
+      attach_alt_text_breadcrumbs
+    end
+
+    private
+
+    def get_alt_info(page)
+      can_have_alt_text = 0
+      has_alt_text = 0
+      page.content.each do |content|
+        content.item&.each_value do |item|
+          next if item['alt_text_backup'].nil?
+
+          can_have_alt_text += 1
+          has_alt_text += 1 if item['alt_text'].present? || item['decorative'].present?
+        end
+      end
+      { can_have_alt_text:, has_alt_text:, page: }
+    end
+
+    def attach_alt_text_breadcrumbs
+      add_breadcrumb(t(:'spotlight.exhibits.breadcrumb', title: @exhibit.title), @exhibit)
+      add_breadcrumb(t(:'spotlight.accessibility.header'), exhibit_dashboard_path(@exhibit))
+      add_breadcrumb(t(:'spotlight.accessibility.alt_text.header'), exhibit_alt_text_path(@exhibit))
+    end
+  end
+end

--- a/app/helpers/spotlight/main_app_helpers.rb
+++ b/app/helpers/spotlight/main_app_helpers.rb
@@ -31,7 +31,7 @@ module Spotlight
 
     # Expecting to upstream this override in https://github.com/projectblacklight/blacklight/pull/3343/files
     def document_presenter(document, view_config: nil, **kwargs)
-      (view_config&.document_presenter_class || document_presenter_class(document)).new(document, self, view_config: view_config, **kwargs)
+      (view_config&.document_presenter_class || document_presenter_class(document)).new(document, self, view_config:, **kwargs)
     end
 
     def document_presenter_class(_document)

--- a/app/helpers/spotlight/title_helper.rb
+++ b/app/helpers/spotlight/title_helper.rb
@@ -8,6 +8,10 @@ module Spotlight
       page_title t(:'spotlight.curation.header'), title
     end
 
+    def accessibility_page_title(title = nil)
+      page_title t(:'spotlight.accessibility.header'), title
+    end
+
     def configuration_page_title(title = nil)
       page_title t(:'spotlight.configuration.header'), title
     end

--- a/app/javascript/spotlight/admin/blocks/resources_block.js
+++ b/app/javascript/spotlight/admin/blocks/resources_block.js
@@ -8,18 +8,16 @@ Core.Block.Resources = (function(){
     formable: true,
     autocompleteable: true,
     show_heading: true,
-    show_alt_text: true,
-
     title: function() { return i18n.t("blocks:" + this.type + ":title"); },
     description: function() { return i18n.t("blocks:" + this.type + ":description"); },
-    alt_text_guidelines: function() { 
-      if (this.show_alt_text) {
+    alt_text_guidelines: function() {
+      if (this.showAltText()) {
         return i18n.t("blocks:alt_text_guidelines:intro"); 
       }
       return "";
     },
     alt_text_guidelines_link: function() {
-      if (this.show_alt_text) {
+      if (this.showAltText()) {
         var link_url = i18n.t("blocks:alt_text_guidelines:link_url");
         var link_label = i18n.t("blocks:alt_text_guidelines:link_label");
         return '<a target="_blank" href="' + link_url + '">' +  link_label + '</a>'; 
@@ -45,10 +43,21 @@ Core.Block.Resources = (function(){
     },
 
     _altTextFieldsHTML: function(index, data) {
-      if (this.show_alt_text) {
+      if (this.showAltText()) {
         return this.altTextHTML(index, data);
       }
       return "";
+    },
+
+    showAltText: function() {
+      return this.editorOptions.altTextSettings[this._typeAsCamelCase()]
+    },
+
+    _typeAsCamelCase: function() {
+      return this.type
+          .split('_')
+          .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+          .join('');
     },
 
     _itemPanel: function(data) {
@@ -188,7 +197,7 @@ Core.Block.Resources = (function(){
     },
 
     attachAltTextHandlers: function(panel) {
-      if (this.show_alt_text) {
+      if (this.showAltText()) {
         const decorativeCheckbox = $('input[name$="[decorative]"]', panel);
         const altTextInput = $('textarea[name$="[alt_text]"]', panel);
         const altTextBackupInput = $('input[name$="[alt_text_backup]"]', panel);

--- a/app/javascript/spotlight/admin/blocks/solr_documents_embed_block.js
+++ b/app/javascript/spotlight/admin/blocks/solr_documents_embed_block.js
@@ -4,7 +4,6 @@ SirTrevor.Blocks.SolrDocumentsEmbed = (function(){
 
   return SirTrevor.Blocks.SolrDocumentsBase.extend({
     type: "solr_documents_embed",
-    show_alt_text: false,
     icon_name: "item_embed",
 
     item_options: function() { return "" },

--- a/app/javascript/spotlight/admin/pages.js
+++ b/app/javascript/spotlight/admin/pages.js
@@ -25,6 +25,7 @@ export default class {
       var editor = new SirTrevor.Editor({
         el: instance[0],
         blockTypes: instance.data('blockTypes'),
+        altTextSettings: instance.data('altTextSettings'),
         defaultType:["Text"],
         onEditorRender: function() {
           $.SerializedForm();

--- a/app/models/sir_trevor_rails/block.rb
+++ b/app/models/sir_trevor_rails/block.rb
@@ -18,10 +18,22 @@ module SirTrevorRails
       send(:[], :format).present? ? send(:[], :format).to_sym : DEFAULT_FORMAT
     end
 
+    def alt_text?
+      self.class.alt_text?
+    end
+
+    def self.alt_text?
+      false
+    end
+
     # Sets a list of custom block types to speed up lookup at runtime.
     def self.custom_block_types
       # You can define your custom block types directly here or in your engine config.
       Spotlight::Engine.config.sir_trevor_widgets
+    end
+
+    def self.custom_block_type_alt_text_settings
+      custom_block_types.index_with { |block_type| SirTrevorRails::Block.block_class(block_type).alt_text? }
     end
 
     def initialize(hash, parent)

--- a/app/models/sir_trevor_rails/blocks/solr_documents_block.rb
+++ b/app/models/sir_trevor_rails/blocks/solr_documents_block.rb
@@ -13,6 +13,10 @@ module SirTrevorRails
         @solr_helper = solr_helper
       end
 
+      def self.alt_text?
+        true
+      end
+
       def each_document
         return to_enum(:each_document) unless block_given?
 

--- a/app/models/sir_trevor_rails/blocks/solr_documents_embed_block.rb
+++ b/app/models/sir_trevor_rails/blocks/solr_documents_embed_block.rb
@@ -5,6 +5,9 @@ module SirTrevorRails
     ##
     # Embed documents (using a special blacklight view configuration) and text block
     class SolrDocumentsEmbedBlock < SirTrevorRails::Blocks::SolrDocumentsBlock
+      def self.alt_text?
+        false
+      end
     end
   end
 end

--- a/app/models/sir_trevor_rails/blocks/uploaded_items_block.rb
+++ b/app/models/sir_trevor_rails/blocks/uploaded_items_block.rb
@@ -12,6 +12,10 @@ module SirTrevorRails
         (item || {}).map { |_, file| file }.select { |file| file[:display].to_s == 'true' }
       end
 
+      def self.alt_text?
+        true
+      end
+
       def zpr_link?
         zpr_link == 'true'
       end

--- a/app/views/spotlight/accessibility/alt_text.html.erb
+++ b/app/views/spotlight/accessibility/alt_text.html.erb
@@ -1,0 +1,64 @@
+<% content_for(:sidebar) do %>
+  <%= render 'spotlight/shared/exhibit_sidebar' %>
+<% end %>
+
+<%= accessibility_page_title t(:".header") %>
+
+<p>
+  <%= t(:'.total_items', has_alt_text: @has_alt_text, total_alt_items: @total_alt_items).html_safe %>
+</p>
+
+<p>
+  <%= t(:'.note') %>
+</p>
+<table class="table table-striped">
+  <thead>
+    <tr class="d-flex">
+      <th class="col-6">
+        <%= t :'.table.page_title' %>
+      </th>
+      <th class="col-3">
+        <%= t :'.table.has_alt_text' %>
+      </th>
+      <th class="col-3">
+        <%= t :'.table.can_have_alt_text' %>
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @pages.each do | page_dict | %>
+      <% page = page_dict[:page] %>
+      <tr class="d-flex">
+        <td class="col-6">
+          <h4 class="h5 mb-0">
+            <%= page.title %>
+            <span class="alt-text-status">
+              <% if page_dict[:has_alt_text]/page_dict[:can_have_alt_text] == 1 %>
+                <svg xmlns="http://www.w3.org/2000/svg" width="20px" height="20px" fill="var(--bs-success)" class="bi bi-check-circle-fill">
+                  <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0m-3.97-3.03a.75.75 0 0 0-1.08.022L7.477 9.417 5.384 7.323a.75.75 0 0 0-1.06 1.06L6.97 11.03a.75.75 0 0 0 1.079-.02l3.992-4.99a.75.75 0 0 0-.01-1.05z"/>
+                </svg>
+              <% else %>
+              <svg xmlns="http://www.w3.org/2000/svg" width="20px" height="20px" fill="var(--bs-warning)" class="bi bi-exclamation-triangle-fill">
+                  <path d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5m.002 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2"/>
+                </svg>
+              <% end %>
+            </span>
+          </h4>
+          <%= render Spotlight::EditViewLinksComponent.new(page:, classes:'page-links pt-0') %>
+        </td>
+        <td class="col-3">
+          <%= page_dict[:has_alt_text] %>
+        </td>
+        <td class="col-3">
+          <%= page_dict[:can_have_alt_text] %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<% unless params[:show_all] || @pages.length < @limit %>
+  <%= link_to '?show_all=true', class: 'ml-3' do %>
+    Show all<%= blacklight_icon('chevron_right') %>
+  <% end %>
+<% end %>

--- a/app/views/spotlight/dashboards/_page.html.erb
+++ b/app/views/spotlight/dashboards/_page.html.erb
@@ -1,15 +1,7 @@
 <tr class="d-flex">
   <td class="col-6">
     <h4 class="h5 mb-0"><%= page.title %></h4>
-    <div class="page-links pt-0">
-      <% if page.is_a?(Spotlight::HomePage) %>
-          <%= link_to action_default_value(page, :view), current_exhibit %> &middot;
-          <%= exhibit_edit_link page, edit_exhibit_home_page_path(page.exhibit), data: { turbolinks: false, turbo: false } %>
-      <% else %>
-        <%= exhibit_view_link page %> &middot;
-        <%= exhibit_edit_link page, data: { turbolinks: false, turbo: false } %>
-      <% end %>
-    </div>
+    <%= render Spotlight::EditViewLinksComponent.new(page:, classes: 'page-links pt-0') %>
   </td>
   <td class="col-4"><%= page.last_edited_by.to_s if page.last_edited_by %></td>
   <td class="col-2"><%= l page.updated_at, format: :long %></td>

--- a/app/views/spotlight/feature_pages/_header.html.erb
+++ b/app/views/spotlight/feature_pages/_header.html.erb
@@ -11,10 +11,7 @@
             <%= p.hidden_field :title, value: page.title , class: 'form-control form-control-sm title-field', data: {:"edit-field-target" => 'true'} %>
           </h3>
         </div>
-        <div class="page-links">
-          <%= exhibit_view_link page, exhibit_root_path(page.exhibit) %> &middot;
-          <%= exhibit_edit_link page, edit_exhibit_home_page_path(page.exhibit), data: { turbolinks: false } %>
-        </div>
+        <%= render Spotlight::EditViewLinksComponent.new(page:) %>
       </div>
     </div>
   </div>

--- a/app/views/spotlight/pages/_form.html.erb
+++ b/app/views/spotlight/pages/_form.html.erb
@@ -40,7 +40,7 @@
         </div>
         <div class="form-group mb-3">
           <%= f.label :content, class: 'sr-only visually-hidden' %>
-          <%= f.text_area_without_bootstrap :content, value: { data: f.object.content.as_json }.to_json, class: content_editor_class(f.object), data: { 'block-types': SirTrevorRails::Block.custom_block_types } %>
+          <%= f.text_area_without_bootstrap :content, value: { data: f.object.content.as_json }.to_json, class: content_editor_class(f.object), data: { 'block-types': SirTrevorRails::Block.custom_block_types, 'alt-text-settings': SirTrevorRails::Block.custom_block_type_alt_text_settings } %>
         </div>
       </div>
 

--- a/app/views/spotlight/pages/_page.html.erb
+++ b/app/views/spotlight/pages/_page.html.erb
@@ -1,11 +1,7 @@
 <% page = f.object %>
 <%= render layout: 'spotlight/shared/dd3_item', locals: { id: page.id.to_s, field: f, label: page.title, label_method: :title, enabled_method: :published } do |_, section| %>
   <% case section when :additional_options %>
-    <div class="page-links">
-      <%= exhibit_view_link page %> &middot;
-      <%= exhibit_edit_link page, data: { turbolinks: false, turbo: false } %> &middot;
-      <%= exhibit_delete_link page %>
-    </div>
+    <%= render Spotlight::EditViewLinksComponent.new(page:, delete_link: true) %>
     <%- if page.feature_page? -%>
       <%= f.hidden_field :parent_page_id, data: {property: "parent_page"} %>
     <% end %>

--- a/app/views/spotlight/shared/_exhibit_sidebar.html.erb
+++ b/app/views/spotlight/shared/_exhibit_sidebar.html.erb
@@ -4,6 +4,7 @@
   <% if current_exhibit.analytics_provider&.enabled? %>
   <%= nav_link t(:'spotlight.curation.sidebar.analytics'), spotlight.analytics_exhibit_dashboard_path(current_exhibit) %>
   <% end %>
+  <%= nav_link t(:'spotlight.accessibility.header'), exhibit_alt_text_path(@exhibit) %>
 </ul>
 <%= render 'spotlight/shared/configuration_sidebar' if can? :update, current_exhibit %>
 <%= render 'spotlight/shared/curation_sidebar' %>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -191,6 +191,16 @@ en:
         instructions: Enter details for each librarian, curator or other contact person for this exhibit. Select the contacts you want to be show in the sidebar of the about pages. Drag and drop contacts to specify the order in which they are shown in the sidebar.
       page_options:
         published: Publish
+    accessibility:
+      alt_text:
+        header: Alternative text
+        note: Items displayed via Item Embed are excluded from these totals, as it not currently possible to add alt text using this widget.
+        table:
+          can_have_alt_text: Total items on page
+          has_alt_text: Items with alt text
+          page_title: Page title
+        total_items: Of the items displayed via widgets, <b>%{has_alt_text} of %{total_alt_items}</b> have entered alt text (or a checked decorative box).
+      header: Accessibility
     admin_users:
       create:
         error: There was a problem adding the user as an exhibits adminstrator

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,6 +74,8 @@ Spotlight::Engine.routes.draw do
       get :analytics
     end
 
+    get '/accessibility/alt-text', to: 'accessibility#alt_text', as: 'alt_text'
+
     resources :resources do
       collection do
         get :monitor

--- a/spec/views/spotlight/about_pages/index.html.erb_spec.rb
+++ b/spec/views/spotlight/about_pages/index.html.erb_spec.rb
@@ -28,6 +28,7 @@ describe 'spotlight/about_pages/index.html.erb', type: :view do
     allow(view).to receive(:page_collection_name).and_return(:about_pages)
     allow(view).to receive(:update_all_exhibit_about_pages_path).and_return('/exhibit/about/update_all')
     allow(view).to receive(:exhibit_contacts_path).and_return('/exhibit/1/contacts')
+    allow(view).to receive(:exhibit_alt_text_path).and_return('/exhibit/1/alt-text')
     allow(view).to receive(:nestable_data_attributes).and_return('data-behavior="nestable"')
     allow(exhibit).to receive_messages(contacts:)
     assign(:page, Spotlight::AboutPage.new)

--- a/spec/views/spotlight/catalog/admin.html.erb_spec.rb
+++ b/spec/views/spotlight/catalog/admin.html.erb_spec.rb
@@ -10,6 +10,7 @@ describe 'spotlight/catalog/admin.html.erb', type: :view do
     allow(view).to receive(:spotlight_page_path_for).and_return(nil)
     allow(view).to receive(:current_exhibit).and_return(exhibit)
     allow(view).to receive(:new_exhibit_resource_path).and_return('')
+    allow(view).to receive(:exhibit_alt_text_path).and_return('')
     allow(view).to receive(:reindex_all_exhibit_resources_path).and_return('')
     allow(view).to receive(:monitor_exhibit_resources_path).and_return('')
     assign(:exhibit, exhibit)

--- a/spec/views/spotlight/contacts/edit.html.erb_spec.rb
+++ b/spec/views/spotlight/contacts/edit.html.erb_spec.rb
@@ -10,6 +10,7 @@ describe 'spotlight/contacts/edit.html.erb' do
   before do
     allow(view).to receive(:exhibit_contacts_path).and_return('/exhibit/1/contacts')
     allow(view).to receive(:exhibit_about_pages_path).and_return('/exhibit/admin/about')
+    allow(view).to receive(:exhibit_alt_text_path).and_return('/exhibit/1/alt-text')
     allow(view).to receive(:contact_images_path).and_return('/contact_images')
     assign(:contact, contact)
     assign(:exhibit, exhibit)

--- a/spec/views/spotlight/dashboards/analytics.html.erb_spec.rb
+++ b/spec/views/spotlight/dashboards/analytics.html.erb_spec.rb
@@ -12,7 +12,8 @@ describe 'spotlight/dashboards/analytics.html.erb', type: :view do
     allow(current_exhibit).to receive(:page_analytics).and_return(data)
     allow(current_exhibit).to receive(:analytics).and_return(data)
     allow(current_exhibit).to receive(:analytics_provider).and_return(double(Spotlight::Analytics::Ga, enabled?: enabled))
-    allow(view).to receive_messages(current_exhibit:, exhibit_root_path: '/some/path', analytics_exhibit_dashboard_path: '/some/path')
+    allow(view).to receive_messages(current_exhibit:, exhibit_root_path: '/some/path', analytics_exhibit_dashboard_path: '/some/path',
+                                    exhibit_alt_text_path: '/alt-text')
   end
 
   context 'without a configured analytics integration' do

--- a/spec/views/spotlight/exhibits/edit.html.erb_spec.rb
+++ b/spec/views/spotlight/exhibits/edit.html.erb_spec.rb
@@ -12,6 +12,7 @@ describe 'spotlight/exhibits/edit', type: :view do
       get_exhibit_path: '/',
       exhibit_filters_path: '/',
       exhibit_languages_path: '/',
+      exhibit_alt_text_path: '/',
       add_exhibit_language_dropdown_options: [],
       default_language?: true
     )

--- a/spec/views/spotlight/job_trackers/show.html.erb_spec.rb
+++ b/spec/views/spotlight/job_trackers/show.html.erb_spec.rb
@@ -9,7 +9,7 @@ describe 'spotlight/job_trackers/show', type: :view do
     assign(:exhibit, exhibit)
     assign(:job_tracker, job_tracker)
 
-    allow(view).to receive_messages(current_exhibit: exhibit)
+    allow(view).to receive_messages(current_exhibit: exhibit, exhibit_alt_text_path: '')
   end
 
   it 'displays the type of job' do

--- a/spec/views/spotlight/metadata_configurations/edit.html.erb_spec.rb
+++ b/spec/views/spotlight/metadata_configurations/edit.html.erb_spec.rb
@@ -10,6 +10,7 @@ describe 'spotlight/metadata_configurations/edit', type: :view do
       current_exhibit: exhibit,
       blacklight_config: exhibit.blacklight_configuration.blacklight_config,
       available_view_fields: { some_view_type: 1, another_view_type: 2 },
+      exhibit_alt_text_path: '/',
       select_deselect_action: nil
     )
     allow(controller).to receive(:enabled_in_spotlight_view_type_configuration?).and_return(true)

--- a/spec/views/spotlight/pages/index.html.erb_spec.rb
+++ b/spec/views/spotlight/pages/index.html.erb_spec.rb
@@ -17,6 +17,7 @@ describe 'spotlight/pages/index.html.erb', type: :view do
 
   before do
     allow(view).to receive(:page_collection_name).and_return(:feature_pages)
+    allow(view).to receive(:exhibit_alt_text_path).and_return('/')
     allow(view).to receive(:update_all_exhibit_feature_pages_path).and_return('/exhibit/features/update_all')
     assign(:page, Spotlight::FeaturePage.new)
     assign(:exhibit, exhibit)

--- a/spec/views/spotlight/resources/new.html.erb_spec.rb
+++ b/spec/views/spotlight/resources/new.html.erb_spec.rb
@@ -7,7 +7,7 @@ describe 'spotlight/resources/new.html.erb', type: :view do
   before do
     allow(view).to receive_messages(blacklight_config:)
     allow(view).to receive(:current_exhibit).and_return(exhibit)
-    allow(view).to receive_messages(current_page?: true)
+    allow(view).to receive_messages(current_page?: true, exhibit_alt_text_path: '')
     stub_template 'spotlight/shared/_curation_sidebar.html.erb' => ''
   end
 

--- a/spec/views/spotlight/roles/index.html.erb_spec.rb
+++ b/spec/views/spotlight/roles/index.html.erb_spec.rb
@@ -8,6 +8,7 @@ describe 'spotlight/roles/index', type: :view do
 
   before do
     assign(:exhibit, exhibit)
+    allow(view).to receive(:exhibit_alt_text_path).and_return('/')
     allow(view).to receive(:current_exhibit).and_return(exhibit)
     allow(exhibit).to receive(:roles).and_return roles
   end

--- a/spec/views/spotlight/searches/edit.html.erb_spec.rb
+++ b/spec/views/spotlight/searches/edit.html.erb_spec.rb
@@ -19,6 +19,7 @@ describe 'spotlight/searches/edit.html.erb', type: :view do
     allow(view).to receive(:featured_images_path).and_return('/featured_images')
     allow(view).to receive(:exhibit_search_path).and_return('/search')
     allow(view).to receive(:exhibit_searches_path).and_return('/searches')
+    allow(view).to receive(:exhibit_alt_text_path).and_return('/alt-text')
     allow(view).to receive(:blacklight_config).and_return(blacklight_config)
     allow(controller).to receive(:search_state_class).and_return(Blacklight::SearchState)
 

--- a/spec/views/spotlight/searches/index.html.erb_spec.rb
+++ b/spec/views/spotlight/searches/index.html.erb_spec.rb
@@ -4,7 +4,7 @@ describe 'spotlight/searches/index.html.erb', type: :view do
   let(:exhibit) { stub_model(Spotlight::Exhibit) }
 
   before do
-    allow(view).to receive_messages(update_all_exhibit_searches_path: '/')
+    allow(view).to receive_messages(update_all_exhibit_searches_path: '/', exhibit_alt_text_path: '/')
     allow(view).to receive(:current_exhibit).and_return(exhibit)
     assign(:exhibit, exhibit)
   end

--- a/spec/views/spotlight/shared/_exhibit_sidebar.html.erb_spec.rb
+++ b/spec/views/spotlight/shared/_exhibit_sidebar.html.erb_spec.rb
@@ -4,7 +4,7 @@ describe 'spotlight/shared/_exhibit_sidebar', type: :view do
   let(:current_exhibit) { FactoryBot.create(:exhibit) }
 
   before do
-    allow(view).to receive_messages(current_exhibit:, exhibit_root_path: '/some/path')
+    allow(view).to receive_messages(current_exhibit:, exhibit_root_path: '/some/path', exhibit_alt_text_path: '/some/path')
   end
 
   context 'with a configured analytics integration' do

--- a/spec/views/spotlight/tags/index.html.erb_spec.rb
+++ b/spec/views/spotlight/tags/index.html.erb_spec.rb
@@ -11,7 +11,7 @@ describe 'spotlight/tags/index.html.erb', type: :view do
     allow(view).to receive_messages(exhibit_tag_path: '/tags')
     allow(view).to receive(:current_exhibit).and_return(exhibit)
     allow(view).to receive(:url_to_tag_facet, &:first)
-    allow(view).to receive_messages(update_all_exhibit_tags_path: '/update_all')
+    allow(view).to receive_messages(update_all_exhibit_tags_path: '/update_all', exhibit_alt_text_path: '/alt-text')
     allow(view).to receive(:exhibit_path)
   end
 


### PR DESCRIPTION
part of https://github.com/sul-dlss/exhibits/issues/2628

<img width="1068" alt="Screenshot 2024-11-14 at 7 59 52 PM" src="https://github.com/user-attachments/assets/46168b3a-06c4-4e87-bf0c-1c873e95e270">


<img width="1175" alt="Screenshot 2024-11-14 at 7 59 25 PM" src="https://github.com/user-attachments/assets/bfe604d1-a3f6-44dd-b929-246333434014">

Small updates done so it now has icons and sorts differently than above but everything else looks the same.

![Screenshot 2024-11-21 at 2 20 12 PM](https://github.com/user-attachments/assets/a5359849-acf8-427a-9f82-f2243663d382)

