### PR TITLE
Avoid rendering partials on the embed component

### DIFF
--- a/app/components/spotlight/solr_document_legacy_embed_component.html.erb
+++ b/app/components/spotlight/solr_document_legacy_embed_component.html.erb
@@ -1,9 +1,5 @@
 <% if body.present? %>
   <%= body %>
-<% elsif partials? %>
-  <% partials.each do |partial| %>
-    <%= partial %>
-  <% end %>
 <% elsif embed? %>
   <%= embed %>
 <% elsif thumbnail? %>

--- a/app/models/spotlight/blacklight_configuration.rb
+++ b/app/models/spotlight/blacklight_configuration.rb
@@ -121,7 +121,11 @@ module Spotlight
         config.default_per_page = default_per_page if default_per_page
 
         config.view.embed!
-        config.view.embed.document_component = Spotlight::SolrDocumentLegacyEmbedComponent unless config.view.embed.document_component
+        # This is blacklight-gallery's openseadragon component
+        unless config.view.embed.document_component
+          config.view.embed.document_component = Spotlight::SolrDocumentLegacyEmbedComponent
+          config.view.embed.embed_component = Blacklight::Gallery::OpenseadragonEmbedComponent
+        end
         config.view.embed.if = false
 
         # blacklight-gallery requires tile_source_field

--- a/app/views/spotlight/sir_trevor/blocks/_embedded_document.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_embedded_document.html.erb
@@ -1,8 +1,6 @@
 <div class="box" data-id="<%= document.id %>">
   <% view_config = blacklight_config.view_config(:embed) %>
-  <%= render (view_config.document_component || Spotlight::SolrDocumentLegacyEmbedComponent).new(document: document_presenter(document, view_config: view_config), counter: nil, block: local_assigns[:block]) do |component| %>
-    <% component.with_partial do %>
-      <%= render_document_partials document, view_config.partials, component: component, document_counter: nil, view_config: view_config, block: local_assigns[:block], **(view_config.locals) %>
-    <% end if Blacklight::VERSION < '9.0' && view_config&.partials&.any? %>
-  <% end %>
+  <%= render (view_config.document_component || Spotlight::SolrDocumentLegacyEmbedComponent)
+              .new((Blacklight.version > '8.0' ? :document : :presenter) => document_presenter(document, view_config: view_config),
+                   counter: nil, block: local_assigns[:block]) %>
 </div>


### PR DESCRIPTION
render_document_partials is deprecated

Fixes #3362