### PR TITLE
Fix CanCan ability prioritization

### DIFF
--- a/app/models/spotlight/ability.rb
+++ b/app/models/spotlight/ability.rb
@@ -42,7 +42,7 @@ module Spotlight
       can %i[read curate tag bulk_update], Spotlight::Exhibit, id: user.exhibit_roles.pluck(:resource_id)
 
       # public
-      can :read, Spotlight::HomePage
+      can :read, Spotlight::HomePage, published: true
       can :read, Spotlight::Exhibit, published: true
       can :read, Spotlight::Page, published: true
       can :read, Spotlight::Search, published: true

--- a/spec/controllers/spotlight/pages_controller_spec.rb
+++ b/spec/controllers/spotlight/pages_controller_spec.rb
@@ -22,6 +22,31 @@ RSpec.describe Spotlight::PagesController, type: :controller do
     }
   end
 
+  describe '#index' do
+    let!(:published_feature_page) { FactoryBot.create(:feature_page, exhibit:, published: true) }
+    let!(:unpublished_feature_page) { FactoryBot.create(:feature_page, exhibit:, published: false) }
+    let!(:published_about_page) { FactoryBot.create(:about_page, exhibit:, published: true) }
+
+    before do
+      sign_in user
+    end
+
+    context 'as JSON' do
+      context 'as a curator' do
+        let(:user) { FactoryBot.create(:exhibit_curator, exhibit:) }
+
+        it 'returns all the published exhibit pages' do
+          get :index, params: { exhibit_id: exhibit, format: 'json' }
+          expect(response).to be_successful
+          pages = response.parsed_body
+          expect(pages.length).to eq(3) # the two published pages above + the home page
+          page_ids = pages.pluck('id')
+          expect(page_ids).not_to include(unpublished_feature_page.id)
+        end
+      end
+    end
+  end
+
   describe 'when signed in as a curator' do
     let(:user) { FactoryBot.create(:exhibit_curator, exhibit:) }
 

--- a/spec/features/javascript/blocks/featured_pages_block_spec.rb
+++ b/spec/features/javascript/blocks/featured_pages_block_spec.rb
@@ -25,8 +25,7 @@ RSpec.describe 'Featured Pages Blocks', js: true, type: :feature do
     login_as exhibit_curator
   end
 
-  pending 'saves the selected exhibits' do
-    pending('Prefetched autocomplete does not work the same way as solr-backed autocompletes')
+  it 'saves the selected exhibits' do
     visit spotlight.exhibit_home_page_path(exhibit, exhibit.home_page)
 
     click_link('Edit')


### PR DESCRIPTION
Closes #3249 

`can :read, Spotlight::HomePage` was too broad and was getting applied in situations I don't think we expected:

```ruby
internal(dev)> exhibit.pages.to_sql
=> "SELECT \"spotlight_pages\".* FROM \"spotlight_pages\" WHERE \"spotlight_pages\".\"exhibit_id\" = 1 ORDER BY weight ASC"
internal(dev)> exhibit.pages.accessible_by(ability).to_sql
=> "SELECT \"spotlight_pages\".* FROM \"spotlight_pages\" WHERE \"spotlight_pages\".\"exhibit_id\" = 1 AND \"spotlight_pages\".\"type\" = 'Spotlight::HomePage' ORDER BY weight ASC"
```