### PR TITLE
migrate secondary-btns to primary

### DIFF
--- a/app/assets/stylesheets/spotlight/_curation.scss
+++ b/app/assets/stylesheets/spotlight/_curation.scss
@@ -21,7 +21,7 @@
     }
     input[type='submit'] {
       @extend .btn;
-      @extend .btn-secondary;
+      @extend .btn-primary;
       @extend .btn-sm;
     }
     display: none;

--- a/app/assets/stylesheets/spotlight/_sir-trevor_overrides.scss
+++ b/app/assets/stylesheets/spotlight/_sir-trevor_overrides.scss
@@ -75,8 +75,8 @@
 
 .st-block-controls__button {
   @extend .btn;
-  @extend .btn-secondary;
-  @extend .btn-outline-secondary;
+  @extend .btn-primary;
+  @extend .btn-outline-primary;
 
   border: 1px solid $gray-700;
 

--- a/app/components/spotlight/bulk_action_component.rb
+++ b/app/components/spotlight/bulk_action_component.rb
@@ -3,7 +3,7 @@
 module Spotlight
   # Displays the "Bulk actions" button and dropdown
   class BulkActionComponent < ViewComponent::Base
-    def initialize(bulk_actions:, button_classes: 'btn btn-secondary dropdown-toggle')
+    def initialize(bulk_actions:, button_classes: 'btn btn-primary dropdown-toggle')
       @bulk_actions = bulk_actions
       @button_classes = button_classes
       super

--- a/app/components/spotlight/save_search_component.rb
+++ b/app/components/spotlight/save_search_component.rb
@@ -3,7 +3,7 @@
 module Spotlight
   # Displays the "Save this search" button and modal
   class SaveSearchComponent < ViewComponent::Base
-    def initialize(button_classes: 'btn btn-secondary')
+    def initialize(button_classes: 'btn btn-outline-primary')
       @button_classes = button_classes
       super
     end

--- a/app/jobs/concerns/spotlight/job_tracking.rb
+++ b/app/jobs/concerns/spotlight/job_tracking.rb
@@ -44,7 +44,7 @@ module Spotlight
     end
 
     def finalize_job_tracker!
-      return unless job_tracker.status == 'in_progress' || job_tracker.status == 'enqueued'
+      return unless %w[in_progress enqueued].include?(job_tracker.status)
 
       job_tracker.update(
         status: @failed ? 'failed' : 'completed',

--- a/app/views/shared/_site_sidebar.html.erb
+++ b/app/views/shared/_site_sidebar.html.erb
@@ -14,6 +14,6 @@
 </ul>
 
 <ul class="nav sidenav nav-pills nav-stacked">
-  <li class="nav-item"><%= link_to t(:'spotlight.exhibits.new.page_title'), spotlight.new_exhibit_path, class: 'btn btn-outline-secondary btn-nav', role: 'button' if can? :create, Spotlight::Exhibit %></li>
+  <li class="nav-item"><%= link_to t(:'spotlight.exhibits.new.page_title'), spotlight.new_exhibit_path, class: 'btn btn-primary btn-nav', role: 'button' if can? :create, Spotlight::Exhibit %></li>
 </ul>
 <% end %>

--- a/app/views/spotlight/admin_users/index.html.erb
+++ b/app/views/spotlight/admin_users/index.html.erb
@@ -45,7 +45,7 @@
 
     <div class="form-actions">
       <div class="primary-actions">
-        <%= link_to(t('.create'), 'javascript:;', class: 'btn btn-secondary', data: { behavior: 'new-user' }) %>
+        <%= link_to(t('.create'), 'javascript:;', class: 'btn btn-primary', data: { behavior: 'new-user' }) %>
       </div>
     </div>
   </div>
@@ -54,7 +54,7 @@
     <h3 class="instructions"><%= t :'.admins_curators' %></h3>
     <div id="admins_curators" class="card card-body bg-light">
       <div class='btn-toolbar float-right align-self-end'>
-        <button class="btn btn-sm btn-secondary copy-email-addresses" data-clipboard-target="#admins_curators">
+        <button class="btn btn-sm btn-primary copy-email-addresses" data-clipboard-target="#admins_curators">
             <%= t('.copy') %>
         </button>
       </div>
@@ -89,7 +89,7 @@
               <% else %>
                 <%= link_to(t('.update'), admin_user_path(user),
                       data: { method: :patch, turbo_method: :patch },
-                      class: 'btn btn-sm btn-secondary') %>
+                      class: 'btn btn-sm btn-primary') %>
               <% end %>
             </td>
           </tr>

--- a/app/views/spotlight/catalog/_admin_header.html.erb
+++ b/app/views/spotlight/catalog/_admin_header.html.erb
@@ -6,7 +6,7 @@
     <div class="float-right float-end">
       <%= link_to t('.reindex'), reindex_all_exhibit_resources_path(current_exhibit), 
           data: { method: :post, turbo_method: :post },
-          class: 'btn btn-secondary' %>
+          class: 'btn btn-outline-primary' %>
       <% if Spotlight::Engine.config.resource_partials.any? %>
         <%= link_to t('.new_resource'), new_exhibit_resource_path(current_exhibit), class: 'btn btn-primary' %>
       <% end %>

--- a/app/views/spotlight/exhibits/_delete.html.erb
+++ b/app/views/spotlight/exhibits/_delete.html.erb
@@ -4,7 +4,7 @@
     <div class="row">
       <p class='col-9'><%= t(:".warning_html", export_link: link_to(t(:'spotlight.exhibits.export.download'), spotlight.edit_exhibit_path(current_exhibit, anchor: 'export'))) %></p>
       <div class='col-3'>
-        <%= delete_link current_exhibit, class: 'btn btn-secondary' %>
+        <%= delete_link current_exhibit, class: 'btn btn-primary' %>
       </div>
     </div>
   </div>

--- a/app/views/spotlight/metadata_configurations/_metadata_field.html.erb
+++ b/app/views/spotlight/metadata_configurations/_metadata_field.html.erb
@@ -14,7 +14,7 @@
         </div>
         <% if default_field_label %>
           <div class="restore-default">
-            <%= button_tag t(:'.restore_default'), data: {:"restore-default" => true}, class: "btn btn-secondary btn-sm #{'d-none' if config.display_label == default_field_label}" %>
+            <%= button_tag t(:'.restore_default'), data: {:"restore-default" => true}, class: "btn btn-primary btn-sm #{'d-none' if config.display_label == default_field_label}" %>
           </div>
         <% end %>
       </div>

--- a/app/views/spotlight/resources/upload/_form.html.erb
+++ b/app/views/spotlight/resources/upload/_form.html.erb
@@ -13,7 +13,7 @@
     <div class="primary-actions">
       <%= hidden_field_tag :tab, 'upload', id: nil %>
       <%= cancel_link @resource, :back, class: 'btn btn-link', role: 'button' %>
-      <%= f.submit t('.add_item_and_continue'), name: 'add-and-continue', class: 'btn btn-secondary' %>
+      <%= f.submit t('.add_item_and_continue'), name: 'add-and-continue', class: 'btn btn-outline-primary' %>
       <%= f.submit t('.add_item'), class: 'btn btn-primary' %>
     </div>
   </div>

--- a/app/views/spotlight/roles/index.html.erb
+++ b/app/views/spotlight/roles/index.html.erb
@@ -55,7 +55,7 @@
 
   <div class="form-actions">
     <div class="primary-actions">
-    <%= exhibit_create_link Spotlight::Role.new, '#', class: 'btn btn-secondary', data: {behavior: 'new-user'} %>
+    <%= exhibit_create_link Spotlight::Role.new, '#', class: 'btn btn-primary', data: {behavior: 'new-user'} %>
     </div>
   </div>
 <% end %>

--- a/app/views/spotlight/shared/_dd3_item.html.erb
+++ b/app/views/spotlight/shared/_dd3_item.html.erb
@@ -33,7 +33,7 @@
 
       <% if default_value %>
         <div class="">
-          <%= button_tag t(:'.restore_default'), data: {:"restore-default" => true}, class: "btn restore-default btn-secondary btn-sm #{'d-none' if label.blank? || label == default_value}" %>
+          <%= button_tag t(:'.restore_default'), data: {:"restore-default" => true}, class: "btn restore-default btn-primary btn-sm #{'d-none' if label.blank? || label == default_value}" %>
         </div>
       <% end %>
 

--- a/app/views/spotlight/sir_trevor/blocks/_solr_documents_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_solr_documents_block.html.erb
@@ -26,7 +26,7 @@
               </div>
             <% end %>
             <% if solr_documents_block.zpr_link? && block_options[:iiif_tilesource].present? %>
-              <button class="btn btn-secondary zpr-link" data-iiif-tilesource="<%= block_options[:iiif_tilesource] %>"><%= t('.zpr_link_html', title: doc_presenter.heading) %></button>
+              <button class="btn btn-primary zpr-link" data-iiif-tilesource="<%= block_options[:iiif_tilesource] %>"><%= t('.zpr_link_html', title: doc_presenter.heading) %></button>
             <% end %>
           </div>
         </div>

--- a/app/views/spotlight/sir_trevor/blocks/_uploaded_items_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_uploaded_items_block.html.erb
@@ -19,7 +19,7 @@
             <% end %>
 
             <% if uploaded_items_block.zpr_link? %>
-              <%= button_tag t('.zpr_link_html', title: file[:caption]), class: 'btn btn-secondary zpr-link', data: { 'iiif-tilesource' => { type: 'image', url: file[:url] }.to_json } %>
+              <%= button_tag t('.zpr_link_html', title: file[:caption]), class: 'btn btn-primary zpr-link', data: { 'iiif-tilesource' => { type: 'image', url: file[:url] }.to_json } %>
             <% end %>
           </div>
         </div>

--- a/lib/generators/spotlight/scaffold_resource_generator.rb
+++ b/lib/generators/spotlight/scaffold_resource_generator.rb
@@ -38,7 +38,7 @@ module Spotlight
           <%= f.text_field :url  %>
           <div class="form-actions">
             <div class="primary-actions">
-              <%= cancel_link @resource, :back, class: 'btn btn-secondary' %>
+              <%= cancel_link @resource, :back, class: 'btn btn-primary' %>
               <%= f.submit t('.add_item'), class: 'btn btn-primary' %>
             </div>
           </div>


### PR DESCRIPTION
Stanford is currently migrating away from two different color buttons on the page based on UX designers. Moving away from this might also be preferable to community but we want to check with the community before merging.