### PR TITLE
Add note about renaming pages and reusing slugs to instructions

### DIFF
--- a/app/views/spotlight/pages/_order_pages.html.erb
+++ b/app/views/spotlight/pages/_order_pages.html.erb
@@ -5,7 +5,7 @@
 
       <%= render partial: 'header', locals: {f: f} %>
       <h2 class="mt-4"><%= t :'.pages_header' %></h2>
-      <p class="instructions"><%= t :'.instructions' %></p>
+      <div class="instructions"><%= t :'.instructions_html' %></div>
       <div class="panel-group dd <%= page_collection_name %>_admin" id="nested-pages" data-behavior="nestable" <%= nestable_data_attributes(page_collection_name).html_safe %> >
         <ol class="dd-list">
           <%= f.fields_for page_collection_name do |p| %>

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -762,7 +762,11 @@ en:
         header: New page
       order_pages:
         cancel: Cancel
-        instructions: Add new pages below. Drag and drop pages to change the order in which they are displayed in the sidebar.
+        instructions_html: |
+          <p>Add new pages below. Drag and drop pages to change the order in which they are displayed in the sidebar.</p>
+          <p><b>Note About Page Titles and URLs</b></p>
+          <p>When renaming pages, keep in mind that Spotlight automatically creates a unique URL (called a slug) based on the page title. If another page is already using that slug—even if it has been renamed—the new page's URL will include extra characters to make it unique.</p>
+          <p><b>Tip:</b> If you want a new or renamed page to have a clean URL (e.g., /collection-highlights), make sure to delete the original page that first used that title before renaming.</p>
         new_page: Add new page
         pages_header: Custom pages
         save: Save


### PR DESCRIPTION
### Description

Addresses https://github.com/projectblacklight/spotlight/issues/3515

Adds note to Feature pages and About pages instructions re: how to reuse slugs after renaming pages.

Screenshot from updated Feature pages dashboard:
<img width="992" height="432" alt="Screenshot 2025-09-22 at 12 33 25 PM" src="https://github.com/user-attachments/assets/a4511d85-addd-4b52-81cb-02b8f2a84c57" />
