### PR TITLE
Remove Github Markup and add RedCarpet markdown renderer with automatic heading ids

### DIFF
--- a/app/helpers/spotlight/rendering_helper.rb
+++ b/app/helpers/spotlight/rendering_helper.rb
@@ -3,7 +3,7 @@
 module Spotlight
   module RenderingHelper # :nodoc:
     def render_markdown(text)
-      # Extend Redcarpet renderer to strip images and to add HTML anchors to each heading in the output HTML
+      # Extend Redcarpet renderer to add HTML anchors to each heading in the output HTML
       renderer = Redcarpet::Render::HTML.new(with_toc_data: true)
       # Use Redcarpet to render markdown as html
       html = Redcarpet::Markdown.new(renderer).render(text)

--- a/app/helpers/spotlight/rendering_helper.rb
+++ b/app/helpers/spotlight/rendering_helper.rb
@@ -3,7 +3,11 @@
 module Spotlight
   module RenderingHelper # :nodoc:
     def render_markdown(text)
-      GitHub::Markup.render('.md', text).html_safe
+      # Extend Redcarpet renderer to strip images and to add HTML anchors to each heading in the output HTML
+      renderer = Redcarpet::Render::HTML.new(with_toc_data: true)
+      # Use Redcarpet to render markdown as html
+      html = Redcarpet::Markdown.new(renderer).render(text)
+      sanitize(html, attributes: %w[href id])
     end
   end
 end

--- a/app/helpers/spotlight/rendering_helper.rb
+++ b/app/helpers/spotlight/rendering_helper.rb
@@ -6,8 +6,7 @@ module Spotlight
       # Extend Redcarpet renderer to add HTML anchors to each heading in the output HTML
       renderer = Redcarpet::Render::HTML.new(with_toc_data: true)
       # Use Redcarpet to render markdown as html
-      html = Redcarpet::Markdown.new(renderer).render(text)
-      sanitize(html, attributes: %w[href id])
+      Redcarpet::Markdown.new(renderer).render(text).html_safe
     end
   end
 end

--- a/app/views/spotlight/sir_trevor/blocks/_text_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_text_block.html.erb
@@ -1,4 +1,4 @@
 <div class="st__content-block st__content-block--text">
-  <%# We prefer the GitHub markup here. %>
+  <%# We prefer the Redcarpet markup here. %>
   <%= sir_trevor_markdown text_block.text %>
 </div>

--- a/blacklight-spotlight.gemspec
+++ b/blacklight-spotlight.gemspec
@@ -33,7 +33,6 @@ these collections.)
   s.add_dependency 'faraday'
   s.add_dependency 'faraday-follow_redirects'
   s.add_dependency 'friendly_id', '~> 5.5'
-  s.add_dependency 'github-markup'
   s.add_dependency 'google-analytics-data'
   s.add_dependency 'i18n'
   s.add_dependency 'i18n-active_record'

--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -25,8 +25,7 @@ module Spotlight
     isolate_namespace Spotlight
 
     require 'carrierwave'
-    require 'redcarpet' # required for markdown support in github/markup https://github.com/github/markup#markups
-    require 'github/markup'
+    require 'redcarpet' # required for markdown support
     require 'openseadragon'
 
     config.assets.precompile += %w[spotlight/fallback/*.png] if defined?(Sprockets)

--- a/spec/helpers/spotlight/rendering_helper_spec.rb
+++ b/spec/helpers/spotlight/rendering_helper_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Spotlight::RenderingHelper, type: :helper do
-  describe '#sir_trevor_markdown' do
+  describe '#render_markdown' do
     it 'renders basic markdown as html' do
       expect(helper.render_markdown('Here is some **styled text**.').chomp).to match(%r{<p>Here is some <strong>styled text</strong>.</p>})
     end

--- a/spec/helpers/spotlight/rendering_helper_spec.rb
+++ b/spec/helpers/spotlight/rendering_helper_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+RSpec.describe Spotlight::RenderingHelper, type: :helper do
+  describe '#sir_trevor_markdown' do
+    it 'renders basic markdown as html' do
+      expect(helper.render_markdown('Here is some **styled text**.').chomp).to match(%r{<p>Here is some <strong>styled text</strong>.</p>})
+    end
+
+    it 'add heading ids automatically' do
+      expect(helper.render_markdown('## Test Header').chomp).to match(%r{<h2 id="test-header">Test Header</h2>})
+    end
+  end
+end


### PR DESCRIPTION
### Description

Advances #3499, adding automatic heading ids for section linking / table of contents

This ticket removes the gem `github-markup`, which served no purpose other than to [run a default version of the redcarpet markdown renderer](https://github.com/github/markup/blob/ebfff7059dcd84c8ec32df138392decfc6544fda/lib/github/markup/markdown.rb#L15). This update instead uses the `redcarpet` gem directly, including an extension to "add HTML anchors to each header in the output HTML, to allow linking to each section" (see [redcarpet readme](https://github.com/vmg/redcarpet) for details).