### PR TITLE
Remove "position: relative" from .handle-wrap to fix handle display

### DIFF
--- a/app/assets/stylesheets/spotlight/_blacklight_configuration.scss
+++ b/app/assets/stylesheets/spotlight/_blacklight_configuration.scss
@@ -11,10 +11,7 @@
       @include edit-in-place-highlighting;
     }
 
-    // the effect of position: relative on table elements is undefined, so put a div in there.
-    // this fix is for Firefox
     .handle-wrap {
-      position: relative;
       padding: 0.75rem 0.75rem 0.75rem 40px;
       margin: 0;
       margin-top: -1px;


### PR DESCRIPTION
It looks like this may have been added to work around an issue with a now 10 year old version of Firefox (https://github.com/projectblacklight/spotlight/pull/380). As far as I can tell it's no longer needed and removing it fixes a display issue when the content of the table wraps and causes the height of the row to increase.

Before:
<img width="716" alt="Screenshot 2024-12-10 at 9 05 25 AM" src="https://github.com/user-attachments/assets/871f0fa6-8d58-4259-92b3-a9f3dc89970f">

After:
<img width="720" alt="Screenshot 2024-12-10 at 9 06 21 AM" src="https://github.com/user-attachments/assets/1d4054f8-4806-4df4-9fd5-d7cd66d2b3ee">
