### PR TITLE
Expect search_service.search_results to return only response

### DIFF
--- a/app/controllers/spotlight/browse_controller.rb
+++ b/app/controllers/spotlight/browse_controller.rb
@@ -36,9 +36,7 @@ module Spotlight
     end
 
     def show
-      # For Blacklight 8, @document_list will be nil but
-      # will be required for Blacklight 7 to work correctly.
-      @response, @document_list = search_service.search_results do |builder|
+      @response = search_service.search_results do |builder|
         builder.with(params.merge(browse_category_id: @search.id))
       end
 

--- a/app/controllers/spotlight/bulk_actions_controller.rb
+++ b/app/controllers/spotlight/bulk_actions_controller.rb
@@ -39,7 +39,7 @@ module Spotlight
 
     def solr_response
       @solr_response ||= begin
-        response, _docs = search_service.search_results do |builder|
+        response = search_service.search_results do |builder|
           builder.merge(fl: 'id', rows: 0)
         end
 

--- a/app/controllers/spotlight/catalog_controller.rb
+++ b/app/controllers/spotlight/catalog_controller.rb
@@ -73,7 +73,7 @@ module Spotlight
     # setup within their index analyzer. This will ensure that this method returns
     # results when a partial match is passed in the "q" parameter.
     def autocomplete
-      @response, = search_service.search_results do |builder|
+      @response = search_service.search_results do |builder|
         builder.with(builder.blacklight_params.merge(search_field: Spotlight::Engine.config.autocomplete_search_field, public: true, rows: 100))
       end
 
@@ -87,7 +87,7 @@ module Spotlight
     def admin
       add_breadcrumb(t(:'spotlight.curation.sidebar.header'), exhibit_dashboard_path(@exhibit))
       add_breadcrumb(t(:'spotlight.curation.sidebar.items'), admin_exhibit_catalog_path(@exhibit))
-      (@response,) = search_service.search_results
+      @response = search_service.search_results
       @filters = params[:f] || []
 
       respond_to do |format|

--- a/app/controllers/spotlight/dashboards_controller.rb
+++ b/app/controllers/spotlight/dashboards_controller.rb
@@ -57,7 +57,7 @@ module Spotlight
 
     def load_recent_solr_documents(count)
       solr_params = { sort: "#{blacklight_config.index.timestamp_field} desc" }
-      @response, _docs = search_service.search_results do |builder|
+      @response = search_service.search_results do |builder|
         builder.merge(solr_params)
       end
       @response.documents.take(count)

--- a/app/controllers/spotlight/home_pages_controller.rb
+++ b/app/controllers/spotlight/home_pages_controller.rb
@@ -17,7 +17,7 @@ module Spotlight
     end
 
     def show
-      @response, @document_list = search_service.search_results if @page.display_sidebar?
+      @response = search_service.search_results if @page.display_sidebar?
 
       if @page.nil? || !@page.published?
         render '/catalog/index'

--- a/app/controllers/spotlight/searches_controller.rb
+++ b/app/controllers/spotlight/searches_controller.rb
@@ -49,7 +49,7 @@ module Spotlight
 
     def autocomplete
       search_params = autocomplete_params.merge(search_field: Spotlight::Engine.config.autocomplete_search_field)
-      (response, _document_list) = search_service.search_results do |builder|
+      response = search_service.search_results do |builder|
         builder.with(search_params)
       end
 

--- a/app/views/spotlight/sir_trevor/blocks/_search_results_block.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_search_results_block.html.erb
@@ -1,12 +1,12 @@
 <% if search_results_block.searches? %>
 <div class="content-block documents">
-  <% response, document_list = get_search_widget_search_results(search_results_block) %>
+  <% response = get_search_widget_search_results(search_results_block) %>
   <%- unless response.documents.present? %>
     <div class="alert alert-warning">
       <strong>No items to display.</strong> There are currently no items in this exhibit that match the curator's search criteria.
     </div>
   <%- else %>
-      <% @response, @document_list = [response, document_list] %>
+      <% @response = response %>
 
       <% views = blacklight_view_config_for_search_block(search_results_block) %>
       <% if views.length > 1 -%>

--- a/spec/controllers/spotlight/browse_controller_spec.rb
+++ b/spec/controllers/spotlight/browse_controller_spec.rb
@@ -83,11 +83,10 @@ RSpec.describe Spotlight::BrowseController, type: :controller do
     end
 
     describe 'GET show' do
-      let(:mock_response) { double documents: document_list, aggregations: {} }
-      let(:document_list) { double }
+      let(:mock_response) { double documents: double, aggregations: {} }
 
       before do
-        allow(controller).to receive_messages(search_service: double(search_results: [mock_response, document_list]))
+        allow(controller).to receive_messages(search_service: double(search_results: mock_response))
       end
 
       it 'shows the items in the category' do

--- a/spec/controllers/spotlight/catalog_controller_spec.rb
+++ b/spec/controllers/spotlight/catalog_controller_spec.rb
@@ -346,7 +346,7 @@ RSpec.describe Spotlight::CatalogController, type: :controller do
 
     context 'with search parameters' do
       before do
-        allow(subject).to receive(:search_results).and_return([])
+        allow(subject).to receive(:search_results).and_return(double)
       end
 
       it 'preserves query parameters' do

--- a/spec/controllers/spotlight/dashboards_controller_spec.rb
+++ b/spec/controllers/spotlight/dashboards_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Spotlight::DashboardsController, type: :controller do
         exhibit.blacklight_configuration.index = { timestamp_field: 'timestamp_field' }
         exhibit.save!
         # TODO: restore test for: .with(sort: 'timestamp_field desc')
-        expect(controller).to receive(:search_service).and_return(double(search_results: [double(:response, documents: [SolrDocument.new(id: 1)])]))
+        expect(controller).to receive(:search_service).and_return(double(search_results: double(:response, documents: [SolrDocument.new(id: 1)])))
         expect(controller).to receive(:add_breadcrumb).with('Home', exhibit)
         expect(controller).to receive(:add_breadcrumb).with('Dashboard', exhibit_dashboard_path(exhibit))
         get :show, params: { exhibit_id: exhibit.id }

--- a/spec/controllers/spotlight/home_pages_controller_spec.rb
+++ b/spec/controllers/spotlight/home_pages_controller_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Spotlight::HomePagesController, type: :controller, versioning: tr
 
   describe 'GET show' do
     it 'gets search results for display facets' do
-      allow(controller).to receive_messages(search_results: [double, double])
+      allow(controller).to receive_messages(search_results: double)
       get :show, params: { exhibit_id: exhibit }
       expect(assigns[:response]).not_to be_blank
       expect(assigns[:response]&.documents).not_to be_blank
@@ -58,7 +58,7 @@ RSpec.describe Spotlight::HomePagesController, type: :controller, versioning: tr
 
     it 'does not render breadcrumbs' do
       expect(controller).not_to receive(:add_breadcrumb)
-      allow(controller).to receive_messages(search_results: [double, double])
+      allow(controller).to receive_messages(search_results: double)
       get :show, params: { exhibit_id: exhibit }
       expect(response).to be_successful
     end
@@ -66,7 +66,7 @@ RSpec.describe Spotlight::HomePagesController, type: :controller, versioning: tr
     it 'does not do the search when the sidebar is hidden' do
       page.display_sidebar = false
       page.save
-      allow(controller).to receive_messages(search_results: [double, double])
+      allow(controller).to receive_messages(search_results: double)
       get :show, params: { exhibit_id: exhibit }
       expect(assigns).not_to have_key :response
     end

--- a/spec/helpers/spotlight/pages_helper_spec.rb
+++ b/spec/helpers/spotlight/pages_helper_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Spotlight::PagesHelper, type: :helper do
       SirTrevorRails::Blocks::SearchResultsBlock.new(content, home_page)
     end
 
-    let(:search_result) { [double('response'), double('documents')] }
+    let(:search_result) { double('response') }
 
     it 'returns the results for a given search browse category' do
       expect(helper).to receive(:search_results).with({ 'q' => 'query' }).and_return(search_result)


### PR DESCRIPTION
### Description

Addresses https://github.com/projectblacklight/spotlight/issues/3069.

Blacklight::SearchService#search_results returns only a Blacklight::Solr::Response in blacklight 8+, not `[response, document_list]`. We already stopped using document_list in spotlight, but this PR removes all assignments and updates mocked search result objects in specs.