### PR TITLE
Backport: Downgrade theme missing message to a debug

### DIFF
--- a/app/helpers/spotlight/main_app_helpers.rb
+++ b/app/helpers/spotlight/main_app_helpers.rb
@@ -46,7 +46,7 @@ module Spotlight
       if current_exhibit_theme && current_exhibit&.theme != 'default'
         stylesheet_link_tag "#{tag}_#{current_exhibit_theme}"
       else
-        Rails.logger.warn "Exhibit theme '#{current_exhibit_theme}' not in the list of available themes: #{current_exhibit&.themes}"
+        Rails.logger.debug { "Exhibit theme '#{current_exhibit_theme}' not in the list of available themes: #{current_exhibit&.themes}" }
         stylesheet_link_tag(tag)
       end
     end


### PR DESCRIPTION
backport: https://github.com/projectblacklight/spotlight/pull/3340 to release-4.x