### PR TITLE
Add newline to test app generator

### DIFF
--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -56,7 +56,7 @@ class TestAppGenerator < Rails::Generators::Base
     copy_file 'fixture.png', 'app/assets/images/spotlight/themes/modern_preview.png'
 
     copy_file 'fixture.css', 'app/assets/stylesheets/application_modern.css'
-    append_to_file 'config/initializers/assets.rb', 'Rails.application.config.assets.precompile += %w( application_modern.css )'
+    append_to_file 'config/initializers/assets.rb', "\nRails.application.config.assets.precompile += %w( application_modern.css )"
 
     append_to_file 'config/initializers/spotlight_initializer.rb', "\nSpotlight::Engine.config.exhibit_themes = %w[default modern]"
   end


### PR DESCRIPTION
Trying to fix this error when backporting:

```
SyntaxError: --> /home/runner/work/spotlight/spotlight/.internal_test_app/config/initializers/assets.rb
syntax error, unexpected constant, expecting end-of-input
>  4  Rails.application.config.assets.version = "1.0"
>  8  Rails.application.config.assets.paths << Rails.root.join("node_modules/bootstrap/dist/js")
>  9  Rails.application.config.assets.paths << Rails.root.join("node_modules/bootstrap-icons/font")
> 10  Rails.application.config.assets.paths << Rails.root.join("node_modules/bootstrap/dist/js")
> 11  Rails.application.config.assets.precompile << "bootstrap.min.js"Rails.application.config.assets.precompile += %w( application_modern.css )
```