### PR TITLE
Add basic axe core testing for blocks

### DIFF
--- a/blacklight-spotlight.gemspec
+++ b/blacklight-spotlight.gemspec
@@ -51,6 +51,7 @@ these collections.)
   s.add_dependency 'roar-rails'
   s.add_dependency 'signet'
   s.add_dependency 'view_component', '>= 2.66', '< 4'
+  s.add_development_dependency 'axe-core-rspec'
   s.add_development_dependency 'capybara', '~> 3.31'
   s.add_development_dependency 'engine_cart', '~> 2.0'
   s.add_development_dependency 'factory_bot', '~> 6.0'

--- a/spec/features/javascript/blocks/browse_group_categories_block_spec.rb
+++ b/spec/features/javascript/blocks/browse_group_categories_block_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe 'Browse Group Categories', js: true, type: :feature do
+RSpec.describe 'Browse Group Categories', :js, type: :feature do
   let(:exhibit) { FactoryBot.create(:exhibit) }
   let(:exhibit_curator) { FactoryBot.create(:exhibit_curator, exhibit:) }
 
@@ -60,5 +60,13 @@ RSpec.describe 'Browse Group Categories', js: true, type: :feature do
 
     expect(page).to have_css 'h2', text: 'Pets'
     expect(page).to have_css '.box.category-1', count: 6, visible: false
+  end
+
+  it 'is accessible' do
+    pending 'focusable hidden content fix, see https://github.com/projectblacklight/spotlight/issues/3578'
+    fill_in_typeahead_field with: 'Pets'
+    save_page_changes
+    expect(page).to have_css 'h2', text: 'Pets'
+    expect(page).to be_axe_clean.within '#content'
   end
 end

--- a/spec/features/javascript/blocks/featured_browse_categories_block_spec.rb
+++ b/spec/features/javascript/blocks/featured_browse_categories_block_spec.rb
@@ -32,6 +32,8 @@ RSpec.describe 'Featured Browse Category Block', js: true, type: :feature do
     expect(page).to have_no_css('.category-title', text: search1.title)
     expect(page).to have_css('.category-title', text: search2.title)
     expect(page).to have_css('.item-count', text: /\d+ items/i)
+
+    expect(page).to be_axe_clean.within '#content'
   end
 
   it 'allows the curator to omit document counts' do

--- a/spec/features/javascript/blocks/featured_pages_block_spec.rb
+++ b/spec/features/javascript/blocks/featured_pages_block_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe 'Featured Pages Blocks', js: true, type: :feature do
+RSpec.describe 'Featured Pages Blocks', :js, type: :feature do
   let(:exhibit) { FactoryBot.create(:exhibit) }
   let!(:feature_page1) do
     FactoryBot.create(
@@ -37,6 +37,8 @@ RSpec.describe 'Featured Pages Blocks', js: true, type: :feature do
     save_page_changes
 
     expect(page).to have_content feature_page2.title
+
+    expect(page).to be_axe_clean.within '#content'
   end
 
   it 'does not display the select image area link' do

--- a/spec/features/javascript/blocks/heading_block_spec.rb
+++ b/spec/features/javascript/blocks/heading_block_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+RSpec.feature 'Heading block', :js do
+  let(:exhibit) { FactoryBot.create(:exhibit) }
+  let(:exhibit_curator) { FactoryBot.create(:exhibit_curator, exhibit:) }
+  let!(:feature_page) { FactoryBot.create(:feature_page, exhibit:) }
+
+  before do
+    login_as exhibit_curator
+
+    visit spotlight.edit_exhibit_feature_page_path(exhibit, feature_page)
+  end
+
+  describe 'accessibility' do
+    context 'when used in isolation' do
+      it 'is accessible' do
+        add_widget 'heading'
+        find('.st-text-block.st-text-block--heading').set('My Feature Page Heading')
+
+        save_page_changes
+
+        expect(page).to have_text('My Feature Page Heading')
+        expect(page).to be_axe_clean.within '#content'
+      end
+    end
+
+    context 'when combined with other blocks that render headings' do
+      it 'is accessible' do
+        pending 'heading updates from https://github.com/projectblacklight/spotlight/issues/3535'
+
+        add_widget 'heading'
+        find('.st-text-block.st-text-block--heading').set('My Feature Page Heading')
+
+        add_widget 'solr_documents_embed'
+        fill_in_solr_document_block_typeahead_field with: 'dq287tq6352'
+        fill_in 'Heading', with: 'Embed Heading'
+
+        save_page_changes
+
+        expect(page).to have_text('My Feature Page Heading')
+        expect(page).to be_axe_clean.within '#content'
+      end
+    end
+  end
+end

--- a/spec/features/javascript/blocks/link_to_search_block_spec.rb
+++ b/spec/features/javascript/blocks/link_to_search_block_spec.rb
@@ -32,6 +32,8 @@ RSpec.describe 'Link to Search Block', js: true, type: :feature do
     expect(page).to have_no_css('.category-title', text: search1.title)
     expect(page).to have_css('.category-title', text: search2.title)
     expect(page).to have_css('.item-count', text: /\d+ items/i)
+
+    expect(page).to be_axe_clean.within '#content'
   end
 
   it 'allows the curator to omit document counts' do

--- a/spec/features/javascript/blocks/rule_block_spec.rb
+++ b/spec/features/javascript/blocks/rule_block_spec.rb
@@ -19,5 +19,7 @@ RSpec.describe 'Horizontal rule block', js: true, type: :feature, versioning: tr
     save_page_changes
 
     expect(page).to have_css('hr')
+
+    expect(page).to be_axe_clean.within '#content'
   end
 end

--- a/spec/features/javascript/blocks/search_result_block_spec.rb
+++ b/spec/features/javascript/blocks/search_result_block_spec.rb
@@ -35,5 +35,7 @@ RSpec.describe 'Search Result Block', js: true, type: :feature do
 
     # Documents should exist
     expect(page).to have_css('.documents-gallery .document')
+
+    expect(page).to be_axe_clean.within '#content'
   end
 end

--- a/spec/features/javascript/blocks/solr_documents_block_spec.rb
+++ b/spec/features/javascript/blocks/solr_documents_block_spec.rb
@@ -140,6 +140,8 @@ RSpec.describe 'Solr Document Block', feature: true, max_wait_time: 30, versioni
       expect(page).to have_css('.primary-caption', text: '[World map]')
       expect(page).to have_css('.secondary-caption', text: 'Latin')
     end
+
+    expect(page).to be_axe_clean.within '#content'
   end
 
   it 'allows you to optionally display a ZPR link with the image', js: true do
@@ -149,6 +151,7 @@ RSpec.describe 'Solr Document Block', feature: true, max_wait_time: 30, versioni
 
     save_page_changes
 
+    expect(page).to be_axe_clean.within '#content'
     within '.contents' do
       click_button 'View [World map] larger'
     end

--- a/spec/features/javascript/blocks/solr_documents_carousel_block_spec.rb
+++ b/spec/features/javascript/blocks/solr_documents_carousel_block_spec.rb
@@ -26,4 +26,14 @@ RSpec.describe 'Solr Documents Carousel Block', js: true, type: :feature do
       expect(page).to have_css('.carousel-caption .primary', text: "L'AMERIQUE")
     end
   end
+
+  it 'is accessible' do
+    pending 'heading updates from https://github.com/projectblacklight/spotlight/issues/3535'
+    fill_in_typeahead_field with: 'dq287tq6352'
+    check 'Primary caption'
+    select 'Title', from: 'primary-caption-field'
+    save_page_changes
+
+    expect(page).to be_axe_clean.within '#content'
+  end
 end

--- a/spec/features/javascript/blocks/solr_documents_embed_block_spec.rb
+++ b/spec/features/javascript/blocks/solr_documents_embed_block_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe 'Solr Documents Embed Block', js: true, type: :feature do
+RSpec.describe 'Solr Documents Embed Block', :js, type: :feature do
   let(:exhibit) { FactoryBot.create(:exhibit) }
   let(:exhibit_curator) { FactoryBot.create(:exhibit_curator, exhibit:) }
 
@@ -13,7 +13,7 @@ RSpec.describe 'Solr Documents Embed Block', js: true, type: :feature do
     add_widget 'solr_documents_embed'
   end
 
-  it 'allows you to add a solr documents embed block widget', js: true do
+  it 'allows you to add a solr documents embed block widget' do
     fill_in_solr_document_block_typeahead_field with: 'dq287tq6352'
 
     save_page_changes
@@ -25,14 +25,23 @@ RSpec.describe 'Solr Documents Embed Block', js: true, type: :feature do
     end
   end
 
-  it 'does not display alternative text guidelines', js: true do
+  it 'does not display alternative text guidelines' do
     expect(page).to have_no_content('For each item, please enter alternative text')
     expect(page).to have_no_link('Guidelines for writing alt text.', href: 'https://www.w3.org/WAI/tutorials/images/')
   end
 
-  it 'does not have alt text customization fields', js: true do
+  it 'does not have alt text customization fields' do
     fill_in_solr_document_block_typeahead_field with: 'dq287tq6352'
     expect(page).to have_no_field('Alternative text')
     expect(page).to have_no_field('Decorative')
+  end
+
+  it 'is accessible' do
+    pending 'heading updates from https://github.com/projectblacklight/spotlight/issues/3535'
+    fill_in_solr_document_block_typeahead_field with: 'dq287tq6352'
+    fill_in 'Heading', with: 'A Heading'
+    save_page_changes
+
+    expect(page).to be_axe_clean.within '#content'
   end
 end

--- a/spec/features/javascript/blocks/uploaded_items_block_spec.rb
+++ b/spec/features/javascript/blocks/uploaded_items_block_spec.rb
@@ -41,6 +41,8 @@ RSpec.describe 'Uploaded Items Block', feature: true, js: true, versioning: true
     expect(page).to have_css('h3', text: heading)
     expect(page).to have_css('p', text:)
 
+    expect(page).to be_axe_clean.within '#content'
+
     within('.uploaded-items-block') do
       expect(page).to have_css('img[alt=""]', count: 1)
       expect(page).to have_css('img[alt="Some caption text"]', count: 1)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,7 @@ require 'paper_trail/frameworks/rspec'
 require 'view_component/test_helpers'
 require 'view_component/system_test_helpers'
 
+require 'axe-rspec'
 require 'selenium-webdriver'
 require 'webmock/rspec'
 


### PR DESCRIPTION
Part of #3535

Adds the `axe-core-rspec` gem as a dev dependency. Axe core has good support for heading ordering rules, so this will start to give us some feedback as we make changes.

I've included these directly in the block specs, sometimes piggy-backing on an existing test, in an attempt to keep the number of new/mostly duplicated feature tests to a minimum. It looks like Blacklight moved away from the `be_accessible` helper and is now using `be_axe_clean` directly so I've done the same.