### PR TITLE
fix published label alignment, remove second label for checkbox

### DIFF
--- a/app/views/spotlight/exhibits/_form.html.erb
+++ b/app/views/spotlight/exhibits/_form.html.erb
@@ -11,8 +11,8 @@
     <button id='another-email' class="btn btn-sm btn-info"><%= t('.add_contact_email_button') %></button>
     <div class="form-text text-muted mb-3"><%= t(:'.fields.contact_emails.help_block') %></div>
   <% end %>
-  <%= f.form_group :published, label: { text: nil, class: 'pt-0' }, help: nil do %>
-    <%= f.check_box :published, label: "" %>
+  <%= f.form_group :published, label: { class: 'pt-0 col-md-2 col-form-label' }, help: nil do %>
+    <%= f.check_box_without_bootstrap :published %>
     <div class="form-text text-muted mb-3"><%= t(:'.fields.published.help_block') %></div>
   <% end %>
 

--- a/app/views/spotlight/searches/_form.html.erb
+++ b/app/views/spotlight/searches/_form.html.erb
@@ -35,8 +35,8 @@
         <%= f.text_field :title, control_col: "col-sm-5" %>
         <%= f.text_field :subtitle, control_col: "col-sm-5" %>
         <%= f.text_area :long_description, rows: 5 %>
-        <%= f.form_group :search_box, label: { text: t(:'.search_box.label'), class: 'pt-0' }, help: t(:'.search_box.help_block') do %>
-          <%= f.check_box :search_box, label: t(:'.search_box.checkbox_label') %>
+        <%= f.form_group :search_box, label: { text: t(:'.search_box.label'), class: 'pt-0 col-md-2 col-sm-2 col-form-label' }, help: t(:'.search_box.help_block') do %>
+          <%= f.check_box_without_bootstrap :search_box %>
         <% end %>
         <%= f.form_group label: { text: t(:".default_index_view_type"), class: 'pt-0' } do %>
           <% available_document_index_views.each do |key, view| %>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -899,9 +899,8 @@ en:
           help_secondary: To create a browse category-specific masthead, you should use an image that is at least 120 pixels tall and 1200 pixels wide. For best results use an image at least 1800 pixels wide. You can crop larger images using the cropping tool below.
         query_params: Search parameters
         search_box:
-          checkbox_label: Display
           help_block: Displays a search box that enables users to search within the browse category results
-          label: Search box
+          label: Display search box
         search_description: Description
         search_group: Group
         search_masthead: Masthead

--- a/spec/features/browse_category_admin_spec.rb
+++ b/spec/features/browse_category_admin_spec.rb
@@ -129,7 +129,7 @@ describe 'Browse Category Administration', type: :feature do
       visit spotlight.edit_exhibit_search_path exhibit, search
       expect(search.search_box).to eq false
 
-      check 'Search box'
+      check 'Display search box'
 
       click_button 'Save changes'
       expect(page).to have_content('The browse category was successfully updated.')


### PR DESCRIPTION
Second label is an accessibility issue for screen readers.

closes #3271 
![Screenshot 2024-11-22 at 12 52 28 PM](https://github.com/user-attachments/assets/f91f2b6e-7bd1-40f8-b7f4-c394865204bb)
![Screenshot 2024-11-22 at 12 52 22 PM](https://github.com/user-attachments/assets/3ee0f64b-7efe-4699-b33b-d5d36d9071eb)
