### PR TITLE
Don't display special characters in description as html entities

### DIFF
--- a/app/models/spotlight/exhibit.rb
+++ b/app/models/spotlight/exhibit.rb
@@ -87,8 +87,6 @@ module Spotlight
     accepts_nested_attributes_for :contact_emails, reject_if: proc { |attr| attr['email'].blank? }
     accepts_nested_attributes_for :roles, allow_destroy: true, reject_if: proc { |attr| attr['user_key'].blank? && attr['id'].blank? }
 
-    before_save :sanitize_description, if: :description_changed?
-
     def main_about_page
       @main_about_page ||= about_pages.for_locale.published.first
     end
@@ -144,12 +142,6 @@ module Spotlight
 
     def available_locales
       @available_locales ||= languages.pluck(:locale)
-    end
-
-    protected
-
-    def sanitize_description
-      self.description = ::Rails::Html::FullSanitizer.new.sanitize(description)
     end
 
     private

--- a/app/views/spotlight/exhibits/_exhibit_card.html.erb
+++ b/app/views/spotlight/exhibits/_exhibit_card.html.erb
@@ -28,7 +28,7 @@
 
           <% if exhibit.description %>
             <p class="description">
-              <%= exhibit.description %>
+              <%= sanitize(exhibit.description, tags: [], attributes: []) %>
             </p>
           <% end %>
         <% end %>

--- a/app/views/spotlight/exhibits/_exhibit_card.html.erb
+++ b/app/views/spotlight/exhibits/_exhibit_card.html.erb
@@ -28,7 +28,7 @@
 
           <% if exhibit.description %>
             <p class="description">
-              <%= sanitize(exhibit.description, tags: [], attributes: []) %>
+              <%= strip_tags(exhibit.description) %>
             </p>
           <% end %>
         <% end %>

--- a/spec/models/spotlight/exhibit_spec.rb
+++ b/spec/models/spotlight/exhibit_spec.rb
@@ -13,12 +13,6 @@ RSpec.describe Spotlight::Exhibit, type: :model do
     expect(subject.subtitle).to eq 'Test subtitle'
   end
 
-  it 'has a description that strips html tags' do
-    subject.description = 'Test <b>description</b>'
-    subject.save!
-    expect(subject.description).to eq 'Test description'
-  end
-
   it 'has reserved slugs' do
     subject.slug = 'site'
 

--- a/spec/views/spotlight/exhibits/_exhibit_card.html.erb_spec.rb
+++ b/spec/views/spotlight/exhibits/_exhibit_card.html.erb_spec.rb
@@ -32,6 +32,18 @@ RSpec.describe 'spotlight/exhibits/_exhibit_card.html.erb', type: :view do
     expect(rendered).to have_selector '.card-title', text: exhibit.title
   end
 
+  context 'for an exhibit with a description' do
+    before do
+      exhibit.update(description: 'Test <b>description</b> & more.')
+    end
+
+    it 'has a description that strips html tags' do
+      render(p, exhibit:)
+
+      expect(rendered).to have_selector '.description', text: 'Test description & more.'
+    end
+  end
+
   context 'for an unpublished exhibit' do
     before do
       exhibit.update(published: false)


### PR DESCRIPTION
### Description

Fixes https://github.com/projectblacklight/spotlight/issues/3239
- Moves sanitization of description to view layer, per suggestion in [rails-html-sanitizer Readme](https://github.com/rails/rails-html-sanitizer?tab=readme-ov-file#a-note-on-html-entities). The description doesn't seem to be saved outside of typical ActiveRecord model updates, so this looks safe to do, but if anyone knows a reason why we need to sanitize this field before saving to the db, I can add this back.
- ~~Switches to default SafeListSanitizer with an empty tag list instead of FullSanitizer, since it seems like we mostly just want to strip html tags.~~
- We'll need to include a note in the release notes about updating any html entities in saved descriptions in folks' local spotlight instances.
