### PR TITLE
Fix specs: purl now encodes the slash between the druid and filename in the IIIF identifier

### DIFF
--- a/spec/features/autocomplete_typeahead_spec.rb
+++ b/spec/features/autocomplete_typeahead_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Autocomplete typeahead', js: true, type: :feature do
         # TODO: this data is fetched by a javascript widget and thus isn't captured by webmock see #2817
         expect(featured_image.iiif_canvas_id).to eq 'https://purl.stanford.edu/gk446cj2442/iiif/canvas/cocina-fileSet-gk446cj2442-gk446cj2442_1'
         expect(featured_image.iiif_image_id).to eq 'https://purl.stanford.edu/gk446cj2442/iiif/annotation/cocina-fileSet-gk446cj2442-gk446cj2442_1'
-        expect(featured_image.iiif_tilesource).to eq 'https://stacks.stanford.edu/image/iiif/gk446cj2442/gk446cj2442_05_0001/info.json'
+        expect(featured_image.iiif_tilesource).to eq 'https://stacks.stanford.edu/image/iiif/gk446cj2442%2Fgk446cj2442_05_0001/info.json'
       end
 
       it 'instantiates the multi-image selector when an multi-image item is chosen in the typeahead (and again on edit)' do

--- a/spec/features/javascript/multi_image_select_spec.rb
+++ b/spec/features/javascript/multi_image_select_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe 'Multi image selector', js: true, max_wait_time: 5, type: :featur
 
     visit spotlight.exhibit_feature_page_path(exhibit, feature_page)
     expect(page).to have_css("[data-id='xd327cm9378']")
-    expect(page).to have_css("img[src='https://stacks.stanford.edu/image/iiif/xd327cm9378/xd327cm9378_05_0001/full/!400,400/0/default.jpg']")
-    expect(page).to have_no_css("img[src='https://stacks.stanford.edu/image/iiif/xd327cm9378/xd327cm9378_05_0002/full/!400,400/0/default.jpg']")
+    expect(page).to have_css("img[src='https://stacks.stanford.edu/image/iiif/xd327cm9378%2Fxd327cm9378_05_0001/full/!400,400/0/default.jpg']")
+    expect(page).to have_no_css("img[src='https://stacks.stanford.edu/image/iiif/xd327cm9378%2Fxd327cm9378_05_0002/full/!400,400/0/default.jpg']")
 
     click_link('Edit')
 
@@ -44,7 +44,7 @@ RSpec.describe 'Multi image selector', js: true, max_wait_time: 5, type: :featur
     save_page_changes
 
     expect(page).to have_css("[data-id='xd327cm9378']")
-    expect(page).to have_no_css("img[src='https://stacks.stanford.edu/image/iiif/xd327cm9378/xd327cm9378_05_0001/full/!400,400/0/default.jpg']")
-    expect(page).to have_css("img[src='https://stacks.stanford.edu/image/iiif/xd327cm9378/xd327cm9378_05_0002/full/!400,400/0/default.jpg']")
+    expect(page).to have_no_css("img[src='https://stacks.stanford.edu/image/iiif/xd327cm9378%2Fxd327cm9378_05_0001/full/!400,400/0/default.jpg']")
+    expect(page).to have_css("img[src='https://stacks.stanford.edu/image/iiif/xd327cm9378%2Fxd327cm9378_05_0002/full/!400,400/0/default.jpg']")
   end
 end


### PR DESCRIPTION
Due to this change in purl: https://github.com/sul-dlss/purl/pull/1236/commits/1f3be24d123007383ba373d0c2d12ac0d6769785.

I think this dependency on production purl is due to cases where the solr document fixtures indexed for tests reference production iiif manifests on purl and gets fetched live via javascript.