### PR TITLE
Use 'yarn link' in the test app

### DIFF
--- a/lib/generators/spotlight/assets/generator_common_utilities.rb
+++ b/lib/generators/spotlight/assets/generator_common_utilities.rb
@@ -31,15 +31,6 @@ module Spotlight
       def bootstrap_yarn_version
         bootstrap_version.match(/(\d+(\.\d+)*)/)[0]
       end
-
-      # Yarn link was including so many files (and a circular reference) that Propshaft was having a bad time.
-      def link_spotlight_frontend
-        empty_directory 'node_modules/spotlight-frontend'
-        empty_directory 'node_modules/spotlight-frontend/app'
-        File.symlink Spotlight::Engine.root.join('package.json'), 'node_modules/spotlight-frontend/package.json'
-        File.symlink Spotlight::Engine.root.join('vendor'), 'node_modules/spotlight-frontend/vendor'
-        File.symlink Spotlight::Engine.root.join('app/assets'), 'node_modules/spotlight-frontend/app/assets'
-      end
     end
   end
 end

--- a/lib/generators/spotlight/assets/importmap_generator.rb
+++ b/lib/generators/spotlight/assets/importmap_generator.rb
@@ -36,7 +36,7 @@ module Spotlight
         if ENV['CI']
           run "yarn add file:#{Spotlight::Engine.root}"
         elsif options[:test]
-          link_spotlight_frontend
+          run 'yarn link spotlight-frontend'
 
         # If a branch was specified (e.g. you are running a template.rb build
         # against a test branch), use the latest version available on npm

--- a/lib/generators/spotlight/assets/propshaft_generator.rb
+++ b/lib/generators/spotlight/assets/propshaft_generator.rb
@@ -46,7 +46,7 @@ module Spotlight
         if ENV['CI']
           run "yarn add file:#{Spotlight::Engine.root}"
         elsif options[:test]
-          link_spotlight_frontend
+          run 'yarn link spotlight-frontend'
 
         # If a branch was specified (e.g. you are running a template.rb build
         # against a test branch), use the latest version available on npm

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -27,6 +27,12 @@ class TestAppGenerator < Rails::Generators::Base
     end
   end
 
+  # This makes the assets available in the test app so that changes made in
+  # local development can be picked up automatically
+  def link_frontend
+    run 'yarn link'
+  end
+
   def run_blacklight_generator
     say_status('warning', 'GENERATING BL', :yellow)
 


### PR DESCRIPTION
Now that `app.config.assets.paths << Rails.root.join('node_modules')` has been removed via https://github.com/projectblacklight/spotlight/pull/3378 we can go back to using `yarn link` for the test app. It seems like that fixes our previous infinite propshaft issue.

This fixes the test app build, which is currently broken:
```
07:58:13 css.1  | Error: Can't find stylesheet to import.
07:58:13 css.1  |   ╷
07:58:13 css.1  | 5 │ @import "spotlight-frontend/vendor/assets/stylesheets/bootstrap-tagsinput";
07:58:13 css.1  |   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
07:58:13 css.1  |   ╵
07:58:13 css.1  |   app/assets/stylesheets/spotlight.scss 5:9              @import
07:58:13 css.1  |   app/assets/stylesheets/application.bootstrap.scss 4:9  root stylesheet
07:58:13 css.1  | error Command failed with exit code 65.
07:58:13 css.1  | info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
07:58:13 css.1  | error Command failed with exit code 65.
07:58:13 css.1  | info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
07:58:13 css.1  | [nodemon] app crashed - waiting for file changes before starting...
```