### PR TITLE
fix breadcrumbs for polymorphic paths

### DIFF
--- a/app/components/spotlight/breadcrumbs_component.rb
+++ b/app/components/spotlight/breadcrumbs_component.rb
@@ -15,9 +15,7 @@ module Spotlight
     end
 
     def path(path)
-      return path unless path.instance_of?(::Spotlight::Exhibit)
-
-      helpers.exhibit_path(path)
+      helpers.url_for(path)
     end
   end
 end


### PR DESCRIPTION

closes https://github.com/sul-dlss/exhibits/issues/2638

Fix was due to me using the wrong way to compute path. I looked at how breadcrumb_rails did this and updated it to use the else in here: https://github.com/weppos/breadcrumbs_on_rails/blob/4e74436c0f3f5cdc16d05de92b67d97a45ba545a/lib/breadcrumbs_on_rails/breadcrumbs.rb#L56C7-L65C10. From what I can tell spotlight isn't using Proc or Symbols so I don't think we need to add it back in.