### PR TITLE
Run `yarn link` inside the spotlight directory, not the test app

### DIFF
--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -13,6 +13,16 @@ class TestAppGenerator < Rails::Generators::Base
     gsub_file 'package.json', '.internal_test_app', 'internal_test_app'
   end
 
+  # This makes the assets available in the test app so that changes made in
+  # local development can be picked up automatically
+  def link_frontend
+    # This generator is run from inside the test app; we have to get back up
+    # to spotlight root to link the right project
+    inside('..') do
+      run 'yarn link'
+    end
+  end
+
   def use_capybara3
     gsub_file 'Gemfile', /gem 'capybara'/, '# gem \'capybara\''
   end
@@ -25,12 +35,6 @@ class TestAppGenerator < Rails::Generators::Base
     Bundler.with_unbundled_env do
       run 'bundle install'
     end
-  end
-
-  # This makes the assets available in the test app so that changes made in
-  # local development can be picked up automatically
-  def link_frontend
-    run 'yarn link'
   end
 
   def run_blacklight_generator


### PR DESCRIPTION
fixes #3539

This also moves that yarn link up next to the package_json and before
all the gem stuff, which initially I did just to make it happen sooner
in my repeated runs but seems to slightly increase the thematic
arrangement of the code stanzas

referenced:
- https://github.com/cbeer/engine_cart/blob/c6896bab1e9191e2870db9d187158721dbc2c6eb/README.md#set-up-your-engine-to-use-engine_cart
- https://ruby-doc.org/3.0.7/stdlibs/bundler/Bundler/Thor/Actions.html#method-i-inside

Screenshot after this fix:
<img width="1577" height="238" alt="Screenshot 2025-09-15 at 10 54 11 AM" src="https://github.com/user-attachments/assets/45485c26-f9cc-4d0f-ad1d-bcffe8237508" />
