### PR TITLE
Update generators to handle Blacklight 8.7.0

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -44,7 +44,7 @@ jobs:
       RAILS_VERSION: ${{ matrix.rails_version }}
       BLACKLIGHT_VERSION: ${{ matrix.blacklight_version }}
       BOOTSTRAP_VERSION: ${{ matrix.bootstrap_version }}
-      ENGINE_CART_RAILS_OPTIONS: "--skip-git --skip-listen --skip-spring --skip-keeps --skip-coffee --skip-test ${{ matrix.additional_engine_cart_rails_options }}"
+      ENGINE_CART_RAILS_OPTIONS: "--skip-git --skip-listen --skip-spring --skip-keeps --skip-coffee --skip-test --css bootstrap ${{ matrix.additional_engine_cart_rails_options }}"
     steps:
       - uses: actions/checkout@v4
       # Remove these Chrome steps after https://issues.chromium.org/issues/351858989 is fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN mkdir -p /spotlight/app
 WORKDIR /spotlight/app
 
 RUN yarn add file:${SPOTLIGHT_GEM}
-RUN SKIP_TRANSLATION=yes rails _${RAILS_VERSION}_ new . -a propshaft --force --template=../engine/template.rb
+RUN SKIP_TRANSLATION=yes rails _${RAILS_VERSION}_ new . -a propshaft --css bootstrap --force --template=../engine/template.rb
 RUN SKIP_TRANSLATION=yes DB_ADAPTER=nulldb  bundle exec rake assets:precompile
 
 ENTRYPOINT ["/sbin/tini", "--", "/spotlight/engine/bin/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Read more about what Spotlight is, our motivations for creating it, and how to i
 ## Requirements
 
 1. [Ruby](https://www.ruby-lang.org/) 3.1+
-2. [Ruby on Rails](https://rubyonrails.org/) 7.x
+2. [Ruby on Rails](https://rubyonrails.org/) 7.1+
 3. Java (11 or greater) *for Solr*
 4. ImageMagick (http://www.imagemagick.org/script/index.php) due to [carrierwave](https://github.com/carrierwaveuploader/carrierwave#adding-versions)
 
@@ -19,13 +19,13 @@ Read more about what Spotlight is, our motivations for creating it, and how to i
 To bootstrap a new Rails application using [importmap-rails](https://github.com/rails/importmap-rails):
 
 ```
-$ SKIP_TRANSLATION=1 rails new app-name -m https://raw.githubusercontent.com/projectblacklight/spotlight/main/template.rb -a propshaft -j importmap
+$ SKIP_TRANSLATION=1 rails new app-name -m https://raw.githubusercontent.com/projectblacklight/spotlight/main/template.rb -a propshaft --css bootstrap
 ```
 
 or using [jsbundling-rails](https://github.com/rails/jsbundling-rails) with [esbuild](https://esbuild.github.io/):
 
 ```
-$ SKIP_TRANSLATION=1 rails new app-name -m https://raw.githubusercontent.com/projectblacklight/spotlight/main/template.rb -a propshaft -j esbuild
+$ SKIP_TRANSLATION=1 rails new app-name -m https://raw.githubusercontent.com/projectblacklight/spotlight/main/template.rb -a propshaft -j esbuild --css bootstrap
 ```
 
 or from an existing Rails application:

--- a/Rakefile
+++ b/Rakefile
@@ -34,6 +34,7 @@ require 'spotlight/version'
 rails_options = ENV.fetch('ENGINE_CART_RAILS_OPTIONS', '')
 rails_options = "#{rails_options} -a propshaft" unless rails_options.match?(/-a\s|--asset-pipeline/)
 rails_options = "#{rails_options} -j importmap" unless rails_options.match?(/-j\s|--javascript/)
+rails_options = "#{rails_options} --css bootstrap" unless rails_options.match?(/--css/)
 ENV['ENGINE_CART_RAILS_OPTIONS'] = rails_options
 
 task ci: ['engine_cart:generate'] do

--- a/blacklight-spotlight.gemspec
+++ b/blacklight-spotlight.gemspec
@@ -22,7 +22,7 @@ these collections.)
 
   s.add_dependency 'activejob-status'
   s.add_dependency 'acts-as-taggable-on', '>= 5.0', '< 12'
-  s.add_dependency 'blacklight', '~> 8.0'
+  s.add_dependency 'blacklight', '>= 8.7.0', '< 9'
   s.add_dependency 'blacklight-gallery', '>= 3.0', '< 5'
   s.add_dependency 'bootstrap_form', '>= 4.1', '< 6'
   s.add_dependency 'cancancan'
@@ -45,7 +45,7 @@ these collections.)
   s.add_dependency 'openseadragon', '>= 0.8.0'
   s.add_dependency 'ostruct', '!= 0.3.0', '!= 0.3.1', '!= 0.3.2'
   s.add_dependency 'paper_trail', '>= 11.0', '< 16'
-  s.add_dependency 'rails', '>= 7.0', '< 8'
+  s.add_dependency 'rails', '>= 7.1', '< 8'
   s.add_dependency 'redcarpet', '>= 2.0.1', '< 4'
   s.add_dependency 'riiif', '~> 2.0'
   s.add_dependency 'roar', '~> 1.1'

--- a/lib/generators/spotlight/assets/propshaft_generator.rb
+++ b/lib/generators/spotlight/assets/propshaft_generator.rb
@@ -45,14 +45,6 @@ module Spotlight
         end
       end
 
-      def install_javascript_bundler
-        rails_command 'javascript:install:esbuild'
-      end
-
-      def install_sass_bundler
-        rails_command 'css:install:sass'
-      end
-
       # Pick a version of the frontend asset package and install it.
       def add_frontend
         if ENV['CI']
@@ -76,11 +68,11 @@ module Spotlight
         copy_file 'javascript/jquery-shim.js', 'app/javascript/jquery-shim.js'
         gsub_file 'app/javascript/application.js', 'import "controllers"', '// import "controllers"'
 
+        # This may have been added from Blacklight, but it is a Spotlight dependency so ensure it is present.
+        insert_into_file 'app/javascript/application.js', "import githubAutoCompleteElement from \"@github/auto-complete-element\";\n"
+
         append_to_file 'app/javascript/application.js' do
           <<~CONTENT
-            import githubAutoCompleteElement from "@github/auto-complete-element"
-            import * as bootstrap from "bootstrap"
-            import Blacklight from "blacklight-frontend"
             import Spotlight from "spotlight-frontend"
 
             Blacklight.onLoad(function() {
@@ -92,7 +84,7 @@ module Spotlight
 
       def add_stylesheets
         copy_file 'assets/spotlight.scss', 'app/assets/stylesheets/spotlight.scss'
-        append_to_file 'app/assets/stylesheets/application.sass.scss', "\n@import \"spotlight\";\n"
+        append_to_file 'app/assets/stylesheets/application.bootstrap.scss', "\n@import \"spotlight\";\n"
       end
 
       def configure_esbuild

--- a/lib/generators/spotlight/templates/assets/spotlight.scss
+++ b/lib/generators/spotlight/templates/assets/spotlight.scss
@@ -1,14 +1,8 @@
-// Bootstrap (will use variables defined in customizations, if present)
-@import 'bootstrap/scss/bootstrap';
-@import 'spotlight-frontend/app/assets/stylesheets/spotlight/variables_bootstrap';
-
-// Blacklight, imported from blacklight-frontend package
-@import 'blacklight-frontend/app/assets/stylesheets/blacklight/blacklight';
-
 // Leaflet
 @import 'leaflet/dist/leaflet';
 
 // Spotlight, imported from spotlight-frontend package
+@import 'spotlight-frontend/app/assets/stylesheets/spotlight/variables_bootstrap';
 @import 'spotlight-frontend/vendor/assets/stylesheets/bootstrap-tagsinput';
 @import 'spotlight-frontend/vendor/assets/stylesheets/sir-trevor/main';
 @import 'spotlight-frontend/app/assets/stylesheets/spotlight/spotlight';

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -20,7 +20,6 @@ class TestAppGenerator < Rails::Generators::Base
   def add_gems
     gem 'blacklight', ENV['BLACKLIGHT_VERSION'] || '~> 8.0' unless Bundler.locked_gems.dependencies.key? 'blacklight'
     gem 'blacklight-gallery', '~> 4.5' unless Bundler.locked_gems.dependencies.key? 'blacklight-gallery'
-    gem 'cssbundling-rails' unless defined?(Sprockets)
 
     unless Bundler.locked_gems.dependencies.key? 'bootstrap_form'
       bootstrap_version = ENV.fetch('BOOTSTRAP_VERSION', '~> 5.3')
@@ -65,7 +64,7 @@ class TestAppGenerator < Rails::Generators::Base
     copy_file 'fixture.png', 'app/assets/images/spotlight/themes/modern_preview.png'
 
     copy_file 'fixture.css', 'app/assets/stylesheets/application_modern.css'
-    append_to_file 'config/initializers/assets.rb', 'Rails.application.config.assets.precompile += %w( application_modern.css )'
+    append_to_file 'config/initializers/assets.rb', "\nRails.application.config.assets.precompile += %w( application_modern.css )"
 
     append_to_file 'config/initializers/spotlight_initializer.rb', "\nSpotlight::Engine.config.exhibit_themes = %w[default modern]"
   end

--- a/template.rb
+++ b/template.rb
@@ -9,11 +9,10 @@ spotlight_options = ENV.fetch('SPOTLIGHT_INSTALL_OPTIONS', DEFAULT_SPOTLIGHT_OPT
 bootstrap_version = ENV.fetch('BOOTSTRAP_VERSION', '~> 5.3')
 
 # Add gem dependencies to the application
-gem 'blacklight', '~> 8.0'
+gem 'blacklight', '>= 8.7.0', '< 9'
 gem 'blacklight-spotlight', ENV['SPOTLIGHT_GEM'] ? { path: ENV['SPOTLIGHT_GEM'] } : { github: 'projectblacklight/spotlight' }
 gem 'sidekiq'
 gem 'bootstrap_form', /(\d)(?:\.\d){0,2}/.match(bootstrap_version)[1].to_i == 5 ? '~> 5.4' : '~> 4.5'
-gem 'cssbundling-rails' unless options[:asset_pipeline] == 'sprockets'
 
 after_bundle do
   run 'yarn init -y' unless File.exist?('package.json')


### PR DESCRIPTION
Blacklight 8.7.0 contains a backport of https://github.com/projectblacklight/blacklight/pull/3340 which alters the ordering of the install generators.

This PR:
* Removes the workarounds we had in place, waiting for that change
* Sets Blacklight 8.7.0 as the minimum required version. After a conversation with @corylown we think that's fine because no version of Spotlight v5 has been released yet.
* Moves to assuming Spotlight will be built using `--css bootstrap`
* Abandons Rails 7.0 as it handles our rails new options differently than subsequent releases 