### PR TITLE
backport: Change wrapping tag on honeypot field

### DIFF
--- a/app/views/spotlight/shared/_honeypot_field.html.erb
+++ b/app/views/spotlight/shared/_honeypot_field.html.erb
@@ -1,4 +1,4 @@
-<span style="display:none;visibility:hidden;">
+<div style="display:none;visibility:hidden;">
   <% honeypot_field_name = Spotlight::Engine.config.spambot_honeypot_email_field %>
   <%= f.email_field honeypot_field_name, label: t(:'spotlight.shared.report_a_problem.honeypot_field_explanation') %>
-</span>
+</div>


### PR DESCRIPTION
Fixes one instance of "Element div not allowed as child of element span in this context."