### PR TITLE
Improve reliability of edit in place test

### DIFF
--- a/spec/features/javascript/edit_in_place_spec.rb
+++ b/spec/features/javascript/edit_in_place_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe 'Edit in place', js: true, type: :feature do
 
       click_button 'Save changes'
 
+      expect(page).to have_button('Save changes', disabled: false) # Wait for new page
       within('.metadata_fields') do
         expect(page).to have_css('a[href="#edit-in-place"]', text: 'Brand new name')
         expect(page).to have_selector('button[name="button"][type="submit"][data-restore-default="true"]', text: 'Restore default', visible: true)
@@ -114,6 +115,7 @@ RSpec.describe 'Edit in place', js: true, type: :feature do
       click_button 'Restore default'
       click_button 'Save changes'
 
+      expect(page).to have_button('Save changes', disabled: false) # Wait for new page
       within('.metadata_fields') do
         expect(page).to have_css('a[href="#edit-in-place"]', text: 'Personal names')
         expect(page).to have_no_selector('button[name="button"][type="submit"][data-restore-default="true"]', text: 'Restore default')


### PR DESCRIPTION
This test flakes out sometimes on CI, including several times today.

The thought here is maybe sometimes it's managing to check the metadata fields so fast the page hasn't switched yet. We'd probably need to run it 100 times to get any real sense but here's 7 in a row:
<img width="290" alt="Screenshot 2025-02-12 at 2 36 50 PM" src="https://github.com/user-attachments/assets/f5a2996c-27ee-456a-9533-d95a16abeee9" />
