### PR TITLE
Extract the HeaderNavigationLinkComponent

### DIFF
--- a/app/components/spotlight/header_navigation_link_component.html.erb
+++ b/app/components/spotlight/header_navigation_link_component.html.erb
@@ -1,0 +1,1 @@
+  <li class="nav-item <%= "active" if @active %>"><%= link_to @label, @path, class: 'nav-link' %></li>

--- a/app/components/spotlight/header_navigation_link_component.rb
+++ b/app/components/spotlight/header_navigation_link_component.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Spotlight
+  # This draws a navigation link in the header.
+  # A downstream application may switch out the implementation to use different styles, etc.
+  class HeaderNavigationLinkComponent < ViewComponent::Base
+    def initialize(path:, active:, label:)
+      @path = path
+      @active = active
+      @label = label
+      super
+    end
+  end
+end

--- a/app/views/shared/_about_navbar.html.erb
+++ b/app/views/shared/_about_navbar.html.erb
@@ -1,3 +1,3 @@
 <% if current_exhibit.main_about_page %>
-  <li class="nav-item <%= "active" if on_about_page? %>"><%= link_to navigation.label_or_default, [spotlight, current_exhibit, current_exhibit.main_about_page], class: 'nav-link' %></li>
+  <%= render Spotlight::Engine.config.spotlight.header_navigation_link_component.new(active: on_about_page?, label: navigation.label_or_default, path: [spotlight, current_exhibit, current_exhibit.main_about_page]) %>
 <% end %>

--- a/app/views/shared/_browse_navbar.html.erb
+++ b/app/views/shared/_browse_navbar.html.erb
@@ -1,3 +1,3 @@
 <% if current_exhibit.browse_categories? %>
-  <li class="nav-item <%= "active" if on_browse_page? %>"><%= link_to navigation.label_or_default, spotlight.exhibit_browse_index_path(current_exhibit), class: 'nav-link' %></li>
+  <%= render Spotlight::Engine.config.spotlight.header_navigation_link_component.new(active: on_browse_page?, label: navigation.label_or_default, path: spotlight.exhibit_browse_index_path(current_exhibit)) %>
 <% end %>

--- a/app/views/shared/_curated_features_navbar.html.erb
+++ b/app/views/shared/_curated_features_navbar.html.erb
@@ -10,6 +10,9 @@
       </ul>
     </li>
   <% else %>
-    <li class="nav-item <%= "active" if current_page?(url_for([spotlight, published_top_level_feature_pages.first.exhibit, published_top_level_feature_pages.first])) %>"><%= link_to published_top_level_feature_pages.first.title, [spotlight, published_top_level_feature_pages.first.exhibit, published_top_level_feature_pages.first], class: 'nav-link' %></li>
+    <%= render Spotlight::Engine.config.spotlight.header_navigation_link_component.new(active: current_page?(url_for([spotlight, published_top_level_feature_pages.first.exhibit, published_top_level_feature_pages.first])),
+                                                              label: published_top_level_feature_pages.first.title,
+                                                              path: [spotlight, published_top_level_feature_pages.first.exhibit, published_top_level_feature_pages.first]) %>
+
   <% end %>
 <% end %>

--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -188,6 +188,13 @@ module Spotlight
       end
     end
 
+    initializer 'components.initialize' do
+      ActiveSupport::Reloader.to_prepare do
+        Spotlight::Engine.config.spotlight = OpenStruct.new
+        Spotlight::Engine.config.spotlight.header_navigation_link_component = Spotlight::HeaderNavigationLinkComponent
+      end
+    end
+
     # After creating a property for your site on Google Analytics, you need to:
     # a) Enable Google Analytics API in https://console.cloud.google.com/
     # b) generate and download the JSON key and make it accessible to your application

--- a/spec/components/spotlight/header_navigation_link_component_spec.rb
+++ b/spec/components/spotlight/header_navigation_link_component_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+RSpec.describe Spotlight::HeaderNavigationLinkComponent, type: :component do
+  pending "add some examples to (or delete) #{__FILE__}"
+
+  # it "renders something useful" do
+  #   expect(
+  #     render_inline(described_class.new(attr: "value")) { "Hello, components!" }.css("p").to_html
+  #   ).to include(
+  #     "Hello, components!"
+  #   )
+  # end
+end


### PR DESCRIPTION
We will find this helpful in our app, because we can just override this component rather than have to copy 3 partials into our local app just to change some classes in the markup