### PR TITLE
fix error if field does not have content

### DIFF
--- a/app/helpers/spotlight/application_helper.rb
+++ b/app/helpers/spotlight/application_helper.rb
@@ -33,7 +33,7 @@ module Spotlight
     def content?(field)
       return content_for?(field) unless Rails.configuration.action_view.annotate_rendered_view_with_filenames
 
-      stripped_content = content_for(field).gsub(/<!-- BEGIN .+? -->/, '').gsub(/<!-- END .+? -->/, '').strip
+      stripped_content = content_for(field)&.gsub(/<!-- BEGIN .+? -->/, '')&.gsub(/<!-- END .+? -->/, '')&.strip
       stripped_content.present?
     end
 

--- a/app/helpers/spotlight/application_helper.rb
+++ b/app/helpers/spotlight/application_helper.rb
@@ -31,9 +31,9 @@ module Spotlight
     end
 
     def content?(field)
-      return content_for?(field) unless Rails.configuration.action_view.annotate_rendered_view_with_filenames
+      return content_for?(field) unless Rails.configuration.action_view.annotate_rendered_view_with_filenames && content_for(field).present?
 
-      stripped_content = content_for(field)&.gsub(/<!-- BEGIN .+? -->/, '')&.gsub(/<!-- END .+? -->/, '')&.strip
+      stripped_content = content_for(field).gsub(/<!-- BEGIN .+? -->/, '').gsub(/<!-- END .+? -->/, '').strip
       stripped_content.present?
     end
 


### PR DESCRIPTION
The line in "content?" which strips out comment lines was throwing an error for me locally when I set up a test exhibit and clicked the edit button on the home page of the exhibit. 

This fix prevents an error being thrown if the field content is empty/nil. (Better solutions may exist).