### PR TITLE
Change webmock config to be less permissive

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,7 +33,7 @@ Capybara.javascript_driver = :selenium_chrome_headless
 
 allowed_sites = ['chromedriver.storage.googleapis.com']
 
-WebMock.disable_net_connect!(net_http_connect_on_start: true, allow_localhost: true, allow: allowed_sites)
+WebMock.disable_net_connect!(allow_localhost: true, allow: allowed_sites)
 
 if ENV['COVERAGE'] || ENV['CI']
   require 'simplecov'


### PR DESCRIPTION
This seems to be a better solution than #3508. This was added in https://github.com/projectblacklight/spotlight/pull/2826 which references https://github.com/teamcapybara/capybara#gotchas. I'm not sure what problem this was addressing...