### PR TITLE
Set items-block class on uploadeditems block widget so layout is correct in Bootstrap 5

### DIFF
--- a/app/views/spotlight/sir_trevor/blocks/_uploaded_items_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_uploaded_items_block.html.erb
@@ -1,5 +1,5 @@
-<div class="content-block item-text row d-block clearfix">
-  <div class="items-col spotlight-flexbox <%= 'col-md-6' if uploaded_items_block.text? %> col-12 <%= uploaded_items_block.content_align == 'right'  ? 'float-right float-end' : 'float-left float-start'  %> uploaded-items-block">
+<div class="content-block items-block item-text row d-block clearfix">
+  <div class="items-col spotlight-flexbox <%= uploaded_items_block.text? ? "col-md-6" : "col-md-12" %> <%= uploaded_items_block.content_align == 'right'  ? 'float-right float-end' : 'float-left float-start' %> uploaded-items-block">
     <% if uploaded_items_block.files.present? %>
       <% uploaded_items_block.files.each do |file| %>
         <div class="box" data-id="<%= file[:id] %>">


### PR DESCRIPTION
Text and image should be able to be placed on the left or right side and the text should wrap around the image.

Before
<img width="670" alt="Screenshot 2024-11-21 at 5 38 44 PM" src="https://github.com/user-attachments/assets/abd20571-f643-419e-a699-ab43d8849b7b">
<img width="356" alt="Screenshot 2024-11-21 at 5 38 53 PM" src="https://github.com/user-attachments/assets/fc534f46-a669-4896-961a-61ca8dc62bc1">
After
<img width="674" alt="Screenshot 2024-11-21 at 5 40 22 PM" src="https://github.com/user-attachments/assets/724d2a90-ec19-4370-9f7d-aa5d2faea86b">
<img width="687" alt="Screenshot 2024-11-21 at 5 40 27 PM" src="https://github.com/user-attachments/assets/c914b955-a28a-4fa6-ab82-18d419519b69">
