### PR TITLE
Unnecessary disabling of Style/RedundantParentheses

### DIFF
--- a/app/models/spotlight/resource.rb
+++ b/app/models/spotlight/resource.rb
@@ -4,7 +4,6 @@ module Spotlight
   ##
   # Exhibit resources
   class Resource < ActiveRecord::Base
-    # rubocop:disable Style/RedundantParentheses
     class_attribute :indexing_pipeline, default: (Spotlight::Etl::Pipeline.new do |pipeline|
       pipeline.sources = [Spotlight::Etl::Sources::IdentitySource]
       pipeline.transforms = [
@@ -16,7 +15,6 @@ module Spotlight
       ]
       pipeline.loaders = [Spotlight::Etl::SolrLoader]
     end)
-    # rubocop:enable Style/RedundantParentheses
 
     extend ActiveModel::Callbacks
     define_model_callbacks :index


### PR DESCRIPTION
Looks like rubocop fixes this false positive.