### PR TITLE
Pin Solr to 9.7 in the solr_wrapper template

### DIFF
--- a/lib/generators/spotlight/templates/.solr_wrapper.yml
+++ b/lib/generators/spotlight/templates/.solr_wrapper.yml
@@ -3,3 +3,4 @@
 collection:
   dir: solr/conf
   name: blacklight-core
+version: 9.7.0


### PR DESCRIPTION
We have it pinned in the project, we should pin it for the template installer as well. Otherwise it is confusing when solr_wrapper fails to start for new installs.