### PR TITLE
Increase reliability of Sir Trevor feature tests

### DIFF
--- a/spec/features/autocomplete_typeahead_spec.rb
+++ b/spec/features/autocomplete_typeahead_spec.rb
@@ -47,9 +47,11 @@ describe 'Autocomplete typeahead', js: true, type: :feature do
         # Open the multi-image selector and choose the last one
         click_link('Change')
         find('.thumbs-list li:last-child').click
+        sleep 1
         expect(page).to have_css('.leaflet-container', visible: true)
 
         click_button 'Save changes'
+        sleep 1
 
         expect(page).to have_content('The exhibit was successfully updated.')
 

--- a/spec/features/javascript/blocks/solr_documents_block_spec.rb
+++ b/spec/features/javascript/blocks/solr_documents_block_spec.rb
@@ -86,17 +86,11 @@ RSpec.describe 'Solr Document Block', default_max_wait_time: 30, feature: true, 
   it 'allows you to toggle visibility of solr documents', js: true do
     fill_in_solr_document_block_typeahead_field with: 'dq287tq6352'
 
-    # Flappy guard. Wait for the thumbnail src to be populated.
-    expect(page).to have_selector('li[data-resource-id="dq287tq6352"] .img-thumbnail[src^="http"]')
-
     within(:css, '.card') do
       uncheck 'Display?'
     end
 
     fill_in_solr_document_block_typeahead_field with: 'gk446cj2442'
-
-    # Flappy guard. Wait for the thumbnail src to be populated.
-    expect(page).to have_selector('li[data-resource-id="gk446cj2442"] .img-thumbnail[src^="http"]')
 
     # display the title as the primary caption
     within('.primary-caption') do
@@ -111,6 +105,7 @@ RSpec.describe 'Solr Document Block', default_max_wait_time: 30, feature: true, 
     expect(page).to have_no_content "L'AMERIQUE"
 
     visit spotlight.edit_exhibit_feature_page_path(exhibit, feature_page)
+    wait_for_sir_trevor
     # display the title as the primary caption
     within('.primary-caption') do
       uncheck('Primary caption')
@@ -149,9 +144,6 @@ RSpec.describe 'Solr Document Block', default_max_wait_time: 30, feature: true, 
   it 'allows you to optionally display a ZPR link with the image', js: true do
     fill_in_solr_document_block_typeahead_field with: 'gk446cj2442'
 
-    # Flappy guard. Wait for the thumbnail src to be populated.
-    expect(page).to have_selector('li[data-resource-id="gk446cj2442"] .img-thumbnail[src^="http"]')
-
     check 'Offer "View larger" option'
 
     save_page_changes
@@ -182,9 +174,6 @@ RSpec.describe 'Solr Document Block', default_max_wait_time: 30, feature: true, 
   it 'allows you to choose which side the text will be on', js: true do
     fill_in_solr_document_block_typeahead_field with: 'dq287tq6352'
 
-    # Flappy guard. Wait for the thumbnail src to be populated.
-    expect(page).to have_selector('li[data-resource-id="dq287tq6352"] .img-thumbnail[src^="http"]')
-
     # Select to align the text right
     choose 'Left'
 
@@ -211,8 +200,6 @@ RSpec.describe 'Solr Document Block', default_max_wait_time: 30, feature: true, 
 
   it 'toggles alt text input when marking an image as decorative', js: true do
     fill_in_solr_document_block_typeahead_field with: 'gk446cj2442'
-    # Flappy guard. Wait for the thumbnail src to be populated.
-    expect(page).to have_selector('li[data-resource-id="gk446cj2442"] .img-thumbnail[src^="http"]')
 
     fill_in 'Alternative text', with: 'custom alt text'
     check 'Decorative'
@@ -223,13 +210,12 @@ RSpec.describe 'Solr Document Block', default_max_wait_time: 30, feature: true, 
 
   it 'retains custom alt text after marking as decorative and saving', js: true do
     fill_in_solr_document_block_typeahead_field with: 'gk446cj2442'
-    # Flappy guard. Wait for the thumbnail src to be populated.
-    expect(page).to have_selector('li[data-resource-id="gk446cj2442"] .img-thumbnail[src^="http"]')
 
     fill_in 'Alternative text', with: 'custom alt text'
     check 'Decorative'
     save_page_changes
     click_on 'Edit'
+    wait_for_sir_trevor
     uncheck 'Decorative'
     expect(page).to have_field('Alternative text', type: 'textarea', disabled: false, with: 'custom alt text')
   end
@@ -237,17 +223,11 @@ RSpec.describe 'Solr Document Block', default_max_wait_time: 30, feature: true, 
   it 'round-trip data', js: true do
     fill_in_solr_document_block_typeahead_field with: 'dq287tq6352'
 
-    # Flappy guard. Wait for the thumbnail src to be populated.
-    expect(page).to have_selector('li[data-resource-id="dq287tq6352"] .img-thumbnail[src^="http"]')
-
     within(:css, '.card') do
       uncheck 'Display?'
     end
 
     fill_in_solr_document_block_typeahead_field with: 'gk446cj2442'
-
-    # Flappy guard. Wait for the thumbnail src to be populated.
-    expect(page).to have_selector('li[data-resource-id="gk446cj2442"] .img-thumbnail[src^="http"]')
 
     # display the title as the primary caption
     within('.primary-caption') do


### PR DESCRIPTION
This dramatically reduces or eliminates erroneous test failures surrounding Sir Trevor widgets. It does increase the time to run the tests, but I feel that's better than having to restart them 2-4 times. It does this by moving and improving some of our in-test checks/guards/sleeps to the helpers.

I think after this, there is only one major flappy test remaining (in `spec/features/javascript/edit_in_place_spec.rb`).