### PR TITLE
Use a consistent parenting strategy for page translations

### DIFF
--- a/spec/models/spotlight/page_spec.rb
+++ b/spec/models/spotlight/page_spec.rb
@@ -241,9 +241,10 @@ RSpec.describe Spotlight::Page, type: :model do
       before { child_page_es.save }
 
       it 'updates the translated child pages with the correct parent association' do
-        expect(child_page_es.parent_page).to eq parent_page
+        expect(child_page_es.parent_page).to be_nil
         parent_page_es.save
         expect(child_page_es.reload.parent_page).to eq parent_page_es
+        expect(child_page.reload.parent_page).to eq parent_page
       end
     end
   end
@@ -294,7 +295,7 @@ RSpec.describe Spotlight::Page, type: :model do
       expect(child_page_es.reload.parent_page).to be_nil
     end
 
-    it 'removes the parent page id when the child page is set to an as-yet-untranslated parent page' do
+    it 'resets the parent page id when the child page is set to an as-yet-untranslated parent page' do
       child_page.update(parent_page: another_page)
       expect(child_page_es.reload.parent_page).to be_nil
     end


### PR DESCRIPTION
Fixes #3533 

I believe these these two tests represent incompatible notions of page parent relationships:

https://github.com/projectblacklight/spotlight/blob/e48b227ba5f8981f41109c6d9b1072771f3bea4a/spec/models/spotlight/page_spec.rb#L243-L247

https://github.com/projectblacklight/spotlight/blob/e48b227ba5f8981f41109c6d9b1072771f3bea4a/spec/models/spotlight/page_spec.rb#L297-L300

The first test suggests that a translated child page can and should point its `parent_page` at the default locale parent page when there is no translated parent page available. 

The second test suggests that translated children should have a `nil` parent relationship when the translated parent is missing.

I think this all might be somewhat awkwardly modeled, but `nil` parent relationships make more sense for our existing code.

This bug was caused by a discrepancy with the parent handling between:
https://github.com/projectblacklight/spotlight/blob/e48b227ba5f8981f41109c6d9b1072771f3bea4a/app/models/spotlight/page.rb#L154-L167

and:
https://github.com/projectblacklight/spotlight/blob/e48b227ba5f8981f41109c6d9b1072771f3bea4a/app/models/spotlight/page.rb#L171-L182

This PR would effectively mean you'd use locale to shift laterally between fully independent trees of feature pages

## Checking if you have translated pages that would be impacted
In a Rails console in your Spotlight app:
```ruby
translated_pages = Spotlight::Page.where.not(locale: I18n.default_locale).where.not(parent_page_id: nil)

pages_with_the_bug = translated_pages.select { |page| page.parent_page&.locale&.to_sym == I18n.default_locale }
```

If you have impacted pages (`pages_with_the_bug.length > 0`) you have two choices:
* add translations for all the parent pages of the `pages_with_the_bug` pages
* set the `parent_page` relationship to `nil` for all `pages_with_the_bug` pages

## Potential Future Work
This PR only serves to establish consistency in how we treat page parent relationships, it does not address the somewhat odd behavior than can arise from how they are currently modeled. Take this example, where all pages with the exception of `FP 3` have French translations:
<img width="729" height="456" alt="Screenshot 2025-09-19 at 4 47 37 PM" src="https://github.com/user-attachments/assets/498d7f1d-dbf5-4c0b-8da4-a442c81bb9c9" />

When viewing the exhibit in French the ordering can differ significantly from the default locale because of the mismatch between the page trees and the weights being considered.
<img width="122" height="261" alt="Screenshot 2025-09-19 at 4 47 44 PM" src="https://github.com/user-attachments/assets/22a04c25-9c85-4a8f-a54e-ce7085507059" />

The Spotlight community may want to revisit if this current page translation approach is meeting their needs or if moving to a more simple approach would suffice.