### PR TITLE
Support adding iiif v3 manifests to exhibits

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -74,7 +74,7 @@ Lint/Debugger:
 Lint/DuplicateBranch:
   Exclude:
     - 'app/controllers/spotlight/concerns/application_controller.rb'
-    - 'app/models/spotlight/resources/iiif_manifest/metadata.rb'
+    - 'app/models/spotlight/resources/iiif_manifest_metadata.rb'
 
 # Offense count: 2
 # Configuration parameters: AllowComments, AllowEmptyLambdas.
@@ -536,10 +536,6 @@ Rails/UnknownEnv:
 Rails/UnusedRenderContent:
   Exclude:
     - 'app/controllers/spotlight/lock_controller.rb'
-
-Style/ClassAndModuleChildren:
-  Exclude:
-    - 'app/models/spotlight/resources/iiif_manifest/metadata.rb'
 
 # Offense count: 1
 # This cop supports unsafe autocorrection (--autocorrect-all).

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -74,7 +74,7 @@ Lint/Debugger:
 Lint/DuplicateBranch:
   Exclude:
     - 'app/controllers/spotlight/concerns/application_controller.rb'
-    - 'app/models/spotlight/resources/iiif_manifest.rb'
+    - 'app/models/spotlight/resources/iiif_manifest/metadata.rb'
 
 # Offense count: 2
 # Configuration parameters: AllowComments, AllowEmptyLambdas.
@@ -536,6 +536,10 @@ Rails/UnknownEnv:
 Rails/UnusedRenderContent:
   Exclude:
     - 'app/controllers/spotlight/lock_controller.rb'
+
+Style/ClassAndModuleChildren:
+  Exclude:
+    - 'app/models/spotlight/resources/iiif_manifest/metadata.rb'
 
 # Offense count: 1
 # This cop supports unsafe autocorrection (--autocorrect-all).

--- a/app/models/spotlight/resources/iiif_manifest/metadata.rb
+++ b/app/models/spotlight/resources/iiif_manifest/metadata.rb
@@ -1,0 +1,158 @@
+module Spotlight
+  module Resources
+    ###
+    #  A simple class to map the metadata field
+    #  in a IIIF document to label/value pairs
+    #  This is intended to be overriden by an
+    #  application if a different metadata
+    #  strucure is used by the consumer
+    class IiifManifest::Metadata
+      def initialize(manifest)
+        @manifest = manifest
+      end
+
+      def to_solr
+        metadata_hash.merge(manifest_level_metadata)
+      end
+
+      def label
+        return unless manifest&.label
+
+        Array(json_ld_value(manifest.label)).map { |v| html_sanitize(v) }.first
+      end
+
+      private
+
+      attr_reader :manifest
+
+      def metadata
+        manifest&.metadata || []
+      end
+
+      def metadata_hash
+        return {} if metadata.blank?
+        return {} unless metadata.is_a?(Array)
+
+        metadata.each_with_object({}) do |md, hash|
+          next unless md['label'] && md['value']
+
+          label = Array(json_ld_value(md['label'])).first
+
+          hash[label] ||= []
+          hash[label] += Array(json_ld_value(md['value'])).map { |v| html_sanitize(v) }
+        end
+      end
+
+      def manifest_level_metadata
+        return manifest_level_metadata_v2 unless manifest_level_metadata_v2.empty?
+
+        manifest_level_metadata_v3
+      end
+
+      def manifest_level_metadata_v2
+        @manifest_level_metadata_v2 ||=
+          manifest2_fields.each_with_object({}) do |field, hash|
+            next unless manifest.respond_to?(field) && manifest.send(field).present?
+
+            hash[field.capitalize] ||= []
+            hash[field.capitalize] += Array(json_ld_value(manifest.send(field))).map { |v| html_sanitize(v) }
+          end
+      end
+
+      def manifest2_fields
+        %w[attribution description license]
+      end
+
+      def manifest_level_metadata_v3
+        manifest3_fields.each_with_object({}) do |field, hash|
+          manifest_key, solr_key = field
+          next unless manifest.respond_to?(manifest_key) && manifest.send(manifest_key).present?
+
+          hash[solr_key.capitalize] ||= []
+          hash[solr_key.capitalize] += Array(json_ld_value(manifest.send(manifest_key))).map { |v| html_sanitize(v) }
+        end.merge(attribution_v3)
+      end
+
+      def manifest3_fields
+        { rights: 'license', summary: 'description' }
+      end
+
+      def attribution_v3
+        rs = manifest['required_statement']
+        return {} if rs.blank?
+
+        key = json_ld_value(rs['label']).first
+        val = json_ld_value(rs['value'])
+        { key => val }
+      end
+
+      # rubocop:disable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
+      def json_ld_value(value)
+        case value
+          # In the case where multiple values are supplied, clients must use the following algorithm to determine which values to display to the user.
+        when Array
+          # IIIF v2, multivalued monolingual, or multivalued multilingual values
+
+          # If none of the values have a language associated with them, the client must display all of the values.
+          if value.none? { |v| v.is_a?(Hash) && v.key?('@language') }
+            value.map { |v| json_ld_value(v) }
+            # If any of the values have a language associated with them, the client must display all of the values associated with the language that best
+            # matches the language preference.
+          elsif value.any? { |v| v.is_a?(Hash) && v['@language'] == default_json_ld_language }
+            value.select { |v| v.is_a?(Hash) && v['@language'] == default_json_ld_language }.pluck('@value')
+            # If all of the values have a language associated with them, and none match the language preference, the client must select a language
+            # and display all of the values associated with that language.
+          elsif value.all? { |v| v.is_a?(Hash) && v.key?('@language') }
+            selected_json_ld_language = value.find { |v| v.is_a?(Hash) && v.key?('@language') }
+
+            value.select { |v| v.is_a?(Hash) && v['@language'] == selected_json_ld_language['@language'] }
+                 .pluck('@value')
+            # If some of the values have a language associated with them, but none match the language preference, the client must display all of the values
+            # that do not have a language associated with them.
+          else
+            value.select { |v| !v.is_a?(Hash) || !v.key?('@language') }.map { |v| json_ld_value(v) }
+          end
+        when Hash
+          # IIIF v2 single-valued value
+          if value.key? '@value'
+            value['@value']
+            # IIIF v3 multilingual(?), multivalued(?) values
+            # If all of the values are associated with the none key, the client must display all of those values.
+          elsif value.keys == ['none']
+            value['none']
+            # If any of the values have a language associated with them, the client must display all of the values associated with the language
+            # that best matches the language preference.
+          elsif value.key? default_json_ld_language
+            value[default_json_ld_language]
+            # If some of the values have a language associated with them, but none match the language preference, the client must display all
+            # of the values that do not have a language associated with them.
+          elsif value.key? 'none'
+            value['none']
+            # If all of the values have a language associated with them, and none match the language preference, the client must select a
+            # language and display all of the values associated with that language.
+          else
+            value.values.first
+          end
+        else
+          # plain old string/number/boolean
+          value
+        end
+      end
+      # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
+
+      def html_sanitize(value)
+        return value unless value.is_a? String
+
+        html_sanitizer.sanitize(value)
+      end
+
+      def html_sanitizer
+        @html_sanitizer ||= Rails::Html::FullSanitizer.new
+      end
+
+      def default_json_ld_language
+        Spotlight::Engine.config.default_json_ld_language
+      end
+    end
+  end
+end

--- a/app/models/spotlight/resources/iiif_manifest/metadata.rb
+++ b/app/models/spotlight/resources/iiif_manifest/metadata.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Spotlight
   module Resources
     ###
@@ -6,6 +8,7 @@ module Spotlight
     #  This is intended to be overriden by an
     #  application if a different metadata
     #  strucure is used by the consumer
+    #  override with Spotlight::Engine.config.iiif_metadata_class
     class IiifManifest::Metadata
       def initialize(manifest)
         @manifest = manifest

--- a/app/models/spotlight/resources/iiif_manifest_metadata.rb
+++ b/app/models/spotlight/resources/iiif_manifest_metadata.rb
@@ -9,7 +9,7 @@ module Spotlight
     #  application if a different metadata
     #  strucure is used by the consumer
     #  override with Spotlight::Engine.config.iiif_metadata_class
-    class IiifManifest::Metadata
+    class IiifManifestMetadata
       def initialize(manifest)
         @manifest = manifest
       end

--- a/app/models/spotlight/resources/iiif_manifest_v3.rb
+++ b/app/models/spotlight/resources/iiif_manifest_v3.rb
@@ -2,6 +2,7 @@
 
 module Spotlight
   module Resources
+    # A PORO to construct a solr hash for a given v3 IiifManifest
     class IiifManifestV3 < Spotlight::Resources::IiifManifest
       private
 
@@ -9,62 +10,6 @@ module Spotlight
         return unless thumbnail_field && manifest['thumbnail'].present?
 
         solr_hash[thumbnail_field] = manifest.thumbnail.map(&:id)
-      end
-
-      def add_full_image_urls
-        return unless full_image_field && full_image_url
-
-        solr_hash[full_image_field] = full_image_url
-      end
-
-      def add_label
-        return unless title_fields.present? && manifest&.label
-
-        Array.wrap(title_fields).each do |field|
-          solr_hash[field] = metadata_class.new(manifest).label
-        end
-      end
-
-      def add_image_urls
-        solr_hash[tile_source_field] = image_urls
-      end
-
-      def add_metadata
-        solr_hash.merge!(manifest_metadata)
-        sidecar.update(data: sidecar.data.merge(manifest_metadata))
-      end
-
-      def manifest_metadata
-        metadata = metadata_class.new(manifest).to_solr
-        return {} if metadata.blank?
-
-        create_sidecars_for(*metadata.keys)
-
-        metadata.each_with_object({}) do |(key, value), hash|
-          next unless (field = exhibit_custom_fields[key])
-
-          hash[field.field] = value
-        end
-      end
-
-      def create_sidecars_for(*keys)
-        missing_keys(keys).each do |k|
-          exhibit.custom_fields.create! label: k, readonly_field: true
-        end
-        @exhibit_custom_fields = nil
-      end
-
-      def missing_keys(keys)
-        custom_field_keys = exhibit_custom_fields.keys.map(&:downcase)
-        keys.reject do |key|
-          custom_field_keys.include?(key.downcase)
-        end
-      end
-
-      def exhibit_custom_fields
-        @exhibit_custom_fields ||= exhibit.custom_fields.index_by do |value|
-          value.label
-        end
       end
 
       def image_urls
@@ -90,38 +35,6 @@ module Spotlight
 
       def canvases
         manifest.try(:items).select { |canvas| canvas.type == 'Canvas' }
-      end
-
-      def sequences
-        manifest.try(:sequences) || []
-      end
-
-      def thumbnail_field
-        blacklight_config.index.thumbnail_field
-      end
-
-      def full_image_field
-        Spotlight::Engine.config.full_image_field
-      end
-
-      def tile_source_field
-        blacklight_config.show.tile_source_field
-      end
-
-      def title_fields
-        Spotlight::Engine.config.iiif_title_fields || blacklight_config.index&.title_field
-      end
-
-      def sidecar
-        @sidecar ||= document_model.new(id: compound_id).sidecar(exhibit)
-      end
-
-      def document_model
-        exhibit.blacklight_config.document_model
-      end
-
-      def metadata_class
-        Spotlight::Engine.config.iiif_metadata_class.call
       end
     end
   end

--- a/blacklight-spotlight.gemspec
+++ b/blacklight-spotlight.gemspec
@@ -37,7 +37,7 @@ these collections.)
   s.add_dependency 'i18n'
   s.add_dependency 'i18n-active_record'
   s.add_dependency 'iiif_manifest'
-  s.add_dependency 'iiif-presentation'
+  s.add_dependency 'iiif-presentation', '>=1.4.1'
   s.add_dependency 'mini_magick'
   s.add_dependency 'nokogiri'
   s.add_dependency 'oauth2'

--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -157,7 +157,7 @@ module Spotlight
     ]
 
     config.iiif_manifest_field = :iiif_manifest_url_ssi
-    config.iiif_metadata_class = -> { Spotlight::Resources::IiifManifest::Metadata }
+    config.iiif_metadata_class = -> { Spotlight::Resources::IiifManifestMetadata }
     config.iiif_collection_id_field = :collection_id_ssim
     config.iiif_title_fields = nil
     config.default_json_ld_language = 'en'

--- a/spec/fixtures/iiif_responses.rb
+++ b/spec/fixtures/iiif_responses.rb
@@ -677,7 +677,7 @@ module IiifResponses
         },
         'value' => {
           'en' => [
-            '<span>Glen Robson, IIIF Technical Coordinator. <a href="https://creativecommons.org/licenses/by-sa/3.0">CC BY-SA 3.0</a> <a href="https://creativecommons.org/licenses/by-sa/3.0" title="CC BY-SA 3.0"><img src="https://licensebuttons.net/l/by-sa/3.0/88x31.png"/></a></span>'
+            '<span>Glen Robson, IIIF Technical Coordinator. <a href="https://creativecommons.org/licenses/by-sa/3.0">CC BY-SA 3.0</a>'
           ]
         }
       },

--- a/spec/fixtures/iiif_responses.rb
+++ b/spec/fixtures/iiif_responses.rb
@@ -447,12 +447,13 @@ module IiifResponses
                     'height' => 4468,
                     'width' => 5998,
                     'format' => 'image/jpeg',
-                    'service' =>
+                    'service' => [
                       {
                         '@id' => 'https://iiif-cloud.example.org/iiif/2/for-v3-manifest/image-1/intermediate_file',
                         'profile' => 'http://iiif.io/api/image/2/level2.json',
                         '@type' => 'ImageService2'
                       }
+                    ]
                   },
                   'id' => 'https://example.org/concern/scanned_maps/for-v3-manifest/manifest/canvas/image-1/annotation_page/page-1/annotation/annotation-1',
                   'target' => 'https://example.org/concern/scanned_maps/for-v3-manifest/manifest/canvas/image-1'
@@ -473,12 +474,13 @@ module IiifResponses
               'height' => 149,
               'width' => 200,
               'format' => 'image/jpeg',
-              'service' =>
+              'service' => [
                 {
                   '@id' => 'https://iiif-cloud.example.org/iiif/2/for-v3-manifest/image-1/intermediate_file',
                   'profile' => 'http://iiif.io/api/image/2/level2.json',
                   '@type' => 'ImageService2'
                 }
+              ]
             }
           ],
           'local_identifier' => 'p6w926v351',
@@ -634,12 +636,13 @@ module IiifResponses
                     'format' => 'image/jpeg',
                     'width' => 1114,
                     'height' => 991,
-                    'service' =>
+                    'service' => [
                       {
                         'id' => 'https://iiif.io/api/image/3.0/example/reference/329817fc8a251a01c393f517d8a17d87-Whistlers_Mother',
                         'profile' => 'level1',
                         'type' => 'ImageService3'
                       }
+                    ]
                   },
                   'target' => 'https://iiif.io/api/cookbook/recipe/0006-text-language/canvas/p1'
                 }

--- a/spec/fixtures/iiif_responses.rb
+++ b/spec/fixtures/iiif_responses.rb
@@ -314,12 +314,10 @@ module IiifResponses
     {
       '@context' => [
         'http://www.w3.org/ns/anno.jsonld',
-        'http://iiif.io/api/presentation/3/context.json',
-        'http://iiif.io/api/extension/navplace/context.json'
+        'http://iiif.io/api/presentation/3/context.json'
       ],
       'type' => 'Manifest',
       'id' => 'uri://for-v3-manifest',
-      # 'id' => 'https://figgy.princeton.edu/concern/scanned_maps/3c184604-3f83-4b42-a1f5-96e417a9cd39/manifest',
       'label' => {
         'eng' => [
           'A Map of the British and French settlements in North America'
@@ -336,18 +334,6 @@ module IiifResponses
         'individuals'
       ],
       'metadata' => [
-        {
-          'label' => {
-            'eng' => [
-              'Alternative'
-            ]
-          },
-          'value' => {
-            'eng' => [
-              'Fort Frederick at Crown Point built by the French, 1731'
-            ]
-          }
-        },
         {
           'label' => {
             'eng' => [
@@ -376,18 +362,6 @@ module IiifResponses
         {
           'label' => {
             'eng' => [
-              'Provenance'
-            ]
-          },
-          'value' => {
-            'eng' => [
-              'Princeton'
-            ]
-          }
-        },
-        {
-          'label' => {
-            'eng' => [
               'Contributor'
             ]
           },
@@ -400,85 +374,12 @@ module IiifResponses
         {
           'label' => {
             'eng' => [
-              'Date'
-            ]
-          },
-          'value' => {
-            'eng' => [
-              '1755'
-            ]
-          }
-        },
-        {
-          'label' => {
-            'eng' => [
-              'Language'
-            ]
-          },
-          'value' => {
-            'eng' => [
-              'English'
-            ]
-          }
-        },
-        {
-          'label' => {
-            'eng' => [
-              'Local Identifier'
-            ]
-          },
-          'value' => {
-            'eng' => %w[
-              p02873d24h
-              PUmap_9170
-            ]
-          }
-        },
-        {
-          'label' => {
-            'eng' => [
-              'Publisher'
-            ]
-          },
-          'value' => {
-            'eng' => [
-              '[London] J. Hinton [1755]'
-            ]
-          }
-        },
-        {
-          'label' => {
-            'eng' => [
-              'Subject'
-            ]
-          },
-          'value' => {
-            'eng' => [
-              'France—Colonies—America—Maps—Early works to 1800'
-            ]
-          }
-        },
-        {
-          'label' => {
-            'eng' => [
               'Cartographic Scale'
             ]
           },
           'value' => {
             'eng' => [
               'Scale [ca. 1:10,000,000].'
-            ]
-          }
-        },
-        {
-          'label' => {
-            'eng' => [
-              'Source Metadata Identifier'
-            ]
-          },
-          'value' => {
-            'eng' => [
-              '9952772633506421'
             ]
           }
         },
@@ -505,57 +406,6 @@ module IiifResponses
               'Electronic Resource'
             ]
           }
-        },
-        {
-          'label' => {
-            'eng' => [
-              'Location'
-            ]
-          },
-          'value' => {
-            'eng' => [
-              'MAP HMC01.1058',
-              'MAP Electronic Resource',
-              'ELF1 HMC01.1058',
-              'ELF1 Electronic Resource'
-            ]
-          }
-        },
-        {
-          'label' => {
-            'eng' => [
-              'Downloadable'
-            ]
-          },
-          'value' => {
-            'eng' => [
-              'public'
-            ]
-          }
-        },
-        {
-          'label' => {
-            'eng' => [
-              'Held By'
-            ]
-          },
-          'value' => {
-            'eng' => [
-              'Princeton'
-            ]
-          }
-        },
-        {
-          'label' => {
-            'eng' => [
-              'Ark'
-            ]
-          },
-          'value' => {
-            'eng' => [
-              'http://arks.princeton.edu/ark:/88435/z603r034k'
-            ]
-          }
         }
       ],
       'rendering' => [
@@ -567,10 +417,10 @@ module IiifResponses
             ]
           },
           'format' => 'application/pdf',
-          'id' => 'https://figgy.princeton.edu/concern/scanned_maps/3c184604-3f83-4b42-a1f5-96e417a9cd39/pdf'
+          'id' => 'https://example.org/concern/scanned_maps/for-v3-manifest/pdf'
         },
         {
-          'id' => 'http://arks.princeton.edu/ark:/88435/z603r034k',
+          'id' => 'http://example.org/for-v3-manifest/permanent-link',
           'format' => 'text/html',
           'type' => 'Text',
           'label' => {
@@ -583,7 +433,7 @@ module IiifResponses
       'items' => [
         {
           'type' => 'Canvas',
-          'id' => 'https://figgy.princeton.edu/concern/scanned_maps/3c184604-3f83-4b42-a1f5-96e417a9cd39/manifest/canvas/e6069b67-5662-466b-afd4-66cd43b2002b',
+          'id' => 'https://example.org/concern/scanned_maps/for-v3-manifest/manifest/canvas/image-1',
           'items' => [
             {
               'type' => 'AnnotationPage',
@@ -592,23 +442,23 @@ module IiifResponses
                   'type' => 'Annotation',
                   'motivation' => 'painting',
                   'body' => {
-                    'id' => 'https://iiif-cloud.princeton.edu/iiif/2/e2%2Fba%2F71%2Fe2ba715dae604c948c5380ed731ba01f%2Fintermediate_file/full/1000,/0/default.jpg',
+                    'id' => 'https://iiif-cloud.example.org/iiif/2/for-v3-manifest/image-1/intermediate_file/full/1000,/0/default.jpg',
                     'type' => 'Image',
                     'height' => 4468,
                     'width' => 5998,
                     'format' => 'image/jpeg',
                     'service' =>
                       {
-                        '@id' => 'https://iiif-cloud.princeton.edu/iiif/2/e2%2Fba%2F71%2Fe2ba715dae604c948c5380ed731ba01f%2Fintermediate_file',
+                        '@id' => 'https://iiif-cloud.example.org/iiif/2/for-v3-manifest/image-1/intermediate_file',
                         'profile' => 'http://iiif.io/api/image/2/level2.json',
                         '@type' => 'ImageService2'
                       }
                   },
-                  'id' => 'https://figgy.princeton.edu/concern/scanned_maps/3c184604-3f83-4b42-a1f5-96e417a9cd39/manifest/canvas/e6069b67-5662-466b-afd4-66cd43b2002b/annotation_page/145c3782-b2b0-4e5c-8f1f-4b465f661530/annotation/73519466-bb68-4238-aea9-6256a67280c9',
-                  'target' => 'https://figgy.princeton.edu/concern/scanned_maps/3c184604-3f83-4b42-a1f5-96e417a9cd39/manifest/canvas/e6069b67-5662-466b-afd4-66cd43b2002b'
+                  'id' => 'https://example.org/concern/scanned_maps/for-v3-manifest/manifest/canvas/image-1/annotation_page/page-1/annotation/annotation-1',
+                  'target' => 'https://example.org/concern/scanned_maps/for-v3-manifest/manifest/canvas/image-1'
                 }
               ],
-              'id' => 'https://figgy.princeton.edu/concern/scanned_maps/3c184604-3f83-4b42-a1f5-96e417a9cd39/manifest/canvas/e6069b67-5662-466b-afd4-66cd43b2002b/annotation_page/145c3782-b2b0-4e5c-8f1f-4b465f661530'
+              'id' => 'https://example.org/concern/scanned_maps/for-v3-manifest/manifest/canvas/image-1/annotation_page/page-1'
             }
           ],
           'label' => {
@@ -618,14 +468,14 @@ module IiifResponses
           },
           'thumbnail' => [
             {
-              'id' => 'https://iiif-cloud.princeton.edu/iiif/2/e2%2Fba%2F71%2Fe2ba715dae604c948c5380ed731ba01f%2Fintermediate_file/full/!200,200/0/default.jpg',
+              'id' => 'https://iiif-cloud.example.org/iiif/2/for-v3-manifest/image-1/intermediate_file/full/!200,200/0/default.jpg',
               'type' => 'Image',
               'height' => 149,
               'width' => 200,
               'format' => 'image/jpeg',
               'service' =>
                 {
-                  '@id' => 'https://iiif-cloud.princeton.edu/iiif/2/e2%2Fba%2F71%2Fe2ba715dae604c948c5380ed731ba01f%2Fintermediate_file',
+                  '@id' => 'https://iiif-cloud.example.org/iiif/2/for-v3-manifest/image-1/intermediate_file',
                   'profile' => 'http://iiif.io/api/image/2/level2.json',
                   '@type' => 'ImageService2'
                 }
@@ -634,7 +484,7 @@ module IiifResponses
           'local_identifier' => 'p6w926v351',
           'rendering' => [
             {
-              'id' => 'https://figgy.princeton.edu/downloads/e6069b67-5662-466b-afd4-66cd43b2002b/file/3f25a806-11fd-4ae3-b54f-275752376ef9',
+              'id' => 'https://example.org/downloads/for-v3-manifest/file/image-1',
               'format' => 'image/tiff',
               'type' => 'Dataset',
               'label' => {
@@ -654,18 +504,6 @@ module IiifResponses
           'type' => 'Image',
           'format' => 'image/jpeg',
           'height' => 150
-        }
-      ],
-      'seeAlso' => [
-        {
-          'id' => 'https://figgy.princeton.edu/catalog/3c184604-3f83-4b42-a1f5-96e417a9cd39.jsonld',
-          'type' => 'Dataset',
-          'format' => 'application/ld+json'
-        },
-        {
-          'id' => 'https://catalog.princeton.edu/catalog/9952772633506421.marcxml',
-          'type' => 'Dataset',
-          'format' => 'text/xml'
         }
       ],
       'rights' => 'http://rightsstatements.org/vocab/NKC/1.0/',
@@ -692,7 +530,7 @@ module IiifResponses
           },
           'logo' => [
             {
-              'id' => 'https://figgy.princeton.edu/pul_logo_icon.png',
+              'id' => 'https://example.org/pul_logo_icon.png',
               'type' => 'Image',
               'format' => 'image/png',
               'height' => 100,

--- a/spec/fixtures/iiif_responses.rb
+++ b/spec/fixtures/iiif_responses.rb
@@ -309,4 +309,507 @@ module IiifResponses
           { '@language' => 'en', '@value' => 'Japanese' }] }
       ] }.to_json
   end
+
+  def test_v3_manifest
+    {
+      '@context' => [
+        'http://www.w3.org/ns/anno.jsonld',
+        'http://iiif.io/api/presentation/3/context.json',
+        'http://iiif.io/api/extension/navplace/context.json'
+      ],
+      'type' => 'Manifest',
+      'id' => 'uri://for-v3-manifest',
+      # 'id' => 'https://figgy.princeton.edu/concern/scanned_maps/3c184604-3f83-4b42-a1f5-96e417a9cd39/manifest',
+      'label' => {
+        'eng' => [
+          'A Map of the British and French settlements in North America'
+        ]
+      },
+      'summary' => {
+        'eng' => [
+          'Relief shown pictorially.',
+          'From the Universal magazine of knowledge and pleasure. v. 17, Oct. 1755, p. 144-145.',
+          'Inset: Fort Frederick at Crown Point built by the French, 1731.'
+        ]
+      },
+      'behavior' => [
+        'individuals'
+      ],
+      'metadata' => [
+        {
+          'label' => {
+            'eng' => [
+              'Alternative'
+            ]
+          },
+          'value' => {
+            'eng' => [
+              'Fort Frederick at Crown Point built by the French, 1731'
+            ]
+          }
+        },
+        {
+          'label' => {
+            'eng' => [
+              'Title'
+            ]
+          },
+          'value' => {
+            'eng' => [
+              'Map of the British and French settlements in North America',
+              'A Map of the British and French settlements in North America'
+            ]
+          }
+        },
+        {
+          'label' => {
+            'eng' => [
+              'Type'
+            ]
+          },
+          'value' => {
+            'eng' => [
+              'Maps'
+            ]
+          }
+        },
+        {
+          'label' => {
+            'eng' => [
+              'Provenance'
+            ]
+          },
+          'value' => {
+            'eng' => [
+              'Princeton'
+            ]
+          }
+        },
+        {
+          'label' => {
+            'eng' => [
+              'Contributor'
+            ]
+          },
+          'value' => {
+            'eng' => [
+              'Hinton, John, d. 1781'
+            ]
+          }
+        },
+        {
+          'label' => {
+            'eng' => [
+              'Date'
+            ]
+          },
+          'value' => {
+            'eng' => [
+              '1755'
+            ]
+          }
+        },
+        {
+          'label' => {
+            'eng' => [
+              'Language'
+            ]
+          },
+          'value' => {
+            'eng' => [
+              'English'
+            ]
+          }
+        },
+        {
+          'label' => {
+            'eng' => [
+              'Local Identifier'
+            ]
+          },
+          'value' => {
+            'eng' => %w[
+              p02873d24h
+              PUmap_9170
+            ]
+          }
+        },
+        {
+          'label' => {
+            'eng' => [
+              'Publisher'
+            ]
+          },
+          'value' => {
+            'eng' => [
+              '[London] J. Hinton [1755]'
+            ]
+          }
+        },
+        {
+          'label' => {
+            'eng' => [
+              'Subject'
+            ]
+          },
+          'value' => {
+            'eng' => [
+              'France—Colonies—America—Maps—Early works to 1800'
+            ]
+          }
+        },
+        {
+          'label' => {
+            'eng' => [
+              'Cartographic Scale'
+            ]
+          },
+          'value' => {
+            'eng' => [
+              'Scale [ca. 1:10,000,000].'
+            ]
+          }
+        },
+        {
+          'label' => {
+            'eng' => [
+              'Source Metadata Identifier'
+            ]
+          },
+          'value' => {
+            'eng' => [
+              '9952772633506421'
+            ]
+          }
+        },
+        {
+          'label' => {
+            'eng' => [
+              'Call Number'
+            ]
+          },
+          'value' => {
+            'eng' => [
+              'HMC01.1058'
+            ]
+          }
+        },
+        {
+          'label' => {
+            'eng' => [
+              'Call Number'
+            ]
+          },
+          'value' => {
+            'eng' => [
+              'Electronic Resource'
+            ]
+          }
+        },
+        {
+          'label' => {
+            'eng' => [
+              'Location'
+            ]
+          },
+          'value' => {
+            'eng' => [
+              'MAP HMC01.1058',
+              'MAP Electronic Resource',
+              'ELF1 HMC01.1058',
+              'ELF1 Electronic Resource'
+            ]
+          }
+        },
+        {
+          'label' => {
+            'eng' => [
+              'Downloadable'
+            ]
+          },
+          'value' => {
+            'eng' => [
+              'public'
+            ]
+          }
+        },
+        {
+          'label' => {
+            'eng' => [
+              'Held By'
+            ]
+          },
+          'value' => {
+            'eng' => [
+              'Princeton'
+            ]
+          }
+        },
+        {
+          'label' => {
+            'eng' => [
+              'Ark'
+            ]
+          },
+          'value' => {
+            'eng' => [
+              'http://arks.princeton.edu/ark:/88435/z603r034k'
+            ]
+          }
+        }
+      ],
+      'rendering' => [
+        {
+          'type' => 'Text',
+          'label' => {
+            'en' => [
+              'Download as PDF'
+            ]
+          },
+          'format' => 'application/pdf',
+          'id' => 'https://figgy.princeton.edu/concern/scanned_maps/3c184604-3f83-4b42-a1f5-96e417a9cd39/pdf'
+        },
+        {
+          'id' => 'http://arks.princeton.edu/ark:/88435/z603r034k',
+          'format' => 'text/html',
+          'type' => 'Text',
+          'label' => {
+            'en' => [
+              'View in catalog'
+            ]
+          }
+        }
+      ],
+      'items' => [
+        {
+          'type' => 'Canvas',
+          'id' => 'https://figgy.princeton.edu/concern/scanned_maps/3c184604-3f83-4b42-a1f5-96e417a9cd39/manifest/canvas/e6069b67-5662-466b-afd4-66cd43b2002b',
+          'items' => [
+            {
+              'type' => 'AnnotationPage',
+              'items' => [
+                {
+                  'type' => 'Annotation',
+                  'motivation' => 'painting',
+                  'body' => {
+                    'id' => 'https://iiif-cloud.princeton.edu/iiif/2/e2%2Fba%2F71%2Fe2ba715dae604c948c5380ed731ba01f%2Fintermediate_file/full/1000,/0/default.jpg',
+                    'type' => 'Image',
+                    'height' => 4468,
+                    'width' => 5998,
+                    'format' => 'image/jpeg',
+                    'service' =>
+                      {
+                        '@id' => 'https://iiif-cloud.princeton.edu/iiif/2/e2%2Fba%2F71%2Fe2ba715dae604c948c5380ed731ba01f%2Fintermediate_file',
+                        'profile' => 'http://iiif.io/api/image/2/level2.json',
+                        '@type' => 'ImageService2'
+                      }
+                  },
+                  'id' => 'https://figgy.princeton.edu/concern/scanned_maps/3c184604-3f83-4b42-a1f5-96e417a9cd39/manifest/canvas/e6069b67-5662-466b-afd4-66cd43b2002b/annotation_page/145c3782-b2b0-4e5c-8f1f-4b465f661530/annotation/73519466-bb68-4238-aea9-6256a67280c9',
+                  'target' => 'https://figgy.princeton.edu/concern/scanned_maps/3c184604-3f83-4b42-a1f5-96e417a9cd39/manifest/canvas/e6069b67-5662-466b-afd4-66cd43b2002b'
+                }
+              ],
+              'id' => 'https://figgy.princeton.edu/concern/scanned_maps/3c184604-3f83-4b42-a1f5-96e417a9cd39/manifest/canvas/e6069b67-5662-466b-afd4-66cd43b2002b/annotation_page/145c3782-b2b0-4e5c-8f1f-4b465f661530'
+            }
+          ],
+          'label' => {
+            'eng' => [
+              'PUmap_9170'
+            ]
+          },
+          'thumbnail' => [
+            {
+              'id' => 'https://iiif-cloud.princeton.edu/iiif/2/e2%2Fba%2F71%2Fe2ba715dae604c948c5380ed731ba01f%2Fintermediate_file/full/!200,200/0/default.jpg',
+              'type' => 'Image',
+              'height' => 149,
+              'width' => 200,
+              'format' => 'image/jpeg',
+              'service' =>
+                {
+                  '@id' => 'https://iiif-cloud.princeton.edu/iiif/2/e2%2Fba%2F71%2Fe2ba715dae604c948c5380ed731ba01f%2Fintermediate_file',
+                  'profile' => 'http://iiif.io/api/image/2/level2.json',
+                  '@type' => 'ImageService2'
+                }
+            }
+          ],
+          'local_identifier' => 'p6w926v351',
+          'rendering' => [
+            {
+              'id' => 'https://figgy.princeton.edu/downloads/e6069b67-5662-466b-afd4-66cd43b2002b/file/3f25a806-11fd-4ae3-b54f-275752376ef9',
+              'format' => 'image/tiff',
+              'type' => 'Dataset',
+              'label' => {
+                'en' => [
+                  'Download the original file'
+                ]
+              }
+            }
+          ],
+          'width' => 5998,
+          'height' => 4468
+        }
+      ],
+      'thumbnail' => [
+        {
+          'id' => 'uri://to-thumbnail',
+          'type' => 'Image',
+          'format' => 'image/jpeg',
+          'height' => 150
+        }
+      ],
+      'seeAlso' => [
+        {
+          'id' => 'https://figgy.princeton.edu/catalog/3c184604-3f83-4b42-a1f5-96e417a9cd39.jsonld',
+          'type' => 'Dataset',
+          'format' => 'application/ld+json'
+        },
+        {
+          'id' => 'https://catalog.princeton.edu/catalog/9952772633506421.marcxml',
+          'type' => 'Dataset',
+          'format' => 'text/xml'
+        }
+      ],
+      'rights' => 'http://rightsstatements.org/vocab/NKC/1.0/',
+      'requiredStatement' => {
+        'label' => {
+          'en' => [
+            'Attribution'
+          ]
+        },
+        'value' => {
+          'en' => [
+            '<span>Glen Robson, IIIF Technical Coordinator. <a href="https://creativecommons.org/licenses/by-sa/3.0">CC BY-SA 3.0</a> <a href="https://creativecommons.org/licenses/by-sa/3.0" title="CC BY-SA 3.0"><img src="https://licensebuttons.net/l/by-sa/3.0/88x31.png"/></a></span>'
+          ]
+        }
+      },
+      'provider' => [
+        {
+          'id' => 'https://library.princeton.edu',
+          'type' => 'Agent',
+          'label' => {
+            'en' => [
+              'Princeton University Library'
+            ]
+          },
+          'logo' => [
+            {
+              'id' => 'https://figgy.princeton.edu/pul_logo_icon.png',
+              'type' => 'Image',
+              'format' => 'image/png',
+              'height' => 100,
+              'width' => 120
+            }
+          ]
+        }
+      ]
+    }.to_json
+  end
+
+  def test_multilingual_v3_manifest
+    {
+      '@context' => 'http://iiif.io/api/presentation/3/context.json',
+      'id' => 'https://iiif.io/api/cookbook/recipe/0006-text-language/manifest.json',
+      'type' => 'Manifest',
+      'label' => {
+        'en' => [
+          "Whistler's Mother"
+        ],
+        'fr' => [
+          'La Mère de Whistler'
+        ]
+      },
+      'metadata' => [
+        {
+          'label' => {
+            'en' => [
+              'Creator'
+            ],
+            'fr' => [
+              'Auteur'
+            ]
+          },
+          'value' => {
+            'none' => [
+              'Whistler, James Abbott McNeill'
+            ]
+          }
+        },
+        {
+          'label' => {
+            'en' => [
+              'Subject'
+            ],
+            'fr' => [
+              'Sujet'
+            ]
+          },
+          'value' => {
+            'en' => [
+              'McNeill Anna Matilda, mother of Whistler (1804-1881)'
+            ],
+            'fr' => [
+              'McNeill Anna Matilda, mère de Whistler (1804-1881)'
+            ]
+          }
+        }
+      ],
+      'summary' => {
+        'en' => [
+          "Arrangement in Grey and Black No. 1, also called Portrait of the Artist's Mother."
+        ],
+        'fr' => [
+          "Arrangement en gris et noir n°1, also called Portrait de la mère de l'artiste."
+        ]
+      },
+      'requiredStatement' => {
+        'label' => {
+          'en' => [
+            'Held By'
+          ],
+          'fr' => [
+            'Détenu par'
+          ]
+        },
+        'value' => {
+          'none' => [
+            "Musée d'Orsay, Paris, France"
+          ]
+        }
+      },
+      'items' => [
+        {
+          'id' => 'https://iiif.io/api/cookbook/recipe/0006-text-language/canvas/p1',
+          'type' => 'Canvas',
+          'width' => 1114,
+          'height' => 991,
+          'items' => [
+            {
+              'id' => 'https://iiif.io/api/cookbook/recipe/0006-text-language/page/p1/1',
+              'type' => 'AnnotationPage',
+              'items' => [
+                {
+                  'id' => 'https://iiif.io/api/cookbook/recipe/0006-text-language/annotation/p0001-image',
+                  'type' => 'Annotation',
+                  'motivation' => 'painting',
+                  'body' => {
+                    'id' => 'https://iiif.io/api/image/3.0/example/reference/329817fc8a251a01c393f517d8a17d87-Whistlers_Mother/full/max/0/default.jpg',
+                    'type' => 'Image',
+                    'format' => 'image/jpeg',
+                    'width' => 1114,
+                    'height' => 991,
+                    'service' =>
+                      {
+                        'id' => 'https://iiif.io/api/image/3.0/example/reference/329817fc8a251a01c393f517d8a17d87-Whistlers_Mother',
+                        'profile' => 'level1',
+                        'type' => 'ImageService3'
+                      }
+                  },
+                  'target' => 'https://iiif.io/api/cookbook/recipe/0006-text-language/canvas/p1'
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }.to_json
+  end
 end

--- a/spec/models/spotlight/resources/iiif_manifest_v3_spec.rb
+++ b/spec/models/spotlight/resources/iiif_manifest_v3_spec.rb
@@ -67,13 +67,13 @@ RSpec.describe Spotlight::Resources::IiifManifestV3 do
 
     describe 'full size image url' do
       it 'is included in the solr document' do
-        expect(subject.to_solr[:full_image_url_ssm]).to eq 'https://iiif-cloud.princeton.edu/iiif/2/e2%2Fba%2F71%2Fe2ba715dae604c948c5380ed731ba01f%2Fintermediate_file'
+        expect(subject.to_solr[:full_image_url_ssm]).to eq 'https://iiif-cloud.example.org/iiif/2/for-v3-manifest/image-1/intermediate_file'
       end
     end
 
     describe 'info url' do
       it 'is included in the solr document when present' do
-        expect(subject.to_solr[:content_metadata_image_iiif_info_ssm]).to eq ['https://iiif-cloud.princeton.edu/iiif/2/e2%2Fba%2F71%2Fe2ba715dae604c948c5380ed731ba01f%2Fintermediate_file/info.json']
+        expect(subject.to_solr[:content_metadata_image_iiif_info_ssm]).to eq ['https://iiif-cloud.example.org/iiif/2/for-v3-manifest/image-1/intermediate_file/info.json']
       end
     end
 
@@ -106,11 +106,11 @@ RSpec.describe Spotlight::Resources::IiifManifestV3 do
       end
 
       it 'exhibit custom fields are created for the necessary fields' do
-        expect { subject.to_solr }.to change(Spotlight::CustomField, :count).by(20)
+        expect { subject.to_solr }.to change(Spotlight::CustomField, :count).by(8)
       end
 
       it 'creates read-only custom fields' do
-        expect { subject.to_solr }.to change(Spotlight::CustomField.where(readonly_field: true), :count).by(20)
+        expect { subject.to_solr }.to change(Spotlight::CustomField.where(readonly_field: true), :count).by(8)
       end
 
       context 'custom class' do

--- a/spec/models/spotlight/resources/iiif_manifest_v3_spec.rb
+++ b/spec/models/spotlight/resources/iiif_manifest_v3_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Spotlight::Resources::IiifManifestV3 do
     describe 'metadata' do
       it 'includes the top-level attribution' do
         expect(subject.to_solr['readonly_attribution_tesim']).to eq [
-          '<span>Glen Robson, IIIF Technical Coordinator. <a href="https://creativecommons.org/licenses/by-sa/3.0">CC BY-SA 3.0</a> <a href="https://creativecommons.org/licenses/by-sa/3.0" title="CC BY-SA 3.0"><img src="https://licensebuttons.net/l/by-sa/3.0/88x31.png"/></a></span>'
+          '<span>Glen Robson, IIIF Technical Coordinator. <a href="https://creativecommons.org/licenses/by-sa/3.0">CC BY-SA 3.0</a>'
         ]
       end
 

--- a/spec/models/spotlight/resources/iiif_manifest_v3_spec.rb
+++ b/spec/models/spotlight/resources/iiif_manifest_v3_spec.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+class TestMetadataClass
+  def initialize(*); end
+
+  def to_solr
+    { 'test_field' => 'metadata-to-solr' }
+  end
+
+  def label; end
+end
+
+RSpec.describe Spotlight::Resources::IiifManifestV3 do
+  subject { described_class.new(url:, manifest:, collection:) }
+
+  let(:url) { 'uri://to-manifest' }
+
+  let(:collection) { double(compound_id: '1') }
+  let(:manifest_fixture) { test_v3_manifest }
+
+  before do
+    stub_iiif_response_for_url(url, manifest_fixture)
+    subject.with_exhibit(exhibit)
+  end
+
+  describe '#to_solr' do
+    let(:manifest) { Spotlight::Resources::IiifService.new(url).send(:object) }
+    let(:exhibit) { FactoryBot.create(:exhibit) }
+
+    describe 'id' do
+      it 'is an MD5 hexdigest of the exhibit id and the and the url' do
+        expected = Digest::MD5.hexdigest("#{exhibit.id}-#{url}")
+        expect(subject.to_solr[:id]).to eq expected
+      end
+    end
+
+    describe 'label' do
+      it 'is included in the solr document when present' do
+        expect(subject.to_solr['full_title_tesim']).to eq 'A Map of the British and French settlements in North America'
+      end
+
+      it 'indexes to multiple fields when configured' do
+        allow(Spotlight::Engine.config).to receive(:iiif_title_fields).at_least(:once).and_return(%w[title_field1 title_field2])
+
+        expect(subject.to_solr['title_field1']).to eq 'A Map of the British and French settlements in North America'
+        expect(subject.to_solr['title_field2']).to eq 'A Map of the British and French settlements in North America'
+      end
+    end
+
+    describe 'collection id' do
+      it 'is included when a collection is given' do
+        expect(subject.to_solr[:collection_id_ssim]).to eq ['1']
+      end
+    end
+
+    describe 'manifest url' do
+      it 'is inlcuded in the solr document when present' do
+        expect(subject.to_solr[:iiif_manifest_url_ssi]).to eq url
+      end
+    end
+
+    describe 'thumbnail url' do
+      it 'is inlcuded in the solr document when present' do
+        expect(subject.to_solr[:thumbnail_url_ssm]).to eq ['uri://to-thumbnail']
+      end
+    end
+
+    describe 'full size image url' do
+      it 'is included in the solr document' do
+        expect(subject.to_solr[:full_image_url_ssm]).to eq 'https://iiif-cloud.princeton.edu/iiif/2/e2%2Fba%2F71%2Fe2ba715dae604c948c5380ed731ba01f%2Fintermediate_file'
+      end
+    end
+
+    describe 'info url' do
+      it 'is included in the solr document when present' do
+        expect(subject.to_solr[:content_metadata_image_iiif_info_ssm]).to eq ['https://iiif-cloud.princeton.edu/iiif/2/e2%2Fba%2F71%2Fe2ba715dae604c948c5380ed731ba01f%2Fintermediate_file/info.json']
+      end
+    end
+
+    describe 'metadata' do
+      it 'includes the top-level attribution' do
+        expect(subject.to_solr['readonly_attribution_tesim']).to eq [
+          '<span>Glen Robson, IIIF Technical Coordinator. <a href="https://creativecommons.org/licenses/by-sa/3.0">CC BY-SA 3.0</a> <a href="https://creativecommons.org/licenses/by-sa/3.0" title="CC BY-SA 3.0"><img src="https://licensebuttons.net/l/by-sa/3.0/88x31.png"/></a></span>'
+        ]
+      end
+
+      it 'includes the top-level description' do
+        expect(subject.to_solr['readonly_description_tesim']).to eq [
+          'Relief shown pictorially.',
+          'From the Universal magazine of knowledge and pleasure. v. 17, Oct. 1755, p. 144-145.',
+          'Inset: Fort Frederick at Crown Point built by the French, 1731.'
+        ]
+      end
+
+      it 'includes the top-level license' do
+        expect(subject.to_solr['readonly_license_tesim']).to eq ['http://rightsstatements.org/vocab/NKC/1.0/']
+      end
+
+      it 'includes fields for each label/value pair in the metadata section' do
+        expect(subject.to_solr['readonly_contributor_tesim']).to include 'Hinton, John, d. 1781'
+        expect(subject.to_solr['readonly_cartographic-scale_tesim']).to eq ['Scale [ca. 1:10,000,000].']
+      end
+
+      it 'collects items with the same label into an array' do
+        expect(subject.to_solr['readonly_call-number_tesim']).to eq ['HMC01.1058', 'Electronic Resource']
+      end
+
+      it 'exhibit custom fields are created for the necessary fields' do
+        expect { subject.to_solr }.to change(Spotlight::CustomField, :count).by(20)
+      end
+
+      it 'creates read-only custom fields' do
+        expect { subject.to_solr }.to change(Spotlight::CustomField.where(readonly_field: true), :count).by(20)
+      end
+
+      context 'custom class' do
+        before do
+          allow(Spotlight::Engine.config).to receive(:iiif_metadata_class).and_return(-> { TestMetadataClass })
+        end
+
+        it 'merges the solr hash from the configured custom metadata class' do
+          expect(subject.to_solr['readonly_test_field_tesim']).to eq 'metadata-to-solr'
+        end
+      end
+    end
+
+    context 'with a multilingual manifest' do
+      let(:manifest_fixture) { test_multilingual_v3_manifest }
+
+      describe 'label' do
+        it 'is included in the solr document when present' do
+          expect(subject.to_solr['full_title_tesim']).to eq "Whistler's Mother"
+        end
+      end
+
+      describe 'metadata' do
+        it 'extracts labels and values out of multivalued data and removes HTML markup' do
+          expect(subject.to_solr).to include 'readonly_creator_tesim' => ['Whistler, James Abbott McNeill'],
+                                             'readonly_subject_tesim' => ['McNeill Anna Matilda, mother of Whistler (1804-1881)']
+        end
+
+        it 'extracts data using the configured default language' do
+          allow(Spotlight::Engine.config).to receive(:default_json_ld_language).and_return('fr')
+          expect(subject.to_solr).to include 'readonly_auteur_tesim' => ['Whistler, James Abbott McNeill'],
+                                             'readonly_sujet_tesim' => ['McNeill Anna Matilda, mère de Whistler (1804-1881)']
+        end
+
+        it 'falls back to a language from the manifest using the IIIF rules' do
+          allow(Spotlight::Engine.config).to receive(:default_json_ld_language).and_return('de')
+          expect(subject.to_solr).to include 'readonly_creator_tesim' => ['Whistler, James Abbott McNeill'],
+                                             'readonly_subject_tesim' => ['McNeill Anna Matilda, mother of Whistler (1804-1881)']
+        end
+      end
+    end
+  end
+end

--- a/spec/models/spotlight/resources/iiif_service_spec.rb
+++ b/spec/models/spotlight/resources/iiif_service_spec.rb
@@ -37,21 +37,53 @@ RSpec.describe Spotlight::Resources::IiifService do
   end
 
   describe '#parse' do
-    let(:manifests) { described_class.parse(url) }
+    let(:parsed) { described_class.parse(url) }
 
-    it 'recursively traverses all all the collections and returns manifests' do
-      expect(manifests).to be_all do |manifest|
-        manifest.is_a?(Spotlight::Resources::IiifManifest)
+    context 'for a collection manifest' do
+      it 'recursively traverses all all the collections and returns manifests' do
+        expect(parsed).to be_all do |manifest|
+          manifest.is_a?(Spotlight::Resources::IiifManifest)
+        end
+      end
+
+      it 'returns manifests representing collection documents' do
+        expect(parsed.count).to eq 8
+      end
+
+      it 'keeps track of the parent collection' do
+        arr = parsed.to_a
+        expect(arr[1].collection).to eq arr[0]
       end
     end
 
-    it 'returns manifests representing collection documents' do
-      expect(manifests.count).to eq 8
+    context 'for a v3 manifest' do
+      let(:url) { 'uri://for-v3-manifest' }
+
+      it 'returns a v3 manifest object' do
+        klass = parsed.first.class
+        expect(klass).to eq Spotlight::Resources::IiifManifestV3
+      end
+    end
+  end
+
+  # TODO: remove this, it's a protected method, just supporting development
+  describe '#object' do
+    let(:object) { described_class.new(url).send(:object) }
+
+    context 'for a v2 manifest' do
+      let(:url) { 'uri://for-manifest1' }
+
+      it 'returns a v2 manifest object' do
+        expect(object.class).to eq IIIF::Presentation::Manifest
+      end
     end
 
-    it 'keeps track of the parent collection' do
-      arr = manifests.to_a
-      expect(arr[1].collection).to eq arr[0]
+    context 'for a v3 manifest' do
+      let(:url) { 'uri://for-v3-manifest' }
+
+      it 'returns a v3 manifest object' do
+        expect(object.class).to eq IIIF::V3::Presentation::Manifest
+      end
     end
   end
 end

--- a/spec/models/spotlight/resources/iiif_service_spec.rb
+++ b/spec/models/spotlight/resources/iiif_service_spec.rb
@@ -65,25 +65,4 @@ RSpec.describe Spotlight::Resources::IiifService do
       end
     end
   end
-
-  # TODO: remove this, it's a protected method, just supporting development
-  describe '#object' do
-    let(:object) { described_class.new(url).send(:object) }
-
-    context 'for a v2 manifest' do
-      let(:url) { 'uri://for-manifest1' }
-
-      it 'returns a v2 manifest object' do
-        expect(object.class).to eq IIIF::Presentation::Manifest
-      end
-    end
-
-    context 'for a v3 manifest' do
-      let(:url) { 'uri://for-v3-manifest' }
-
-      it 'returns a v3 manifest object' do
-        expect(object.class).to eq IIIF::V3::Presentation::Manifest
-      end
-    end
-  end
 end

--- a/spec/support/stub_iiif_response.rb
+++ b/spec/support/stub_iiif_response.rb
@@ -17,6 +17,7 @@ module StubIiifResponse
     stub_iiif_response_for_url('uri://for-manifest2', test_manifest2)
     stub_iiif_response_for_url('uri://for-manifest3', test_manifest3)
     stub_iiif_response_for_url('uri://for-manifest4', test_manifest4)
+    stub_iiif_response_for_url('uri://for-v3-manifest', test_v3_manifest)
   end
 end
 


### PR DESCRIPTION
Allow items to be added to exhibits via iiif v3 manifests.

This PR adds a sort of factory into Spotlight::Resources::IiifService so that it may return either a v2 or a v3 manifest object (via the iiif-presentation gem). A new manifest v3 class is split out and inherits from the previously-existing manifest class. The metadata class is configurable and both manifest classes use the same configuration. So rather than add a new metadata class for v3 I made it more flexible -- it already had notes about handling v3-type json-ld values. However, if we wanted to add an additional configuration for the metadata class, we could split that into 2 different classes.

closes #3482

screenshot of a successfully ingested item in my dev instance:

<img width="2251" height="2120" alt="Screenshot 2025-09-25 at 09-34-36 A Map of the British and French settlements in North America - IIIF V3 - Blacklight" src="https://github.com/user-attachments/assets/71f4cab8-1cd5-470a-8905-c1d6a8a572ad" />

