### PR TITLE
fix blacklight version check

### DIFF
--- a/app/controllers/spotlight/catalog_controller.rb
+++ b/app/controllers/spotlight/catalog_controller.rb
@@ -26,8 +26,8 @@ module Spotlight
     before_action only: :show do
       # Substitute the default document component with the custom one for Blacklight 8,
       # and add the necessary partials for Blacklight 7 (if they haven't configured the document component)
-      if blacklight_config.show.document_component.nil? || blacklight_config.show.document_component == Blacklight::DocumentComponent
-        if Blacklight::VERSION > '8'
+      if blacklight_config.show.document_component.nil? || blacklight_config.show.document_component.to_s == 'Blacklight::DocumentComponent'
+        if Blacklight::VERSION.to_i > 7
           blacklight_config.show.document_component = Spotlight::DocumentComponent
         else
           blacklight_config.show.partials.unshift 'tophat'


### PR DESCRIPTION
Blacklight::VERSION returns "8.6.1"


For some reason I could not figure out blacklight_config.show.document_component == Blacklight::DocumentComponent wouldn't work. The classes wouldn't line up correctly.