### PR TITLE
Set private label text color to black

### DIFF
--- a/app/assets/stylesheets/spotlight/_mixins.scss
+++ b/app/assets/stylesheets/spotlight/_mixins.scss
@@ -14,5 +14,6 @@
     @extend .bg-warning !optional;
     content: 'Private';
     margin-left: 3px;
+    color: black;
   }
 }


### PR DESCRIPTION
In bootstrap 5 the text is white without sufficient contrast on the yellow background.

Before:
<img width="333" alt="Screenshot 2024-11-21 at 5 23 45 PM" src="https://github.com/user-attachments/assets/c563c519-a308-4b52-aaf3-8bff62fc36a6">

After:
<img width="359" alt="Screenshot 2024-11-21 at 5 23 31 PM" src="https://github.com/user-attachments/assets/1784bdec-68ad-4f71-a9b0-839e45385f05">
