### PR TITLE
Backport: Extract BulkActionsComponent

### DIFF
--- a/app/components/spotlight/bulk_action_component.html.erb
+++ b/app/components/spotlight/bulk_action_component.html.erb
@@ -1,0 +1,8 @@
+<div class="dropdown bulk-actions-dropdown">
+  <%= button %>
+  <div class="dropdown-menu" aria-labelledby="bulk-actions-button">
+    <% bulk_actions.each do |key, _config| %>
+      <%= link_to t("spotlight.bulk_actions.#{key}.heading"), '#', class: 'dropdown-item', data: { toggle: "modal", "bs-toggle": "modal", target: "##{key.to_s.dasherize}-modal", "bs-target": "##{key.to_s.dasherize}-modal" } %>
+    <% end %>
+  </div>
+</div>

--- a/app/components/spotlight/bulk_action_component.rb
+++ b/app/components/spotlight/bulk_action_component.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Spotlight
+  # Displays the "Bulk actions" button and dropdown
+  class BulkActionComponent < ViewComponent::Base
+    def initialize(bulk_actions:, button_classes: 'btn btn-secondary dropdown-toggle')
+      @bulk_actions = bulk_actions
+      @button_classes = button_classes
+      super
+    end
+
+    attr_reader :button_classes, :bulk_actions
+
+    def button
+      button_tag t(:'spotlight.bulk_actions.label'), id: 'bulk-actions-button', class: button_classes,
+                                                     data: { toggle: 'dropdown', 'bs-toggle': 'dropdown' },
+                                                     aria: { haspopup: true, expanded: false }
+    end
+  end
+end

--- a/app/views/catalog/_bulk_actions.html.erb
+++ b/app/views/catalog/_bulk_actions.html.erb
@@ -1,12 +1,3 @@
-<div class="dropdown bulk-actions-dropdown">
-  <button class="btn btn-secondary dropdown-toggle" type="button" id="bulk-actions-button" data-toggle="dropdown" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-    <%= t(:'spotlight.bulk_actions.label') %>
-  </button>
-  <div class="dropdown-menu" aria-labelledby="bulk-actions-button">
-    <% blacklight_config.bulk_actions.each do |key, _config| %>
-      <%= link_to t("spotlight.bulk_actions.#{key}.heading"), '#', class: 'dropdown-item', data: { toggle: "modal", "bs-toggle": "modal", target: "##{key.to_s.dasherize}-modal", "bs-target": "##{key.to_s.dasherize}-modal" } %>
-    <% end %>
-  </div>
-</div>
+<%= render Spotlight::BulkActionComponent.new(bulk_actions: blacklight_config.bulk_actions) %>
 
 <%= render_filtered_partials(blacklight_config.bulk_actions) %>

--- a/spec/features/bulk_actions_spec.rb
+++ b/spec/features/bulk_actions_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe 'Bulk actions', type: :feature do
+RSpec.describe 'Bulk actions', type: :feature do
   let(:exhibit) { FactoryBot.create(:exhibit) }
   let(:curator) { FactoryBot.create(:exhibit_curator, exhibit:) }
 


### PR DESCRIPTION
This will enable downstream apps to easily set the css classes on the button

Backports https://github.com/projectblacklight/spotlight/pull/3347/ to release-4.x