### PR TITLE
Check for less specific error message

### DIFF
--- a/spec/services/spotlight/iiif_resource_resolver_spec.rb
+++ b/spec/services/spotlight/iiif_resource_resolver_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Spotlight::IiifResourceResolver do
       it 'logs that the JSON was unparsable and falls through to an no-canvas error' do
         klass = described_class.name
         expect(Rails.logger).to receive(:warn).with(
-          a_string_matching(/#{klass} failed to parse #{iiif_manifest_url} .* unexpected token at/)
+          a_string_matching(/#{klass} failed to parse #{iiif_manifest_url}/)
         )
         expect { resolver.resolve! }.to raise_error(Spotlight::IiifResourceResolver::ManifestError)
       end


### PR DESCRIPTION
Seems like "unexpected token" has become "unexpected character" for some version. I don't think we need to have this level of specificity.