### PR TITLE
Add initial weight to all nestables

### DIFF
--- a/app/views/spotlight/about_pages/_contact.html.erb
+++ b/app/views/spotlight/about_pages/_contact.html.erb
@@ -1,4 +1,4 @@
-<%= render layout: 'spotlight/shared/dd3_item', locals: { id: f.object.id.to_s, field: f, enabled_method: :show_in_sidebar, label_method: :name } do |_, section| %>
+<%= render layout: 'spotlight/shared/dd3_item', locals: { id: f.object.id.to_s, field: f, index: f.index, enabled_method: :show_in_sidebar, label_method: :name } do |_, section| %>
   <% case section when nil %>
     <div class="d-flex flex-grow-1">
       <%= f.check_box :show_in_sidebar, hide_label: true, inline: true %>

--- a/app/views/spotlight/pages/_page.html.erb
+++ b/app/views/spotlight/pages/_page.html.erb
@@ -1,5 +1,5 @@
 <% page = f.object %>
-<%= render layout: 'spotlight/shared/dd3_item', locals: { id: page.id.to_s, field: f, label: page.title, label_method: :title, enabled_method: :published } do |_, section| %>
+<%= render layout: 'spotlight/shared/dd3_item', locals: { id: page.id.to_s, index: f.index, field: f, label: page.title, label_method: :title, enabled_method: :published } do |_, section| %>
   <% case section when :additional_options %>
     <%= render Spotlight::EditViewLinksComponent.new(page:, delete_link: true) %>
     <%- if page.feature_page? -%>

--- a/app/views/spotlight/search_configurations/_facets.html.erb
+++ b/app/views/spotlight/search_configurations/_facets.html.erb
@@ -6,7 +6,7 @@
         <% metadata = @field_metadata.field(key) %>
         <% next unless metadata[:document_count] > 0 || config.custom_field %>
         <%= idxf.fields_for key, config do |facet| %>
-          <%= render layout: 'spotlight/shared/dd3_item', locals: { id: key, field: facet, dd3_content_classes: "facet-config-#{key.parameterize} page" , enabled_method: :show, label_method: :label, label: facet_field_label(key) } do |_, section| %>
+          <%= render layout: 'spotlight/shared/dd3_item', locals: { id: key, field: facet, index: facet.index, dd3_content_classes: "facet-config-#{key.parameterize} page" , enabled_method: :show, label_method: :label, label: facet_field_label(key) } do |_, section| %>
             <% case section when :additional_content %>
               <div class="mt-2">
                 <%= facet.form_group :terms, label_col: 'col-md-2 offset-md-1', label: { text: t(:'spotlight.search_configurations.facets.sort_by.label') } do %>

--- a/app/views/spotlight/searches/_group.html.erb
+++ b/app/views/spotlight/searches/_group.html.erb
@@ -1,5 +1,5 @@
 <% group = f.object %>
-<%= render layout: 'spotlight/shared/dd3_item', locals: { id: group.id.to_s, field: f, dd3_content_classes: "group" , enabled_method: :published, label_method: :title, label: group.title } do |_, section| %>
+<%= render layout: 'spotlight/shared/dd3_item', locals: { id: group.id.to_s, index: f.index, field: f, dd3_content_classes: "group" , enabled_method: :published, label_method: :title, label: group.title } do |_, section| %>
   <% case section when nil %>
   <div class="d-flex flex-grow-1">
     <div>

--- a/app/views/spotlight/searches/_search.html.erb
+++ b/app/views/spotlight/searches/_search.html.erb
@@ -1,5 +1,5 @@
 <% search = f.object %>
-<%= render layout: 'spotlight/shared/dd3_item', locals: { id: search.id.to_s, field: f, dd3_content_classes: "search" , enabled_method: :published, label_method: :title, label: search.title } do |_, section| %>
+<%= render layout: 'spotlight/shared/dd3_item', locals: { id: search.id.to_s, field: f, index: f.index, dd3_content_classes: "search" , enabled_method: :published, label_method: :title, label: search.title } do |_, section| %>
   <% case section when nil %>
   <div class="d-flex flex-grow-1">
     <div>

--- a/app/views/spotlight/tags/_tag.html.erb
+++ b/app/views/spotlight/tags/_tag.html.erb
@@ -1,6 +1,6 @@
 <% tag = f.object %>
 
-<%= render layout: 'spotlight/shared/dd3_item', locals: { id: tag.id.to_s, field: f, dd3_content_classes: "tag" , enabled_method: :present?, label_method: :name, label: tag.name } do |_, section| %>
+<%= render layout: 'spotlight/shared/dd3_item', locals: { id: tag.id.to_s, field: f, index: f.index, dd3_content_classes: "tag" , enabled_method: :present?, label_method: :name, label: tag.name } do |_, section| %>
   <% case section when nil %>
   <div class="d-flex flex-grow-1">
     <div class="flex-grow-1 mx-2 main">

--- a/spec/features/javascript/feature_page_admin_spec.rb
+++ b/spec/features/javascript/feature_page_admin_spec.rb
@@ -33,6 +33,27 @@ RSpec.describe 'Feature Pages Adminstration', js: true do
     expect(page).to have_css('h3', text: 'My New Page')
   end
 
+  it 'can order the pages' do
+    visit spotlight.exhibit_dashboard_path(exhibit)
+
+    click_link 'Feature pages'
+
+    add_new_via_button('FeaturePage3')
+
+    page1 = find('.dd-item', text: 'FeaturePage1').find('.dd-handle')
+    page2 = find('.dd-item', text: 'FeaturePage2').find('.dd-handle')
+    page1.drag_to(page2)
+
+    click_button('Save changes')
+    all_page_items = all('li.dd-item h3')
+    expect(all_page_items.map(&:text)).to eq(%w[FeaturePage2 FeaturePage1 FeaturePage3])
+
+    # This save is to make sure the weights are correctly initialized. We expect nothing to change
+    click_button('Save changes')
+    all_page_items = all('li.dd-item h3')
+    expect(all_page_items.map(&:text)).to eq(%w[FeaturePage2 FeaturePage1 FeaturePage3])
+  end
+
   it 'updates the page titles' do
     visit spotlight.exhibit_dashboard_path(exhibit)
 


### PR DESCRIPTION
Fixes https://github.com/sul-dlss/exhibits/issues/2895

Similar to https://github.com/projectblacklight/spotlight/pull/3435, but that only added the initial weights to one of the sets of orderable (nestable) elements, we need to do them all.