### PR TITLE
Always show the default title and link to the default page

### DIFF
--- a/app/models/spotlight/page.rb
+++ b/app/models/spotlight/page.rb
@@ -52,6 +52,13 @@ module Spotlight
       translated_page_for(I18n.locale)&.title || super
     end
 
+    # Returns the title of the page in the default locale regardless of the current locale.
+    def default_locale_title
+      return self[:title] if I18n.locale == I18n.default_locale || default_locale_page.blank?
+
+      default_locale_page[:title]
+    end
+
     def content_changed!
       @content = nil
     end

--- a/app/views/spotlight/translations/_page.html.erb
+++ b/app/views/spotlight/translations/_page.html.erb
@@ -1,7 +1,7 @@
 <% translated_page = page.translated_page_for(@language) %>
 <tr data-translation-progress-item="true">
   <td>
-    <%= link_to page.title, polymorphic_path([spotlight, current_exhibit, page]) %>
+    <%= link_to page.default_locale_title, polymorphic_path([spotlight, current_exhibit, page], locale: I18n.default_locale) %>
     <p class="<%= 'default-page-outdated' if page.updated_after? translated_page %>">
       <%= l(page.updated_at, format: :long) %>
     </p>

--- a/spec/features/exhibits/translation_editing_spec.rb
+++ b/spec/features/exhibits/translation_editing_spec.rb
@@ -433,7 +433,10 @@ RSpec.describe 'Translation editing', type: :feature do
 
     before do
       exhibit.home_page.clone_for_locale('fr').save
-      about_page.clone_for_locale('fr').tap { |p| p.published = true }.save
+      about_page.clone_for_locale('fr').tap do |p|
+        p.published = true
+        p.title = 'French title'
+      end.save
       visit spotlight.edit_exhibit_translations_path(exhibit, language: 'fr', tab: 'pages')
     end
 
@@ -444,6 +447,11 @@ RSpec.describe 'Translation editing', type: :feature do
       expect(page).to have_no_css('.translation-feature-page-settings input[type="checkbox"]')
       # about page should have a checked checkbox
       expect(page).to have_css('.translation-about-page-settings input[type="checkbox"][checked]')
+    end
+
+    it 'renders the default title and the translated title' do
+      expect(page).to have_text 'French title'
+      expect(page).to have_text 'About page'
     end
   end
 

--- a/spec/models/spotlight/page_spec.rb
+++ b/spec/models/spotlight/page_spec.rb
@@ -132,6 +132,24 @@ RSpec.describe Spotlight::Page, type: :model do
     end
   end
 
+  describe '#default_locale_title' do
+    let(:page) { FactoryBot.create(:feature_page, exhibit:) }
+    let(:translated_page) { FactoryBot.create(:feature_page, exhibit:, locale: 'es', default_locale_page: page) }
+
+    before do
+      translated_page.update(title: 'Translated Title')
+      translated_page.save
+    end
+
+    around do |example|
+      I18n.with_locale(:es) { example.run }
+    end
+
+    it 'returns the title of the default locale page' do
+      expect(translated_page.default_locale_title).to eq page['title']
+    end
+  end
+
   describe 'thumbnail_image_url' do
     subject(:page) { FactoryBot.create(:feature_page, exhibit:) }
 


### PR DESCRIPTION
Part of #3478 

Fixes issue when a locale other than the default is set when viewing the exhibit dashboard translations editor. In the first column we always want the default language page title to display and for the link to go the page in the default language. Before this change it was displaying the page for the currently set locale and also linking to that page.

<img width="1023" alt="Screenshot 2025-06-06 at 9 50 10 AM" src="https://github.com/user-attachments/assets/bb7ab24e-87f1-41e7-815d-062e1d1cde3e" />
