### PR TITLE
Apply bootstrap classes without requiring SASS

### DIFF
--- a/app/assets/stylesheets/spotlight/_blacklight_overrides.scss
+++ b/app/assets/stylesheets/spotlight/_blacklight_overrides.scss
@@ -1,15 +1,10 @@
-.submit-search-text {
-  @extend .sr-only !optional;
-  @extend .visually-hidden !optional;
-}
-
 .search-query-form {
   z-index: 1;
 
   .input-group {
     width: 100%;
   }
-  
+
   .search-btn {
     max-height: 2.375rem;
   }

--- a/app/views/spotlight/browse/_search_box.html.erb
+++ b/app/views/spotlight/browse/_search_box.html.erb
@@ -11,7 +11,7 @@
             <%= blacklight_icon('highlight_off') %>
           </button>
           <button type="submit" class="btn btn-primary search-btn" id="browse-search">
-            <span class="submit-search-text"><%= t(:'.submit') %></span>
+            <span class="submit-search-text sr-only visually-hidden"><%= t(:'.submit') %></span>
             <%= blacklight_icon('search', aria_hidden: true) %>
           </button>
         </div>


### PR DESCRIPTION
This makes it possible to remove these classes in a downstream application if not desired.