### PR TITLE
Set width auto on uploaded item text block so it wraps around images.…

### DIFF
--- a/app/views/spotlight/sir_trevor/blocks/_uploaded_items_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_uploaded_items_block.html.erb
@@ -1,4 +1,4 @@
-<div class="content-block items-block item-text row d-block clearfix">
+<div class="content-block item-text row d-block clearfix">
   <div class="items-col spotlight-flexbox <%= uploaded_items_block.text? ? "col-md-6" : "col-md-12" %> <%= uploaded_items_block.content_align == 'right'  ? 'float-right float-end' : 'float-left float-start' %> uploaded-items-block">
     <% if uploaded_items_block.files.present? %>
       <% uploaded_items_block.files.each do |file| %>
@@ -28,7 +28,7 @@
   </div>
 
   <% if uploaded_items_block.text? %>
-    <div class="text-col col-md-6 mw-100">
+    <div class="text-col col-md-6 mw-100 w-auto">
       <%= content_tag(:h3, uploaded_items_block.title) if uploaded_items_block.title.present? %>
       <%= sir_trevor_markdown uploaded_items_block.text %>
     </div>


### PR DESCRIPTION
… Remove items-block class that adds unwanted CSS.

Before:
<img width="1062" alt="Screenshot 2024-11-25 at 9 18 02 AM" src="https://github.com/user-attachments/assets/3eeb7817-21b9-44d6-9997-f935f2bf4786">

After:
<img width="1050" alt="Screenshot 2024-11-25 at 9 17 44 AM" src="https://github.com/user-attachments/assets/8be7a7d8-47ed-4878-8d8d-dd7cd51c233b">
