### PR TITLE
Fix edit browse category radio button form layout for BS5

### DIFF
--- a/app/views/spotlight/searches/_form.html.erb
+++ b/app/views/spotlight/searches/_form.html.erb
@@ -38,7 +38,7 @@
         <%= f.form_group :search_box, label: { text: t(:'.search_box.label'), class: 'pt-0 col-md-2 col-sm-2 col-form-label' }, help: t(:'.search_box.help_block') do %>
           <%= f.check_box_without_bootstrap :search_box %>
         <% end %>
-        <%= f.form_group label: { text: t(:".default_index_view_type"), class: 'pt-0' } do %>
+        <%= f.form_group label: { text: t(:".default_index_view_type") } do %>
           <% available_document_index_views.each do |key, view| %>
             <%= f.radio_button :default_index_view_type, key, label: view.display_label %>
           <% end %>


### PR DESCRIPTION
Before:
<img width="747" alt="Screenshot 2024-11-22 at 4 54 53 PM" src="https://github.com/user-attachments/assets/2a00184f-da02-4d8f-8f8e-38340b4264f1">

After:
<img width="740" alt="Screenshot 2024-11-22 at 4 54 21 PM" src="https://github.com/user-attachments/assets/fd085e91-5195-4a70-b2dd-6e84d331e4d9">
