### PR TITLE
Add bootstrap 5 markup to tag form

### DIFF
--- a/app/components/spotlight/tag_list_form_component.html.erb
+++ b/app/components/spotlight/tag_list_form_component.html.erb
@@ -1,5 +1,5 @@
 <% if Spotlight::Engine.config.site_tags %>
-  <div class="form-group row">
+  <div class="form-group mb-3 row">
   <label class="col-form-label col-md-2" for="tag_list">Tag list</label>
   <div class="col-md-10">
     <div class="overflow-scroll rounded border px-3 py-2 h-25" style="overflow: scroll; height: 25vh!important;">


### PR DESCRIPTION
Before:
<img width="992" alt="Screenshot 2024-11-21 at 5 08 42 PM" src="https://github.com/user-attachments/assets/ca78cf40-1fab-4ca5-9bb4-d090bdcf0889">

After:
<img width="1020" alt="Screenshot 2024-11-21 at 5 08 14 PM" src="https://github.com/user-attachments/assets/3e522ef2-41f7-4d4d-b932-b32de9e967af">
