### PR TITLE
Remove duplicate oembed initializer

### DIFF
--- a/lib/generators/spotlight/install_generator.rb
+++ b/lib/generators/spotlight/install_generator.rb
@@ -125,7 +125,6 @@ module Spotlight
         bundle_install
       end
       generate 'blacklight_oembed:install'
-      copy_file 'config/initializers/oembed.rb'
     end
 
     def add_mailer_defaults

--- a/lib/generators/spotlight/templates/config/initializers/oembed.rb
+++ b/lib/generators/spotlight/templates/config/initializers/oembed.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-require 'oembed'
-OEmbed::Providers.register_all


### PR DESCRIPTION
I don't think this is the CI problem, but blacklight-ombed already does this