### PR TITLE
Ensure a string is being passed to the CSV parser

### DIFF
--- a/spec/controllers/spotlight/bulk_updates_controller_spec.rb
+++ b/spec/controllers/spotlight/bulk_updates_controller_spec.rb
@@ -46,7 +46,8 @@ RSpec.describe Spotlight::BulkUpdatesController, type: :controller do
           updatable_fields: { tags: 0, visibility: 1 }
         }
 
-        content = CSV.parse(response.body)
+        body_content = response.body.is_a?(Enumerator) ? response.body.to_a.join : response.body
+        content = CSV.parse(body_content)
         expect(content.length).to eq(56)
         expect(content[0]).to eq ['Item ID', 'Item Title', 'Visibility']
       end


### PR DESCRIPTION
Running into this on Rails 8.0.3:
```sh
Failures:

  1) Spotlight::BulkUpdatesController when the user is a curator POST download_template downloads a CSV template
     Failure/Error: content = CSV.parse(response.body)

     NoMethodError:
       undefined method 'close' for an instance of Enumerator
     # ./spec/controllers/spotlight/bulk_updates_controller_spec.rb:49:in 'block (4 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # NoMethodError:
     #   private method 'gets' called for an instance of Enumerator
     #   /opt/hostedtoolcache/Ruby/3.4.6/x64/lib/ruby/gems/3.4.0/gems/csv-3.3.5/lib/csv/parser.rb:323:in 'CSV::Parser::InputsScanner#read_chunk'
```


https://github.com/rails/rails/blob/b0c813bc7b61c71dd21ee3a6c6210f6d14030f71/actionpack/lib/action_dispatch/http/response.rb#L330-L332

https://github.com/rails/rails/blob/529f933fc8b13114d308dd0752f76a9e293c8537/actionpack/lib/action_dispatch/http/response.rb#L356-L364
