### PR TITLE
Set gemspec to use compatible version of bootstrap_form gem

### DIFF
--- a/blacklight-spotlight.gemspec
+++ b/blacklight-spotlight.gemspec
@@ -24,7 +24,7 @@ these collections.)
   s.add_dependency 'acts-as-taggable-on', '>= 5.0', '< 13'
   s.add_dependency 'blacklight', '>= 8.7.0', '< 9'
   s.add_dependency 'blacklight-gallery', '>= 3.0', '< 5'
-  s.add_dependency 'bootstrap_form', '>= 4.1', '< 6'
+  s.add_dependency 'bootstrap_form', '>= 5.4', '< 6'
   s.add_dependency 'cancancan'
   s.add_dependency 'carrierwave', '~> 2.2'
   s.add_dependency 'csv'


### PR DESCRIPTION
Bootstrap 5 only works with bootstrap_form 5 and above. Since we've dropped Bootstrap 4 we should set the gemspec appropriately.