### PR TITLE
fix long exhibit title display

### DIFF
--- a/app/assets/stylesheets/spotlight/_exhibits_index.scss
+++ b/app/assets/stylesheets/spotlight/_exhibits_index.scss
@@ -33,6 +33,7 @@ $exhibit-card-overlay-padding: $card-img-overlay-padding * 0.5 !default;
   }
 
   .card-img-overlay {
+    --exhibit-card-overlay-opacity: .7;
     --exhibit-card-overlay-rgb: 255, 255, 255;
     --exhibit-card-overlay-bg: rgba(
       var(--exhibit-card-overlay-rgb),
@@ -74,7 +75,6 @@ $exhibit-card-overlay-padding: $card-img-overlay-padding * 0.5 !default;
   }
 
   &:hover {
-    --exhibit-card-overlay-opacity: .7;
     .exhibit-description {
       max-height: 450px;
     }


### PR DESCRIPTION
Before
![Screenshot 2025-01-27 at 3 33 55 PM](https://github.com/user-attachments/assets/7405557c-8278-49f0-a337-44aadf139d7d)

After
![Screenshot 2025-01-27 at 3 32 33 PM](https://github.com/user-attachments/assets/45b34d67-62a8-4fe3-88a6-887d551665c2)

closes https://github.com/sul-dlss/exhibits/issues/2819