### PR TITLE
Store imported sidecar and resource data with string keys

### DIFF
--- a/app/services/spotlight/exhibit_import_export_service.rb
+++ b/app/services/spotlight/exhibit_import_export_service.rb
@@ -164,12 +164,13 @@ module Spotlight
 
       hash[:custom_fields].each do |attr|
         ar = exhibit.custom_fields.find_or_initialize_by(slug: attr[:slug])
-        attr[:configuration] = attr[:configuration].clone.transform_keys(&:to_s)
+        attr[:configuration] = attr[:configuration].clone.deep_transform_keys(&:to_s) if attr[:configuration]
         ar.update(attr)
       end
 
       hash[:solr_document_sidecars].each do |attr|
         ar = exhibit.solr_document_sidecars.find_or_initialize_by(document_id: attr[:document_id])
+        attr[:data] = attr[:data].clone.deep_transform_keys(&:to_s) if attr[:data]
         ar.update(attr)
       end
 
@@ -177,6 +178,7 @@ module Spotlight
         upload = attr.delete(:upload)
 
         ar = exhibit.resources.find_or_initialize_by(type: attr[:type], url: attr[:url])
+        attr[:data] = attr[:data].clone.deep_transform_keys(&:to_s) if attr[:data]
         ar.update(attr)
 
         deserialize_featured_image(ar, :upload, upload) if upload


### PR DESCRIPTION
This partially addresses #3199 by always importing sidecar and resource data values with string keys. This does not address problem where imported sidecars and resources are not correctly associated with each other.
