### PR TITLE
update content_for check when annotate_rendered_view_with_filenames i…

### DIFF
--- a/app/helpers/spotlight/application_helper.rb
+++ b/app/helpers/spotlight/application_helper.rb
@@ -30,6 +30,13 @@ module Spotlight
       current_site.title.presence
     end
 
+    def content?(field)
+      return content_for?(field) unless Rails.configuration.action_view.annotate_rendered_view_with_filenames
+
+      stripped_content = content_for(field).gsub(/<!-- BEGIN .+? -->/, '').gsub(/<!-- END .+? -->/, '').strip
+      stripped_content.present?
+    end
+
     # Returns the url for the current page in the new locale. This may be
     # overridden in downstream applications where our naive use of `url_for`
     # is insufficient to generate the expected routes

--- a/app/views/layouts/spotlight/spotlight.html.erb
+++ b/app/views/layouts/spotlight/spotlight.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:content) do %>
-  <% if content_for? :sidebar %>
+  <% if content? :sidebar %>
     <section id="content" class="<%= main_content_classes %> <%= content_for(:content_position) || 'order-last' %>" aria-label="<%= t('blacklight.search.search_results') %>">
       <%= yield %>
     </section>

--- a/spec/features/confirm_email_spec.rb
+++ b/spec/features/confirm_email_spec.rb
@@ -5,6 +5,10 @@ describe 'Confirming an email', type: :feature do
   let(:contact_email) { Spotlight::ContactEmail.create!(email: 'justin@example.com', exhibit:) }
   let(:raw_token) { contact_email.instance_variable_get(:@raw_confirmation_token) }
 
+  before do
+    allow_any_instance_of(ApplicationHelper).to receive(:content?).and_return(true)
+  end
+
   it 'resends confirmation instructions' do
     visit spotlight.new_contact_email_confirmation_url(confirmation_token: contact_email.confirmation_token)
     expect(page).to have_content('Resend confirmation instructions')

--- a/spec/views/spotlight/pages/show.html.erb_spec.rb
+++ b/spec/views/spotlight/pages/show.html.erb_spec.rb
@@ -46,6 +46,7 @@ describe 'spotlight/pages/show', type: :view do
       stub_template 'shared/_user_util_links.html.erb' => ''
       stub_template 'shared/_masthead.html.erb' => ''
       allow(view).to receive_messages(document_presenter: presenter, action_name: 'show', blacklight_config:)
+      allow(view).to receive(:content?).and_return(true)
       allow(view).to receive(:search_action_url).and_return('/catalog')
       render template: 'spotlight/pages/show', layout: 'layouts/spotlight/spotlight'
     end


### PR DESCRIPTION
…s enabled

content_for?(:sidebar) returns true because the content is <!--BEGIN file --><!--END file -->

closes #3261 