### PR TITLE
Use exhibit curator in pages widget feature specs

### DIFF
--- a/spec/features/javascript/blocks/featured_pages_block_spec.rb
+++ b/spec/features/javascript/blocks/featured_pages_block_spec.rb
@@ -19,11 +19,10 @@ RSpec.describe 'Featured Pages Blocks', js: true, type: :feature do
     )
   end
 
-  # TODO: Change to exhibit curator role once issue #3249 is fixed
-  let(:site_admin) { FactoryBot.create(:site_admin) }
+  let(:exhibit_curator) { FactoryBot.create(:exhibit_curator, exhibit:) }
 
   before do
-    login_as site_admin
+    login_as exhibit_curator
   end
 
   it 'saves the selected exhibits' do


### PR DESCRIPTION
### Description

Now that the page widget permissions are fixed, we can use the exhibit creator role in the page widget specs. Fixes merge conflict from merging https://github.com/projectblacklight/spotlight/pull/3547 after https://github.com/projectblacklight/spotlight/pull/3550.