### PR TITLE
patch devise mappings

### DIFF
--- a/config/initializers/devise_rails8_patch.rb
+++ b/config/initializers/devise_rails8_patch.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'devise' # make sure it's already loaded
+
+# Starting from Rails 8.0, routes are lazy-loaded by default in test and development environments.
+# However, Devise's mappings are built during the routes loading phase.
+# To ensure it works correctly, we need to load the routes first before accessing @@mappings.
+module Devise
+  def self.mappings
+    Rails.application.try(:reload_routes_unless_loaded)
+    @@mappings
+  end
+end


### PR DESCRIPTION
This fixes frequent / intermittent errors when running individual controller specs or controller specs as a whole in a local environment. example error:

```
main % bundle exec rspec --seed 54353 spec/controllers/spotlight/versions_controller_spec.rb

Randomized with seed 54353

Failures:

  1) Spotlight::VersionsController when not authorized for the exhibit resource POST revert is not allowed
     Failure/Error: sign_in user

     RuntimeError:
       Could not find a valid mapping for #<User id: 1, email: [FILTERED], created_at: "2025-09-16 16:44:45.748330000 +0000", updated_at: "2025-09-16 16:44:45.748330000 +0000", guest: false>
     # ./spec/controllers/spotlight/versions_controller_spec.rb:21:in `block (3 levels) in <top (required)>'
```

For more info see https://github.com/heartcombo/devise/pull/5728

advances #3538