### PR TITLE
allow for no items, no alt_text in model

### DIFF
--- a/app/controllers/spotlight/accessibility_controller.rb
+++ b/app/controllers/spotlight/accessibility_controller.rb
@@ -31,13 +31,12 @@ module Spotlight
       has_alt_text = 0
       page.content.each do |content|
         content.item&.each_value do |item|
-          next if item['alt_text_backup'].nil?
-
           can_have_alt_text += 1
           has_alt_text += 1 if item['alt_text'].present? || item['decorative'].present?
         end
       end
-      { can_have_alt_text:, has_alt_text:, page: }
+      complete = can_have_alt_text.zero? || has_alt_text / can_have_alt_text == 1
+      { can_have_alt_text:, has_alt_text:, page:, status: has_alt_text, complete: }
     end
 
     def attach_alt_text_breadcrumbs

--- a/app/views/spotlight/accessibility/alt_text.html.erb
+++ b/app/views/spotlight/accessibility/alt_text.html.erb
@@ -33,7 +33,7 @@
           <h4 class="h5 mb-0">
             <%= page.title %>
             <span class="alt-text-status">
-              <% if page_dict[:has_alt_text]/page_dict[:can_have_alt_text] == 1 %>
+              <% if page_dict[:complete] %>
                 <svg xmlns="http://www.w3.org/2000/svg" width="20px" height="20px" fill="var(--bs-success)" class="bi bi-check-circle-fill">
                   <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0m-3.97-3.03a.75.75 0 0 0-1.08.022L7.477 9.417 5.384 7.323a.75.75 0 0 0-1.06 1.06L6.97 11.03a.75.75 0 0 0 1.079-.02l3.992-4.99a.75.75 0 0 0-.01-1.05z"/>
                 </svg>


### PR DESCRIPTION
closes https://github.com/sul-dlss/exhibits/issues/2656

To recreate, create a feature page. Add an item row widget. Save without adding an item. This means there will be zero items that can have alt text. 

Also for old instances of spotlight, the alt_text fields don't exist. Also the line ```next if item['alt_text_backup'].nil?``` is not necessary anymore since we are using the model to determine which fields can have alt text (this is leftover from a different approach).