### PR TITLE
Remove p tag wrapper in heading block text

### DIFF
--- a/app/views/spotlight/sir_trevor/blocks/_heading_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_heading_block.html.erb
@@ -1,1 +1,1 @@
-<h2><%= sir_trevor_markdown heading_block.text %></h2>
+<%= sir_trevor_markdown "## #{heading_block.text}" %>


### PR DESCRIPTION
Running the heading block text through the markdown renderer fixed the issues from https://github.com/projectblacklight/spotlight/issues/944 but is wrapping the inner text in a paragraph tag. This is flagging some a11y checks. See https://github.com/sul-dlss/exhibits/issues/2877 for more detail.

Using the markdown renderer this way results in only the h2 tag and heading text.