### PR TITLE
make input-group-append work with bs4 and bs5

### DIFF
--- a/app/views/spotlight/bulk_updates/_upload.html.erb
+++ b/app/views/spotlight/bulk_updates/_upload.html.erb
@@ -9,7 +9,7 @@
       <div class="input-group">
         <%= file_field_tag :file, class: 'form-control', accept: '.csv,text/csv', 'aria-described-by': 'bulk-update-form-help' %>
         <div class="input-group-append">
-          <%= f.submit t('.submit'), class: 'btn btn-primary' %>
+          <%= f.submit t('.submit'), class: 'btn btn-primary rounded-0 rounded-end' %>
         </div>
       </div>
     </div>

--- a/app/views/spotlight/translations/_import.html.erb
+++ b/app/views/spotlight/translations/_import.html.erb
@@ -14,7 +14,7 @@
                 <%= file_field_tag :file, class: 'form-control' %>
                 <%= hidden_field_tag :tab, 'import', id: nil %>
                 <div class="input-group-append">
-                  <%= f.submit t(:'.import_submit'), class: 'btn btn-primary' %>
+                  <%= f.submit t(:'.import_submit'), class: 'btn btn-primary rounded-0 rounded-end' %>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
closes #3300 

To work only with bs5 we can remove `<div class="input-group-append">`.