### PR TITLE
Extract MastheadComponent

### DIFF
--- a/app/components/spotlight/masthead_component.html.erb
+++ b/app/components/spotlight/masthead_component.html.erb
@@ -1,0 +1,18 @@
+<% if show_contact_form? && (current_exhibit.nil? || !current_page?(spotlight.new_exhibit_contact_form_path(current_exhibit))) %>
+  <div id="report-problem-form">
+    <%= render 'spotlight/shared/report_a_problem' %>
+  </div>
+<% end %>
+
+<header class="masthead <%= 'image-masthead' if current_masthead %> <%= 'resource-masthead' if resource_masthead? %>">
+  <% if current_masthead %>
+    <span class="background-container" style="background-image: url('<%= current_masthead.iiif_url %>')"></span>
+    <span class="background-container-gradient"></span>
+  <% end %>
+
+  <%= masthead_navbar if resource_masthead? %>
+  <%= title_and_subtitle %>
+  <%= masthead_navbar unless resource_masthead? %>
+</header>
+
+<%= render Spotlight::BreadcrumbsComponent.new(breadcrumbs:) %>

--- a/app/components/spotlight/masthead_component.rb
+++ b/app/components/spotlight/masthead_component.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Spotlight
+  # Draws the masthead
+  class MastheadComponent < ViewComponent::Base
+    def initialize(current_exhibit:, current_masthead:, resource_masthead:)
+      @current_exhibit = current_exhibit
+      @current_masthead = current_masthead
+      @resource_masthead = resource_masthead
+      super
+    end
+
+    attr_reader :current_exhibit, :current_masthead
+
+    delegate :breadcrumbs, :masthead_heading_content, :masthead_subheading_content, to: :helpers
+
+    def resource_masthead?
+      @resource_masthead
+    end
+
+    def show_contact_form?
+      helpers.show_contact_form? &&
+        (current_exhibit.nil? || !current_page?(spotlight.new_exhibit_contact_form_path(current_exhibit)))
+    end
+
+    def masthead_navbar
+      if current_exhibit
+        render 'shared/exhibit_navbar'
+      else
+        render 'shared/site_navbar'
+      end
+    end
+
+    def title
+      content_for(:masthead) || masthead_heading_content
+    end
+
+    def title_and_subtitle
+      render title_component.new(title:, subtitle: masthead_subheading_content)
+    end
+
+    def title_component
+      Spotlight::Engine.config.spotlight.title_component
+    end
+  end
+end

--- a/app/views/layouts/spotlight/base.html.erb
+++ b/app/views/layouts/spotlight/base.html.erb
@@ -44,7 +44,7 @@
       <%= content_for(:skip_links) %>
     <% end %>
     <%= render partial: 'shared/header_navbar' %>
-    <%= render partial: 'shared/masthead' %>
+    <%= render Spotlight::MastheadComponent.new(current_exhibit:, current_masthead:, resource_masthead: resource_masthead?) %>
     <%= content_for?(:header_content) ? yield(:header_content) : "" %>
 
     <main id="main-container" class="<%= container_classes %>" aria-label="<%= t('blacklight.main.aria.main_container') %>">

--- a/app/views/shared/_masthead.html.erb
+++ b/app/views/shared/_masthead.html.erb
@@ -1,18 +1,2 @@
-<% if show_contact_form? && (current_exhibit.nil? || !current_page?(spotlight.new_exhibit_contact_form_path(current_exhibit))) %>
-  <div id="report-problem-form" class="collapse">
-    <%= render 'spotlight/shared/report_a_problem' %>
-  </div>
-<% end %>
-
-<header class="masthead <%= 'image-masthead' if current_masthead %> <%= 'resource-masthead' if resource_masthead? %>">
-  <% if current_masthead %>
-    <span class="background-container" style="background-image: url('<%= current_masthead.iiif_url %>')"></span>
-    <span class="background-container-gradient"></span>
-  <% end %>
-
-  <%= render current_exhibit ? 'shared/exhibit_navbar' : 'shared/site_navbar' if resource_masthead? %>
-  <%= render Spotlight::Engine.config.spotlight.title_component.new(title: content_for(:masthead) || masthead_heading_content, subtitle: masthead_subheading_content) %>
-  <%= render current_exhibit ? 'shared/exhibit_navbar' : 'shared/site_navbar' unless resource_masthead? %>
-</header>
-
-<%= render Spotlight::BreadcrumbsComponent.new(breadcrumbs:) %>
+<% Spotlight.deprecator.warn "Rendering deprecated partial shared/masthead. Use MastheadComponent instead" %>
+<%= render Spotlight::MastheadComponent.new(current_exhibit:, current_masthead:, resource_masthead: resource_masthead?) %>


### PR DESCRIPTION
This allows us to do class overriding to customize components and follows the patterns in Blacklight.