### PR TITLE
Set imagePath for Leaflet

### DIFF
--- a/app/views/layouts/spotlight/base.html.erb
+++ b/app/views/layouts/spotlight/base.html.erb
@@ -18,6 +18,7 @@
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.serializeJSON/3.2.1/jquery.serializejson.min.js"></script>
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+    <%= javascript_tag 'L.Icon.Default.prototype.options.imagePath = "https://unpkg.com/leaflet@1.9.4/dist/images/"' %>
     <%= javascript_include_tag 'bootstrap-tagsinput', "data-turbo-track": "reload", defer: false %>
     <%= javascript_include_tag 'typeahead.bundle.min', "data-turbo-track": "reload", defer: false %>
     <%= javascript_include_tag 'leaflet-iiif', "data-turbo-track": "reload", defer: true %>


### PR DESCRIPTION
Currently none of the default Leaflet icons will resolve. Leaflet builds the paths here:

https://github.com/Leaflet/Leaflet/blob/142f94a9ba5757f7e7180ffa6cbed2b3a9bc73c9/src/layer/marker/Icon.Default.js

The image assets will be present locally in `node_modules` for the style assets, but those icon paths are built & used after the propshaft digest steps. I think it's easiest just to point at the CDN.

Looks like Geoblacklight did similar: https://github.com/geoblacklight/geoblacklight/blob/bee5ae91cfee1fba8084a6e1d9a3f05d6a0cea00/app/javascript/geoblacklight/controllers/leaflet_viewer_controller.js#L44