### PR TITLE
Give a more descriptive name to a method

### DIFF
--- a/app/controllers/spotlight/accessibility_controller.rb
+++ b/app/controllers/spotlight/accessibility_controller.rb
@@ -9,7 +9,7 @@ module Spotlight
 
     def alt_text
       # Sort by newest except for the homepage, which is always first
-      pages_with_alt = @exhibit.pages.order(Arel.sql('id = 1 DESC, created_at DESC')).select { |elem| elem.content.any?(&:alt_text?) }
+      pages_with_alt = @exhibit.pages.order(Arel.sql('id = 1 DESC, created_at DESC')).select { |elem| elem.content.any?(&:supports_alt_text?) }
       @pages = pages_with_alt.map { |page| get_alt_info(page) }
       @has_alt_text = @pages.sum { |page| page[:has_alt_text] }
       @total_alt_items = @pages.sum { |page| page[:can_have_alt_text] }
@@ -23,7 +23,7 @@ module Spotlight
       can_have_alt_text = 0
       has_alt_text = 0
       page.content.each do |content|
-        next unless content.alt_text?
+        next unless content.supports_alt_text?
 
         content.item&.each_value do |item|
           can_have_alt_text += 1

--- a/app/models/sir_trevor_rails/block.rb
+++ b/app/models/sir_trevor_rails/block.rb
@@ -18,11 +18,12 @@ module SirTrevorRails
       send(:[], :format).present? ? send(:[], :format).to_sym : DEFAULT_FORMAT
     end
 
-    def alt_text?
-      self.class.alt_text?
+    def supports_alt_text?
+      self.class.supports_alt_text?
     end
 
-    def self.alt_text?
+    # By default we don't support alt text, but some subclasses do
+    def self.supports_alt_text?
       false
     end
 
@@ -33,7 +34,7 @@ module SirTrevorRails
     end
 
     def self.custom_block_type_alt_text_settings
-      custom_block_types.index_with { |block_type| SirTrevorRails::Block.block_class(block_type).alt_text? }
+      custom_block_types.index_with { |block_type| SirTrevorRails::Block.block_class(block_type).supports_alt_text? }
     end
 
     def initialize(hash, parent)

--- a/app/models/sir_trevor_rails/blocks/solr_documents_block.rb
+++ b/app/models/sir_trevor_rails/blocks/solr_documents_block.rb
@@ -13,7 +13,7 @@ module SirTrevorRails
         @solr_helper = solr_helper
       end
 
-      def self.alt_text?
+      def self.supports_alt_text?
         true
       end
 

--- a/app/models/sir_trevor_rails/blocks/solr_documents_embed_block.rb
+++ b/app/models/sir_trevor_rails/blocks/solr_documents_embed_block.rb
@@ -5,7 +5,7 @@ module SirTrevorRails
     ##
     # Embed documents (using a special blacklight view configuration) and text block
     class SolrDocumentsEmbedBlock < SirTrevorRails::Blocks::SolrDocumentsBlock
-      def self.alt_text?
+      def self.supports_alt_text?
         false
       end
     end

--- a/app/models/sir_trevor_rails/blocks/uploaded_items_block.rb
+++ b/app/models/sir_trevor_rails/blocks/uploaded_items_block.rb
@@ -12,7 +12,7 @@ module SirTrevorRails
         (item || {}).map { |_, file| file }.select { |file| file[:display].to_s == 'true' }
       end
 
-      def self.alt_text?
+      def self.supports_alt_text?
         true
       end
 


### PR DESCRIPTION
This shows that the class supports having alt text, but does not have the alt text itself.