### PR TITLE
Backport: Add bootstrap 5 markup to tag form

### DIFF
--- a/app/components/spotlight/tag_list_form_component.html.erb
+++ b/app/components/spotlight/tag_list_form_component.html.erb
@@ -1,5 +1,5 @@
 <% if Spotlight::Engine.config.site_tags %>
-  <div class="form-group row">
+  <div class="form-group mb-3 row">
   <label class="col-form-label col-md-2" for="tag_list">Tag list</label>
   <div class="col-md-10">
     <div class="overflow-scroll rounded border px-3 py-2 h-25" style="overflow: scroll; height: 25vh!important;">


### PR DESCRIPTION
Backport of https://github.com/projectblacklight/spotlight/pull/3275 to release 4.x