### PR TITLE
fix double click bug

### DIFF
--- a/app/javascript/spotlight/admin/croppable_modal.js
+++ b/app/javascript/spotlight/admin/croppable_modal.js
@@ -11,7 +11,7 @@ export default class CroppableModal {
 
   attachModalLoadBehavior() {
     // Listen for event thrown when modal is displayed with content
-    document.addEventListener('show.blacklight.blacklight-modal', function(e) {      
+    document.addEventListener('loaded.blacklight.blacklight-modal', function(e) {
       var dataCropperDiv = $('#blacklight-modal [data-behavior="iiif-cropper"]');
       
       if(dataCropperDiv) {


### PR DESCRIPTION
97% sure this bug is happening because the blacklight modal is reloading the modal on the second click and since the modal is already loaded it is rerunning the initialization of the cropper.

Tested this locally and it fixed things.

closes #3384 