### PR TITLE
Backport: Prefer docker for starting solr; support Solr 9.8

### DIFF
--- a/.env
+++ b/.env
@@ -5,3 +5,4 @@ RAILS_QUEUE=inline
 SOLR_VERSION=latest
 SOLR_HOST=solr
 SOLR_PORT=8983
+SOLR_MODULES=analysis-extras

--- a/Rakefile
+++ b/Rakefile
@@ -19,6 +19,7 @@ end
 Bundler::GemHelper.install_tasks
 
 require 'solr_wrapper'
+require 'open3'
 
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
@@ -30,16 +31,45 @@ require 'engine_cart/rake_task'
 
 require 'spotlight/version'
 
-task ci: ['engine_cart:generate'] do
+def system_with_error_handling(*args)
+  Open3.popen3(*args) do |_stdin, stdout, stderr, thread|
+    puts stdout.read
+    raise "Unable to run #{args.inspect}: #{stderr.read}" unless thread.value.success?
+  end
+end
+
+def with_solr(&block) # rubocop:disable Metrics/MethodLength
+  # We're being invoked by the app entrypoint script and solr is already up via docker compose
+  if ENV['SOLR_ENV'] == 'docker-compose'
+    yield
+  elsif system('docker compose version')
+    # We're not running `docker compose up' but still want to use a docker instance of solr.
+    begin
+      puts 'Starting Solr'
+      system_with_error_handling 'docker compose up -d solr'
+      yield
+    ensure
+      puts 'Stopping Solr'
+      system_with_error_handling 'docker compose stop solr'
+    end
+  else
+    SolrWrapper.wrap do |solr|
+      solr.with_collection(&block)
+    end
+  end
+end
+
+task :ci do
   ENV['environment'] = 'test'
 
-  SolrWrapper.wrap(port: '8983') do |solr|
-    solr.with_collection(name: 'blacklight-core', dir: 'lib/generators/spotlight/templates/solr/conf') do
-      Rake::Task['spotlight:fixtures'].invoke
-
-      # run the tests
-      Rake::Task['spec'].invoke
+  with_solr do
+    Rake::Task['spotlight:fixtures'].invoke
+    within_test_app do
+      system 'bin/rake spec:prepare'
     end
+
+    # run the tests
+    Rake::Task['spec'].invoke
   end
 end
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -36,6 +36,7 @@ services:
     environment:
       - SOLR_PORT # Set via environment variable or use default defined in .env file
       - SOLR_VERSION # Set via environment variable or use default defined in .env file
+      - SOLR_MODULES # Set via environment variable or use default defined in .env file
     image: "solr:${SOLR_VERSION}"
     volumes:
       - $PWD/lib/generators/spotlight/templates/solr/conf:/opt/solr/conf

--- a/lib/generators/spotlight/templates/solr/conf/solrconfig.xml
+++ b/lib/generators/spotlight/templates/solr/conf/solrconfig.xml
@@ -16,7 +16,7 @@
     </updateLog>
   </updateHandler>
 
-  <!-- solr lib dirs -->
+  <!-- solr lib dirs: needed for Solr 8 compatibility but ignored in solr 9.8 and above -->
   <lib dir="${solr.install.dir:../../../..}/modules/analysis-extras/lib" />
   <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lib" />
   <lib dir="${solr.install.dir:../../../..}/contrib/analysis-extras/lucene-libs" />


### PR DESCRIPTION
Backport https://github.com/projectblacklight/spotlight/pull/3209 and https://github.com/projectblacklight/spotlight/pull/3417 to release-4.x