### PR TITLE
Specify versions of carrierwave that work

### DIFF
--- a/blacklight-spotlight.gemspec
+++ b/blacklight-spotlight.gemspec
@@ -26,7 +26,7 @@ these collections.)
   s.add_dependency 'blacklight-gallery', '>= 3.0', '< 5'
   s.add_dependency 'bootstrap_form', '>= 5.4', '< 6'
   s.add_dependency 'cancancan'
-  s.add_dependency 'carrierwave', '~> 2.2'
+  s.add_dependency 'carrierwave', '> 2.2.1', '< 3'
   s.add_dependency 'csv'
   s.add_dependency 'devise', '~> 4.9'
   s.add_dependency 'devise_invitable'


### PR DESCRIPTION
version 2.2.0 of carrierwave is known not to work. Let's avoid it: https://github.com/carrierwaveuploader/carrierwave/issues/2554
