### PR TITLE
[4.x] Swap the order of the openseadragon asset paths

### DIFF
--- a/lib/generators/spotlight/install_generator.rb
+++ b/lib/generators/spotlight/install_generator.rb
@@ -129,8 +129,8 @@ module Spotlight
 
       append_to_file 'config/initializers/assets.rb' do
         <<~CONTENT
-          Rails.application.config.assets.paths << Rails.root.join('node_modules/openseadragon/build/openseadragon')
           Rails.application.config.assets.paths << Rails.root.join('node_modules/openseadragon/build/openseadragon/images')
+          Rails.application.config.assets.paths << Rails.root.join('node_modules/openseadragon/build/openseadragon')
         CONTENT
       end
 


### PR DESCRIPTION
We found that with the original order when assets were being copied in production, the images would be copied to an 'image' directory.