### PR TITLE
Let st-block-controls hover use the default color

### DIFF
--- a/vendor/assets/stylesheets/sir-trevor/block-controls.scss
+++ b/vendor/assets/stylesheets/sir-trevor/block-controls.scss
@@ -32,7 +32,3 @@
   width: 42px;
   height: 42px;
 }
-
-.st-block-controls__button:hover {
-  color: $accent-color;
-}


### PR DESCRIPTION
Uses whatever is set for `var(--bs-btn-hover-color)` instead.

Before:
<img width="352" alt="Screenshot 2025-02-18 at 2 27 25 PM" src="https://github.com/user-attachments/assets/bdcf4ee0-4179-44af-8066-29632d05797a" />

After:
<img width="337" alt="Screenshot 2025-02-18 at 2 27 42 PM" src="https://github.com/user-attachments/assets/4d332ddc-aa97-41d0-a1cf-4be156cc2636" />
