### PR TITLE
Namespace reference to exhibit_alt_text_path

### DIFF
--- a/app/views/spotlight/shared/_exhibit_sidebar.html.erb
+++ b/app/views/spotlight/shared/_exhibit_sidebar.html.erb
@@ -4,7 +4,7 @@
   <% if current_exhibit.analytics_provider&.enabled? %>
   <%= nav_link t(:'spotlight.curation.sidebar.analytics'), spotlight.analytics_exhibit_dashboard_path(current_exhibit) %>
   <% end %>
-  <%= nav_link t(:'spotlight.accessibility.header'), exhibit_alt_text_path(@exhibit) %>
+  <%= nav_link t(:'spotlight.accessibility.header'), spotlight.exhibit_alt_text_path(current_exhibit) %>
 </ul>
 <%= render 'spotlight/shared/configuration_sidebar' if can? :update, current_exhibit %>
 <%= render 'spotlight/shared/curation_sidebar' %>

--- a/spec/views/spotlight/dashboards/analytics.html.erb_spec.rb
+++ b/spec/views/spotlight/dashboards/analytics.html.erb_spec.rb
@@ -12,8 +12,7 @@ describe 'spotlight/dashboards/analytics.html.erb', type: :view do
     allow(current_exhibit).to receive(:page_analytics).and_return(data)
     allow(current_exhibit).to receive(:analytics).and_return(data)
     allow(current_exhibit).to receive(:analytics_provider).and_return(double(Spotlight::Analytics::Ga, enabled?: enabled))
-    allow(view).to receive_messages(current_exhibit:, exhibit_root_path: '/some/path', analytics_exhibit_dashboard_path: '/some/path',
-                                    exhibit_alt_text_path: '/alt-text')
+    allow(view).to receive_messages(current_exhibit:, exhibit_root_path: '/some/path', analytics_exhibit_dashboard_path: '/some/path')
   end
 
   context 'without a configured analytics integration' do


### PR DESCRIPTION
Fixes an error in our exhibits app that has its own admin templates that render the sidebar:

```
tionView::Template::Error (undefined method `exhibit_alt_text_path' for #<ActionView::Base:0x0000000011f2d8>):

Causes:
NoMethodError (undefined method `exhibit_alt_text_path' for #<ActionView::Base:0x0000000011f2d8>)
    4:   <% if current_exhibit.analytics_provider&.enabled? %>
    5:   <%= nav_link t(:'spotlight.curation.sidebar.analytics'), spotlight.analytics_exhibit_dashboard_path(current_exhibit) %>
    6:   <% end %>
    7:   <%= nav_link t(:'spotlight.accessibility.header'), exhibit_alt_text_path(@exhibit) %>
    8: </ul>
    9: <%= render 'spotlight/shared/configuration_sidebar' if can? :update, current_exhibit %>
   10: <%= render 'spotlight/shared/curation_sidebar' %>
  
app/views/viewers/edit.html.erb:2
app/views/viewers/edit.html.erb:1
```