### PR TITLE
Do not allow editing of translatable fields when a locale other than default is selected

### DIFF
--- a/app/components/spotlight/uneditable_non_default_language_component.html.erb
+++ b/app/components/spotlight/uneditable_non_default_language_component.html.erb
@@ -1,0 +1,5 @@
+<p>
+  <%= t('spotlight.exhibits.form.uneditable_non_default_language_form.instructions') %>
+</p>
+<%= edit_translations_button %>
+<%= switch_to_default_language_button %>

--- a/app/components/spotlight/uneditable_non_default_language_component.rb
+++ b/app/components/spotlight/uneditable_non_default_language_component.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Spotlight
+  # Displays a message that this exhibit information cannot be edited in the
+  # currently selected language and provides other options.
+  class UneditableNonDefaultLanguageComponent < ViewComponent::Base
+    def initialize(current_exhibit:, current_language:)
+      @current_exhibit = current_exhibit
+      @current_language = current_language
+      super
+    end
+
+    def edit_translations_button
+      link_to I18n.t('spotlight.exhibits.form.uneditable_non_default_language_form.translations'),
+              helpers.spotlight.edit_exhibit_translations_path(@current_exhibit, locale: @current_language),
+              class: 'btn btn-primary'
+    end
+
+    def switch_to_default_language_button
+      link_to I18n.t('spotlight.exhibits.form.uneditable_non_default_language_form.default_language'),
+              helpers.spotlight.edit_exhibit_path(@current_exhibit, locale: I18n.default_locale),
+              class: 'btn btn-primary'
+    end
+  end
+end

--- a/app/views/spotlight/appearances/edit.html.erb
+++ b/app/views/spotlight/appearances/edit.html.erb
@@ -66,15 +66,20 @@
       </div>
 
       <div role="tabpanel" class="tab-pane" id="main-menu">
-        <%= field_set_tag do %>
-          <p class="instructions"><%= t(:'.main_navigation.help') %></p>
-          <div class="card-group dd main_navigation_admin col-sm-7" id="nested-navigation" data-behavior="nestable" data-max-depth="1">
-            <ol class="dd-list">
-              <%= f.fields_for :main_navigations do |label| %>
-                <%= render layout: 'spotlight/shared/dd3_item', locals: { id: label.object.nav_type, field: label, label: label.object.label_or_default, default_value: label.object.default_label, index: label.index, enabled_method: :display } do; end %>
-              <% end %>
-            </ol>
-          </div>
+        <%# These fields are translatable and should only be edited here in the default locale %>
+        <% if default_language? %>
+          <%= field_set_tag do %>
+            <p class="instructions"><%= t(:'.main_navigation.help') %></p>
+            <div class="card-group dd main_navigation_admin col-sm-7" id="nested-navigation" data-behavior="nestable" data-max-depth="1">
+              <ol class="dd-list">
+                <%= f.fields_for :main_navigations do |label| %>
+                  <%= render layout: 'spotlight/shared/dd3_item', locals: { id: label.object.nav_type, field: label, label: label.object.label_or_default, default_value: label.object.default_label, index: label.index, enabled_method: :display } do; end %>
+                <% end %>
+              </ol>
+            </div>
+          <% end %>
+        <% else %>
+          <%= render Spotlight::UneditableNonDefaultLanguageComponent.new(current_exhibit:, current_language: I18n.locale)%>
         <% end %>
       </div>
     </div>

--- a/app/views/spotlight/exhibits/_form.html.erb
+++ b/app/views/spotlight/exhibits/_form.html.erb
@@ -1,8 +1,8 @@
 <%= bootstrap_form_for @exhibit, url: ((spotlight.exhibit_path(@exhibit) if @exhibit.persisted?) || spotlight.exhibits_path), layout: :horizontal, label_col: 'col-md-2', control_col: 'col-md-10', html: {class: "row"} do |f| %>
 <div class="col-md-12">
   <%= f.text_field :title, disabled: !default_language?, help: !default_language? ? t('.uneditable_non_default_language') : '' %>
-  <%= f.text_field :subtitle %>
-  <%= f.text_area :description %>
+  <%= f.text_field :subtitle, disabled: !default_language?, help: !default_language? ? t('.uneditable_non_default_language') : '' %>
+  <%= f.text_area :description, disabled: !default_language?, help: !default_language? ? t('.uneditable_non_default_language') : '' %>
   <%= render Spotlight::TagListFormComponent.new(form: f) %>
   <%= f.form_group(:contact_emails, label: { text: nil, class: nil, for: 'exhibit_contact_email_0' }, class: 'form-group mb-3', help: nil) do %>
     <%= f.fields_for :contact_emails do |contact| %> 

--- a/app/views/spotlight/metadata_configurations/edit.html.erb
+++ b/app/views/spotlight/metadata_configurations/edit.html.erb
@@ -3,59 +3,59 @@
 <% end %>
 
 <%= configuration_page_title %>
-<%= bootstrap_form_for @blacklight_configuration, url: spotlight.exhibit_metadata_configuration_path(@exhibit), layout: :horizontal, label_col: 'col-md-3 col-sm-3', control_col: 'col-md-5 col-sm-5' do |f| %>
-    <h2><%= t(:'.order_header') %></h2>
+<%# These fields are translatable and should only be edited here in the default locale %>
+<% if default_language? %>
+  <%= bootstrap_form_for @blacklight_configuration, url: spotlight.exhibit_metadata_configuration_path(@exhibit), layout: :horizontal, label_col: 'col-md-3 col-sm-3', control_col: 'col-md-5 col-sm-5' do |f| %>
+      <h2><%= t(:'.order_header') %></h2>
 
-    <p class="instructions"><%= t :'.instructions' %></p>
+      <p class="instructions"><%= t :'.instructions' %></p>
 
-    <table id="nested-fields" class="metadata-configuration table table-striped dd-table">
-      <thead>
-        <tr>
-          <th class="w-50"><%= t :'.field.label' %></th>
-          <th class="text-center">
-            <div>
-              <%= t :'.view.show' %>
-            </div>
-            <div class="text-center">
-               <%= label_tag 'item_details', class: 'select-label'  do %>
-                  <%= select_deselect_action(t :'.view.select_id') %>
-                  <%= t(:'.select_all') %>
-                <% end %>
-             </div>
-          </th>
-          <% available_view_fields.keys.each do |type| %>
+      <table id="nested-fields" class="metadata-configuration table table-striped dd-table">
+        <thead>
+          <tr>
+            <th class="w-50"><%= t :'.field.label' %></th>
             <th class="text-center">
-              <div> 
-                <%= t :".view.#{type}", default: t("blacklight.search.view.#{type}", default: type.to_s.humanize.titleize) %>
+              <div>
+                <%= t :'.view.show' %>
               </div>
               <div class="text-center">
-                <%= label_tag t(:'.deselect_all') + type.to_s, class: 'select-label'  do %>
-                  <%= select_deselect_action(t(:'.deselect_all') + type.to_s) %>
-                  <%= t(:'.select_all') %>
-                <% end %>
+                <%= label_tag 'item_details', class: 'select-label'  do %>
+                    <%= select_deselect_action(t :'.view.select_id') %>
+                    <%= t(:'.select_all') %>
+                  <% end %>
               </div>
             </th>
+            <% available_view_fields.keys.each do |type| %>
+              <th class="text-center">
+                <div> 
+                  <%= t :".view.#{type}", default: t("blacklight.search.view.#{type}", default: type.to_s.humanize.titleize) %>
+                </div>
+                <div class="text-center">
+                  <%= label_tag t(:'.deselect_all') + type.to_s, class: 'select-label'  do %>
+                    <%= select_deselect_action(t(:'.deselect_all') + type.to_s) %>
+                    <%= t(:'.select_all') %>
+                  <% end %>
+                </div>
+              </th>
+            <% end %>
+            <th class="text-center"><%= t :'.type_label' %></th>
+          </tr>
+        </thead>
+        <tbody class="metadata_fields dd dd-list" data-behavior="nestable" data-max-depth="1" data-list-node-name="tbody" data-item-node-name="tr" data-expand-btn-HTML=" " data-collapse-btn-HTML=" ">
+          <%= f.fields_for :index_fields do |idxf| %>
+            <% @blacklight_configuration.blacklight_config.index_fields.select { |k, v| blacklight_configuration_context.evaluate_if_unless_configuration(v.original) }.each do |key, config| %>
+              <%= render partial: 'metadata_field', locals: { key: key, config: config, f: idxf } %>
+            <% end %>
           <% end %>
-          <th class="text-center"><%= t :'.type_label' %></th>
-        </tr>
-      </thead>
-      <tbody class="metadata_fields dd dd-list" data-behavior="nestable" data-max-depth="1" data-list-node-name="tbody" data-item-node-name="tr" data-expand-btn-HTML=" " data-collapse-btn-HTML=" ">
-        <%= f.fields_for :index_fields do |idxf| %>
-          <% @blacklight_configuration.blacklight_config.index_fields.select { |k, v| blacklight_configuration_context.evaluate_if_unless_configuration(v.original) }.each do |key, config| %>
-            <%= render partial: 'metadata_field', locals: { key: key, config: config, f: idxf } %>
-          <% end %>
-        <% end %>
-     </tbody>
-  </table>
+      </tbody>
+    </table>
 
-  <div class="form-actions">
-    <div class="primary-actions">
-      <%= f.submit nil, class: 'btn btn-primary' %>
+    <div class="form-actions">
+      <div class="primary-actions">
+        <%= f.submit nil, class: 'btn btn-primary' %>
+      </div>
     </div>
-  </div>
-<% end %>
-
-
+  <% end %>
     <h2 class="mt-4"><%= t(:'.exhibit_specific.header') %></h2>
     <p class="instructions"><%= t(:'.exhibit_specific.instructions') %></p>
 
@@ -80,4 +80,7 @@
     </table>
 
 
-<%= exhibit_create_link Spotlight::CustomField.new, class: 'btn btn-primary' %>
+  <%= exhibit_create_link Spotlight::CustomField.new, class: 'btn btn-primary' %>
+<% else %>
+  <%= render Spotlight::UneditableNonDefaultLanguageComponent.new(current_exhibit:, current_language: I18n.locale) %>
+<% end %>

--- a/app/views/spotlight/pages/_order_pages.html.erb
+++ b/app/views/spotlight/pages/_order_pages.html.erb
@@ -1,33 +1,38 @@
 <%= curation_page_title t(:"spotlight.pages.index.#{page_collection_name}.header") %>
-<%= bootstrap_form_for @exhibit, url: polymorphic_path([:update_all, @exhibit, page_collection_name.to_sym]), layout: :horizontal, control_col: 'col-sm-10', html: {:'data-form-observer' => true} do |f| %>
+<%# These fields are translatable and should only be edited here in the default locale %>
+<% if default_language? %>
+  <%= bootstrap_form_for @exhibit, url: polymorphic_path([:update_all, @exhibit, page_collection_name.to_sym]), layout: :horizontal, control_col: 'col-sm-10', html: {:'data-form-observer' => true} do |f| %>
 
-    <%= render partial: 'header', locals: {f: f} %>
-    <h2 class="mt-4"><%= t :'.pages_header' %></h2>
-    <p class="instructions"><%= t :'.instructions' %></p>
-    <div class="panel-group dd <%= page_collection_name %>_admin" id="nested-pages" data-behavior="nestable" <%= nestable_data_attributes(page_collection_name).html_safe %> >
-      <ol class="dd-list">
-        <%= f.fields_for page_collection_name do |p| %>
-          <%- if p.object.about_page? || p.object.top_level_page? -%>
-            <%= render partial: 'page', locals: {f: p, parent_form: f} %>
-          <%- end -%>
-        <% end %>
-      </ol>
-    </div>
-    <div class="form-actions float-end">
-      <div class="primary-actions">
-        <%= button_tag action_label(page_collection_name, :update_all), class: "btn btn-primary", disabled: disable_save_pages_button? %>
+      <%= render partial: 'header', locals: {f: f} %>
+      <h2 class="mt-4"><%= t :'.pages_header' %></h2>
+      <p class="instructions"><%= t :'.instructions' %></p>
+      <div class="panel-group dd <%= page_collection_name %>_admin" id="nested-pages" data-behavior="nestable" <%= nestable_data_attributes(page_collection_name).html_safe %> >
+        <ol class="dd-list">
+          <%= f.fields_for page_collection_name do |p| %>
+            <%- if p.object.about_page? || p.object.top_level_page? -%>
+              <%= render partial: 'page', locals: {f: p, parent_form: f} %>
+            <%- end -%>
+          <% end %>
+        </ol>
       </div>
-    </div>
-<%- end -%>
-<div>
-  <%= form_for @page, url: spotlight.polymorphic_path([@exhibit, page_collection_name.to_sym]), html: {class: "expanded-add-button"} do |f|%>
-    <a href='#add-new' class="btn btn-primary" data-turbo="false" data-turbolinks="false" data-expanded-add-button="true" data-field-target="[data-title-field]">
-      <%= t(:'.new_page') %> <%= blacklight_icon('chevron_right') %>
-      <span data-title-field="true" class="input-field">
-        <%= f.text_field(:title) %>
-        <%= f.submit t(:'.save'), data: {behavior: "save"} %>
-        <%= f.submit t(:'.cancel'), data: {behavior: "cancel"} %>
-      </span>
-    </a>
+      <div class="form-actions float-end">
+        <div class="primary-actions">
+          <%= button_tag action_label(page_collection_name, :update_all), class: "btn btn-primary", disabled: disable_save_pages_button? %>
+        </div>
+      </div>
   <%- end -%>
-</div>
+  <div>
+    <%= form_for @page, url: spotlight.polymorphic_path([@exhibit, page_collection_name.to_sym]), html: {class: "expanded-add-button"} do |f|%>
+      <a href='#add-new' class="btn btn-primary" data-turbo="false" data-turbolinks="false" data-expanded-add-button="true" data-field-target="[data-title-field]">
+        <%= t(:'.new_page') %> <%= blacklight_icon('chevron_right') %>
+        <span data-title-field="true" class="input-field">
+          <%= f.text_field(:title) %>
+          <%= f.submit t(:'.save'), data: {behavior: "save"} %>
+          <%= f.submit t(:'.cancel'), data: {behavior: "cancel"} %>
+        </span>
+      </a>
+    <%- end -%>
+  </div>
+<% else %>
+  <%= render Spotlight::UneditableNonDefaultLanguageComponent.new(current_exhibit:, current_language: I18n.locale)%>
+<% end %>

--- a/app/views/spotlight/search_configurations/edit.html.erb
+++ b/app/views/spotlight/search_configurations/edit.html.erb
@@ -3,45 +3,51 @@
 <% end %>
 
 <%= configuration_page_title %>
-<%= bootstrap_form_for @blacklight_configuration, url: spotlight.exhibit_search_configuration_path(@exhibit), layout: :horizontal, label_col: 'col-md-3 col-sm-3', control_col: 'col-md-5 col-sm-5' do |f| %>
 
-  <div role="tabpanel">
-    <ul class="nav nav-tabs" role="tablist">
-      <li role="presentation" class="nav-item">
-        <a href="#options" aria-controls="options" role="tab" data-bs-toggle="tab" class="nav-link active"><%= t(:'.tab.options') %></a>
-      </li>
-      <li role="presentation" class="nav-item">
-        <a href="#facets" aria-controls="facets" role="tab" data-bs-toggle="tab" class="nav-link"><%= t(:'.tab.facets') %></a>
-      </li>
-      <li role="presentation" class="nav-item">
-        <a href="#results" aria-controls="results" role="tab" data-bs-toggle="tab" class="nav-link"><%= t(:'.tab.results') %></a>
-      </li>
-    </ul>
-    <div class="tab-content">
-      <div role="tabpanel" class="tab-pane active" id="options">
-        <%= render 'search_fields', f: f %>
+<%# These fields are translatable and should only be edited here in the default locale %>
+<% if default_language? %>
+  <%= bootstrap_form_for @blacklight_configuration, url: spotlight.exhibit_search_configuration_path(@exhibit), layout: :horizontal, label_col: 'col-md-3 col-sm-3', control_col: 'col-md-5 col-sm-5' do |f| %>
+
+    <div role="tabpanel">
+      <ul class="nav nav-tabs" role="tablist">
+        <li role="presentation" class="nav-item">
+          <a href="#options" aria-controls="options" role="tab" data-bs-toggle="tab" class="nav-link active"><%= t(:'.tab.options') %></a>
+        </li>
+        <li role="presentation" class="nav-item">
+          <a href="#facets" aria-controls="facets" role="tab" data-bs-toggle="tab" class="nav-link"><%= t(:'.tab.facets') %></a>
+        </li>
+        <li role="presentation" class="nav-item">
+          <a href="#results" aria-controls="results" role="tab" data-bs-toggle="tab" class="nav-link"><%= t(:'.tab.results') %></a>
+        </li>
+      </ul>
+      <div class="tab-content">
+        <div role="tabpanel" class="tab-pane active" id="options">
+          <%= render 'search_fields', f: f %>
+        </div>
+
+        <div role="tabpanel" class="tab-pane" id="facets">
+          <%= render 'facets', f: f %>
+        </div>
+
+        <div role="tabpanel" class="tab-pane" id="results">
+          <%= field_set_tag do %>
+            <%= render 'document_index_view_types', f: f %>
+            <%= render 'default_per_page', f: f %>
+          <% end %>
+
+          <%= render 'sort', f: f %>
+        </div>
+
       </div>
-
-      <div role="tabpanel" class="tab-pane" id="facets">
-        <%= render 'facets', f: f %>
-      </div>
-
-      <div role="tabpanel" class="tab-pane" id="results">
-        <%= field_set_tag do %>
-          <%= render 'document_index_view_types', f: f %>
-          <%= render 'default_per_page', f: f %>
-        <% end %>
-
-        <%= render 'sort', f: f %>
-      </div>
-
     </div>
-  </div>
 
-  <div class="form-actions">
-    <div class="primary-actions">
-      <%= f.submit nil, class: 'btn btn-primary' %>
+    <div class="form-actions">
+      <div class="primary-actions">
+        <%= f.submit nil, class: 'btn btn-primary' %>
+      </div>
     </div>
-  </div>
 
+  <% end %>
+<% else %>
+  <%= render Spotlight::UneditableNonDefaultLanguageComponent.new(current_exhibit:, current_language: I18n.locale)%>
 <% end %>

--- a/app/views/spotlight/searches/index.html.erb
+++ b/app/views/spotlight/searches/index.html.erb
@@ -4,14 +4,14 @@
 
 <%= curation_page_title %>
 
-<% if @searches.empty? %>
+<% if @searches.empty? && default_language? %>
   <%= t :'.no_saved_searches' %>
   <% unless @exhibit.searchable? %>
     <p class="instructions alert-warning">
       <%= t(:'.not_searchable_html', href: link_to(t(:'spotlight.configuration.sidebar.search_configuration'), spotlight.edit_exhibit_search_configuration_path(@exhibit))) %>
     </p>
   <% end %>
-<% else %>
+<% elsif default_language? %>
   <div role="tabpanel">
     <ul class="nav nav-tabs" role="tablist">
       <li role="presentation" class="nav-item">
@@ -74,4 +74,6 @@
       </div>
     </div>
   </div>
+<% else %>
+  <%= render Spotlight::UneditableNonDefaultLanguageComponent.new(current_exhibit:, current_language: I18n.locale) %>
 <% end %>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -576,6 +576,10 @@ en:
           published:
             help_block: ''
         uneditable_non_default_language: This field is not editable in the current language. Switch to the default language to edit it.
+        uneditable_non_default_language_form:
+          default_language: Switch to default language
+          instructions: Please use the translations editor or switch to the default language to make configuration changes.
+          translations: Edit translations
       groups:
         all: All
       import:

--- a/spec/views/spotlight/about_pages/index.html.erb_spec.rb
+++ b/spec/views/spotlight/about_pages/index.html.erb_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe 'spotlight/about_pages/index.html.erb', type: :view do
     ]
   end
   let(:exhibit) { stub_model(Spotlight::Exhibit) }
+  let(:default_language) { true }
 
   before do
     allow(view).to receive(:disable_save_pages_button?).and_return(false)
@@ -30,6 +31,7 @@ RSpec.describe 'spotlight/about_pages/index.html.erb', type: :view do
     allow(view).to receive(:exhibit_contacts_path).and_return('/exhibit/1/contacts')
     allow(view).to receive(:exhibit_alt_text_path).and_return('/exhibit/1/alt-text')
     allow(view).to receive(:nestable_data_attributes).and_return('data-behavior="nestable"')
+    allow(view).to receive(:default_language?).and_return(default_language)
     allow(exhibit).to receive_messages(contacts:)
     assign(:page, Spotlight::AboutPage.new)
     assign(:exhibit, exhibit)
@@ -65,6 +67,22 @@ RSpec.describe 'spotlight/about_pages/index.html.erb', type: :view do
       render
       expect(rendered).to have_no_selector 'button[disabled]', text: 'Save changes'
       expect(rendered).to have_selector 'button', text: 'Save changes'
+    end
+  end
+
+  describe 'when a locale other than the default is set' do
+    let(:default_language) { false }
+
+    before do
+      assign(:pages, pages)
+      allow(exhibit).to receive(:about_pages).and_return pages
+      render
+    end
+
+    it 'removes the form and displays a translations message' do
+      expect(rendered).to have_text 'Please use the translations editor'
+      expect(rendered).to have_no_selector '.card-title', text: 'Title1'
+      expect(rendered).to have_no_selector '.card-title', text: 'Title2'
     end
   end
 end

--- a/spec/views/spotlight/exhibits/edit.html.erb_spec.rb
+++ b/spec/views/spotlight/exhibits/edit.html.erb_spec.rb
@@ -2,6 +2,7 @@
 
 RSpec.describe 'spotlight/exhibits/edit', type: :view do
   let(:exhibit) { FactoryBot.create(:exhibit) }
+  let(:default_language) { true }
 
   before do
     assign(:exhibit, exhibit)
@@ -14,7 +15,7 @@ RSpec.describe 'spotlight/exhibits/edit', type: :view do
       exhibit_languages_path: '/',
       exhibit_alt_text_path: '/',
       add_exhibit_language_dropdown_options: [],
-      default_language?: true
+      default_language?: default_language
     )
   end
 
@@ -26,5 +27,18 @@ RSpec.describe 'spotlight/exhibits/edit', type: :view do
     expect(rendered).to have_content 'This action is irreversible'
     expect(rendered).to have_link 'Export data', href: spotlight.edit_exhibit_path(exhibit, anchor: 'export')
     expect(rendered).to have_button 'Import data'
+  end
+
+  describe 'when a locale other than the default is set' do
+    let(:default_language) { false }
+
+    before { render }
+
+    it 'disables the input for translatable fields' do
+      expect(rendered).to have_text 'This field is not editable in the current language'
+      expect(rendered).to have_selector '#exhibit_title[disabled]'
+      expect(rendered).to have_selector '#exhibit_subtitle[disabled]'
+      expect(rendered).to have_selector '#exhibit_description[disabled]'
+    end
   end
 end

--- a/spec/views/spotlight/metadata_configurations/edit.html.erb_spec.rb
+++ b/spec/views/spotlight/metadata_configurations/edit.html.erb_spec.rb
@@ -2,6 +2,7 @@
 
 RSpec.describe 'spotlight/metadata_configurations/edit', type: :view do
   let(:exhibit) { FactoryBot.create(:exhibit) }
+  let(:default_language) { true }
 
   before do
     assign(:exhibit, exhibit)
@@ -11,7 +12,8 @@ RSpec.describe 'spotlight/metadata_configurations/edit', type: :view do
       blacklight_config: exhibit.blacklight_configuration.blacklight_config,
       available_view_fields: { some_view_type: 1, another_view_type: 2 },
       exhibit_alt_text_path: '/',
-      select_deselect_action: nil
+      select_deselect_action: nil,
+      default_language?: default_language
     )
     allow(controller).to receive(:enabled_in_spotlight_view_type_configuration?).and_return(true)
   end
@@ -20,5 +22,17 @@ RSpec.describe 'spotlight/metadata_configurations/edit', type: :view do
     render
     expect(rendered).to have_selector 'th', text: 'Some View Type'
     expect(rendered).to have_selector 'th', text: 'Another View Type'
+  end
+
+  describe 'when a locale other than the default is set' do
+    let(:default_language) { false }
+
+    before { render }
+
+    it 'removes the form and displays a translations message' do
+      expect(rendered).to have_text 'Please use the translations editor'
+      expect(rendered).to have_no_selector 'th', text: 'Some View Type'
+      expect(rendered).to have_no_selector 'th', text: 'Another View Type'
+    end
   end
 end

--- a/spec/views/spotlight/pages/index.html.erb_spec.rb
+++ b/spec/views/spotlight/pages/index.html.erb_spec.rb
@@ -14,11 +14,13 @@ RSpec.describe 'spotlight/pages/index.html.erb', type: :view do
     ]
   end
   let(:exhibit) { stub_model(Spotlight::Exhibit) }
+  let(:default_language) { true }
 
   before do
     allow(view).to receive(:page_collection_name).and_return(:feature_pages)
     allow(view).to receive(:exhibit_alt_text_path).and_return('/')
     allow(view).to receive(:update_all_exhibit_feature_pages_path).and_return('/exhibit/features/update_all')
+    allow(view).to receive(:default_language?).and_return(default_language)
     assign(:page, Spotlight::FeaturePage.new)
     assign(:exhibit, exhibit)
     allow(view).to receive(:current_exhibit).and_return(exhibit)
@@ -38,6 +40,22 @@ RSpec.describe 'spotlight/pages/index.html.erb', type: :view do
       render
       expect(rendered).to have_no_selector 'button[disabled]', text: 'Save changes'
       expect(rendered).to have_selector 'button', text: 'Save changes'
+    end
+  end
+
+  describe 'when a locale other than the default is set' do
+    let(:default_language) { false }
+
+    before do
+      assign(:pages, pages)
+      allow(exhibit).to receive(:feature_pages).and_return pages
+      render
+    end
+
+    it 'removes the form and displays a translations message' do
+      expect(rendered).to have_text 'Please use the translations editor'
+      expect(rendered).to have_no_selector '.card-title', text: 'Title1'
+      expect(rendered).to have_no_selector '.card-title', text: 'Title2'
     end
   end
 end

--- a/spec/views/spotlight/searches/index.html.erb_spec.rb
+++ b/spec/views/spotlight/searches/index.html.erb_spec.rb
@@ -2,9 +2,12 @@
 
 RSpec.describe 'spotlight/searches/index.html.erb', type: :view do
   let(:exhibit) { stub_model(Spotlight::Exhibit) }
+  let(:default_language) { true }
 
   before do
-    allow(view).to receive_messages(update_all_exhibit_searches_path: '/', exhibit_alt_text_path: '/')
+    allow(view).to receive_messages(update_all_exhibit_searches_path: '/',
+                                    exhibit_alt_text_path: '/',
+                                    default_language?: default_language)
     allow(view).to receive(:current_exhibit).and_return(exhibit)
     assign(:exhibit, exhibit)
   end
@@ -28,6 +31,21 @@ This exhibit is not currently searchable. To perform searches that can \
 be saved as additional browse categories, \
 temporarily turn on the Display search box option in the Options section \
 of the Configuration > Search page.)
+    end
+  end
+
+  describe 'when a locale other than the default is set' do
+    let(:default_language) { false }
+
+    before do
+      assign(:searches, [])
+      allow(exhibit).to receive(:searchable?).and_return(true)
+      render
+    end
+
+    it 'removes the form and displays a translations message' do
+      expect(rendered).to have_text 'Please use the translations editor'
+      expect(rendered).to have_no_content 'You can save search results'
     end
   end
 end


### PR DESCRIPTION
Fixes #3478 

More details in https://github.com/sul-dlss/exhibits/issues/2920

This change blocks editing of translatable fields/forms when a locale other than the default is selected. This prevents exhibit editors from unintentionally editing the default locale values and directs them to either switch locales or to use the translations editor:

<img width="815" alt="Screenshot 2025-06-05 at 4 11 33 PM" src="https://github.com/user-attachments/assets/6c842f5b-99b7-4ae0-9583-5b6bece10aac" />

<img width="1009" alt="Screenshot 2025-06-05 at 4 11 45 PM" src="https://github.com/user-attachments/assets/04381446-b5b5-4cff-af4a-2762ca16c8a5" />
