### PR TITLE
Appease Rubocop

### DIFF
--- a/app/controllers/concerns/spotlight/controller.rb
+++ b/app/controllers/concerns/spotlight/controller.rb
@@ -57,7 +57,7 @@ module Spotlight
     end
 
     def exhibit_masthead?
-      current_exhibit&.masthead && current_exhibit.masthead.display?
+      current_exhibit&.masthead&.display?
     end
 
     def set_locale

--- a/app/controllers/spotlight/browse_controller.rb
+++ b/app/controllers/spotlight/browse_controller.rb
@@ -73,7 +73,7 @@ module Spotlight
     end
 
     def attach_search_breadcrumb
-      add_breadcrumb(@search.full_title, (@group.present? ? exhibit_browse_group_path(@exhibit, @group, @search) : exhibit_browse_path(@exhibit, @search)))
+      add_breadcrumb(@search.full_title, @group.present? ? exhibit_browse_group_path(@exhibit, @group, @search) : exhibit_browse_path(@exhibit, @search))
     end
 
     def _prefixes
@@ -89,7 +89,7 @@ module Spotlight
     end
 
     def resource_masthead?
-      @search&.masthead && @search.masthead.display?
+      @search&.masthead&.display?
     end
 
     # This is overidden for the browse controller context from where it is defined in a helper

--- a/app/controllers/spotlight/searches_controller.rb
+++ b/app/controllers/spotlight/searches_controller.rb
@@ -35,7 +35,8 @@ module Spotlight
     end
 
     def create
-      @search.assign_attributes(search_params.except(:title unless @search.new_record?))
+      params_to_exclude = :title unless @search.new_record?
+      @search.assign_attributes(search_params.except(params_to_exclude))
       @search.query_params = query_params
 
       if @search.save

--- a/app/controllers/spotlight/searches_controller.rb
+++ b/app/controllers/spotlight/searches_controller.rb
@@ -35,7 +35,7 @@ module Spotlight
     end
 
     def create
-      @search.assign_attributes(search_params.except((:title unless @search.new_record?)))
+      @search.assign_attributes(search_params.except(:title unless @search.new_record?))
       @search.query_params = query_params
 
       if @search.save

--- a/app/models/sir_trevor_rails/blocks/displayable.rb
+++ b/app/models/sir_trevor_rails/blocks/displayable.rb
@@ -20,7 +20,7 @@ module SirTrevorRails
       private
 
       def item_values
-        Array((item.values if item.present?))
+        Array(item.values if item.present?)
       end
     end
   end

--- a/app/models/sir_trevor_rails/blocks/displayable.rb
+++ b/app/models/sir_trevor_rails/blocks/displayable.rb
@@ -20,7 +20,8 @@ module SirTrevorRails
       private
 
       def item_values
-        Array(item.values if item.present?)
+        values = item.values if item.present?
+        Array(values)
       end
     end
   end

--- a/app/models/spotlight/lock.rb
+++ b/app/models/spotlight/lock.rb
@@ -16,7 +16,7 @@ module Spotlight
     end
 
     def stale?
-      created_at < (12.hours.ago)
+      created_at < 12.hours.ago
     end
   end
 end


### PR DESCRIPTION
Linter errors for reference:

```
app/controllers/spotlight/searches_controller.rb:38:61: F: Lint/Syntax: unexpected token kUNLESS_MOD
(Using Ruby 3.1 parser; configure using TargetRubyVersion parameter, under AllCops)
      @search.assign_attributes(search_params.except(:title unless @search.new_record?))
                                                            ^^^^^^
app/controllers/spotlight/searches_controller.rb:38:87: F: Lint/Syntax: unexpected token tRPAREN
(Using Ruby 3.1 parser; configure using TargetRubyVersion parameter, under AllCops)
      @search.assign_attributes(search_params.except(:title unless @search.new_record?))
                                                                                      ^
app/models/sir_trevor_rails/blocks/displayable.rb:23:27: F: Lint/Syntax: unexpected token kIF_MOD
(Using Ruby 3.1 parser; configure using TargetRubyVersion parameter, under AllCops)
        Array(item.values if item.present?)
                          ^^
app/models/sir_trevor_rails/blocks/displayable.rb:23:43: F: Lint/Syntax: unexpected token tRPAREN
(Using Ruby 3.1 parser; configure using TargetRubyVersion parameter, under AllCops)
        Array(item.values if item.present?)
```