### PR TITLE
Specify branch when adding Spotlight to generated Gemfile

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -9,7 +9,7 @@ spotlight_options = ENV.fetch('SPOTLIGHT_INSTALL_OPTIONS', DEFAULT_SPOTLIGHT_OPT
 
 # Add gem dependencies to the application
 gem 'blacklight', '>= 8.7.0', '< 9'
-gem 'blacklight-spotlight', ENV['SPOTLIGHT_GEM'] ? { path: ENV['SPOTLIGHT_GEM'] } : { github: 'projectblacklight/spotlight' }
+gem 'blacklight-spotlight', ENV['SPOTLIGHT_GEM'] ? { path: ENV['SPOTLIGHT_GEM'] } : { github: 'projectblacklight/spotlight', branch: 'main' }
 gem 'sidekiq'
 gem 'bootstrap_form'
 


### PR DESCRIPTION
### Description

Fixes #3536

### Reminders
You can verify this fix locally by checking out this branch, running the generator, and verifying that it does not fail with the error specific in #3536 

Modify the path the spotlight depending on where you have cloned spotlight locally:
```
SKIP_TRANSLATION=1 rails new spotlight-importmap -m ./spotlight/template.rb -a propshaft --css bootstrap
```
