### PR TITLE
Rubocop fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -69,7 +69,7 @@ Metrics/ClassLength:
     - "app/services/spotlight/exhibit_import_export_service.rb"
     - "lib/generators/spotlight/**/*" # Generators tend to have longer class lengths due to their lengthy public API
 
-Naming/PredicateName:
+Naming/PredicatePrefix:
   Exclude:
     - "app/models/concerns/spotlight/ar_light.rb"
 
@@ -89,6 +89,10 @@ Metrics/PerceivedComplexity:
   Exclude:
     - "app/controllers/spotlight/home_pages_controller.rb"
     - "app/services/spotlight/exhibit_import_export_service.rb"
+
+Style/SafeNavigation:
+  Exclude:
+    - "lib/generators/spotlight/assets/importmap_generator.rb"
 
 Rails:
   Enabled: true

--- a/app/controllers/spotlight/catalog_controller.rb
+++ b/app/controllers/spotlight/catalog_controller.rb
@@ -226,7 +226,7 @@ module Spotlight
       redirect_to spotlight.exhibit_root_path(@exhibit) unless has_search_parameters?
     end
 
-    def has_search_parameters? # rubocop:disable Naming/PredicateName
+    def has_search_parameters? # rubocop:disable Naming/PredicatePrefix
       super || params[:browse_category_id].present?
     end
 


### PR DESCRIPTION
`Style/SafeNavigation` can't parse `lib/generators/spotlight/assets/importmap_generator.rb`

`Naming/PredicateName` is now `Naming/PredicatePrefix`