### PR TITLE
Remove conditional checks for Blacklight 7 vs 8

### DIFF
--- a/app/controllers/spotlight/browse_controller.rb
+++ b/app/controllers/spotlight/browse_controller.rb
@@ -20,11 +20,7 @@ module Spotlight
     before_action :swap_actions_configuration, only: :show
 
     before_action do
-      if Blacklight::VERSION > '8'
-        blacklight_config.track_search_session.storage = false
-      else
-        blacklight_config.track_search_session = false
-      end
+      blacklight_config.track_search_session.storage = false
       blacklight_config.view.gallery.classes = 'row-cols-2 row-cols-md-4' if blacklight_config.view.key? :gallery
       blacklight_config.action_mapping.default = blacklight_config.index
       blacklight_config.action_mapping.show = blacklight_config.index

--- a/app/controllers/spotlight/catalog_controller.rb
+++ b/app/controllers/spotlight/catalog_controller.rb
@@ -24,14 +24,10 @@ module Spotlight
     before_action :load_document, only: %i[edit update make_private make_public manifest]
 
     before_action only: :show do
-      # Substitute the default document component with the custom one for Blacklight 8,
-      # and add the necessary partials for Blacklight 7 (if they haven't configured the document component)
+      # Substitute the default document component with the custom one for Blacklight 8
+      # (if they haven't configured the document component)
       if blacklight_config.show.document_component.nil? || blacklight_config.show.document_component == Blacklight::DocumentComponent
-        if Blacklight::VERSION > '8'
-          blacklight_config.show.document_component = Spotlight::DocumentComponent
-        else
-          blacklight_config.show.partials.unshift 'curation_mode_toggle'
-        end
+        blacklight_config.show.document_component = Spotlight::DocumentComponent
       end
     end
 
@@ -42,13 +38,9 @@ module Spotlight
                                            partials: [:index_compact],
                                            document_actions: [])
       end
-      blacklight_config.view.admin_table.document_component ||= Spotlight::DocumentAdminTableComponent
 
-      if Blacklight::VERSION > '8'
-        blacklight_config.track_search_session.storage = false
-      else
-        blacklight_config.track_search_session = false
-      end
+      blacklight_config.view.admin_table.document_component ||= Spotlight::DocumentAdminTableComponent
+      blacklight_config.track_search_session.storage = false
 
       unless blacklight_config.sort_fields.key? :timestamp
         blacklight_config.add_sort_field :timestamp, default: true,

--- a/app/controllers/spotlight/dashboards_controller.rb
+++ b/app/controllers/spotlight/dashboards_controller.rb
@@ -16,11 +16,7 @@ module Spotlight
 
       blacklight_config.index.document_component = Spotlight::DocumentAdminTableComponent
       blacklight_config.index.document_actions = []
-      if Blacklight::VERSION > '8'
-        blacklight_config.track_search_session.storage = false
-      else
-        blacklight_config.track_search_session = false
-      end
+      blacklight_config.track_search_session.storage = false
     end
 
     def show

--- a/app/helpers/spotlight/main_app_helpers.rb
+++ b/app/helpers/spotlight/main_app_helpers.rb
@@ -4,11 +4,7 @@ module Spotlight
   ##
   # Helpers that are injected into the main application (because they used in layouts)
   module MainAppHelpers
-    if Blacklight.version < '8'
-      include Blacklight::BlacklightHelperBehavior
-    else
-      include Blacklight::DocumentHelperBehavior
-    end
+    include Blacklight::DocumentHelperBehavior
     include Spotlight::NavbarHelper
     include Spotlight::MastheadHelper
 

--- a/app/views/spotlight/catalog/_document_admin_table.html.erb
+++ b/app/views/spotlight/catalog/_document_admin_table.html.erb
@@ -10,10 +10,6 @@
     </tr>
   </thead>
 
-  <% if Blacklight.version < '8.0' %>
-    <%= render (view_config.document_component || Spotlight::DocumentAdminTableComponent).with_collection(documents) %>
-  <% else %>
-    <% document_presenters = documents.map { |doc| document_presenter(doc) } -%>
-    <%= render view_config.document_component.with_collection(document_presenters) %>
-  <% end %>
+  <% document_presenters = documents.map { |doc| document_presenter(doc) } -%>
+  <%= render view_config.document_component.with_collection(document_presenters) %>
 </table>

--- a/app/views/spotlight/catalog/edit.html.erb
+++ b/app/views/spotlight/catalog/edit.html.erb
@@ -1,13 +1,8 @@
 <div class="container">
   <div class="row">
     <%- view_config = blacklight_config.view_config(action_name: :edit) %>
-    <%= render (view_config.document_component || Blacklight::DocumentComponent).new((Blacklight.version > '8.0' ? :document : :presenter) => document_presenter(@document), classes: ['col-md-8'], component: :div, show: true, partials: view_config.partials) do |component| %>
+    <%= render (view_config.document_component || Blacklight::DocumentComponent).new(document: document_presenter(@document), classes: ['col-md-8'], component: :div, show: true, partials: view_config.partials) do |component| %>
       <% component.with_title(as: 'h1', classes: '', link_to_document: false) %>
-      <% component.with_body do %>
-        <% view_config.partials.each do |view_partial| %>
-          <%= render_document_partial @document, view_partial, component: component, document_counter: 1 %>
-        <% end %>
-      <% end if Blacklight.version < '8.0' && view_config.document_component.blank? %>
     <% end %>
     <div class="col-md-4">
       <%= render 'edit_default', document: @document %>

--- a/app/views/spotlight/sir_trevor/blocks/_embedded_document.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_embedded_document.html.erb
@@ -1,6 +1,6 @@
 <div class="box" data-id="<%= document.id %>">
   <% view_config = blacklight_config.view_config(:embed) %>
-  <%= render (view_config.document_component || Spotlight::SolrDocumentLegacyEmbedComponent).new((Blacklight.version > '8.0' ? :document : :presenter) => document_presenter(document, view_config: view_config), counter: nil, block: local_assigns[:block]) do |component| %>
+  <%= render (view_config.document_component || Spotlight::SolrDocumentLegacyEmbedComponent).new(document: document_presenter(document, view_config: view_config), counter: nil, block: local_assigns[:block]) do |component| %>
     <% component.with_partial do %>
       <%= render_document_partials document, view_config.partials, component: component, document_counter: nil, view_config: view_config, block: local_assigns[:block], **(view_config.locals) %>
     <% end if view_config&.partials&.any? %>

--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -264,31 +264,16 @@ module Spotlight
 
     config.spambot_honeypot_email_field = :email_address
 
-    if Blacklight::VERSION > '8'
-      Blacklight::Configuration.default_configuration do
-        # Field containing the last modified date for a Solr document
-        Blacklight::Configuration.default_values[:index].timestamp_field ||= 'timestamp'
+    Blacklight::Configuration.default_configuration do
+      # Field containing the last modified date for a Solr document
+      Blacklight::Configuration.default_values[:index].timestamp_field ||= 'timestamp'
 
-        # Default configuration for the browse view
-        Blacklight::Configuration.property :browse, default: Blacklight::OpenStructWithHashAccess.new(document_actions: [])
+      # Default configuration for the browse view
+      Blacklight::Configuration.property :browse, default: Blacklight::OpenStructWithHashAccess.new(document_actions: [])
 
-        Blacklight::Configuration.default_values[:search_state_fields] ||= []
-        Blacklight::Configuration.default_values[:search_state_fields] += %i[id exhibit_id browse_category_id]
-        Blacklight::Configuration.default_values[:skip_link_component] = Spotlight::SkipLinkComponent
-      end
-    else
-      config.to_prepare do
-        Blacklight::Configuration.try(:initialize_default_configuration) unless Blacklight::Configuration.try(:initialized_default_configuration?)
-
-        # Field containing the last modified date for a Solr document
-        Blacklight::Configuration.default_values[:index].timestamp_field ||= 'timestamp'
-
-        # Default configuration for the browse view
-        Blacklight::Configuration.default_values[:browse] ||= Blacklight::OpenStructWithHashAccess.new(document_actions: [])
-
-        Blacklight::Configuration.default_values[:search_state_fields] ||= []
-        Blacklight::Configuration.default_values[:search_state_fields] += %i[id exhibit_id browse_category_id]
-      end
+      Blacklight::Configuration.default_values[:search_state_fields] ||= []
+      Blacklight::Configuration.default_values[:search_state_fields] += %i[id exhibit_id browse_category_id]
+      Blacklight::Configuration.default_values[:skip_link_component] = Spotlight::SkipLinkComponent
     end
 
     # make blacklight configuration play nice with bootstrap_form

--- a/spec/controllers/spotlight/catalog_controller_spec.rb
+++ b/spec/controllers/spotlight/catalog_controller_spec.rb
@@ -79,13 +79,6 @@ RSpec.describe Spotlight::CatalogController, type: :controller do
         expect(response).to be_successful
       end
 
-      it 'adds the curation widget for legacy applications' do
-        skip if Blacklight::VERSION > '8'
-
-        get :show, params: { exhibit_id: exhibit, id: 'dq287tq6352' }
-        expect(controller.blacklight_config.show.partials.first).to eq 'curation_mode_toggle'
-      end
-
       it 'does not have a solr_json serialization' do
         get :show, params: { exhibit_id: exhibit, id: 'dq287tq6352', format: :solr_json }
         expect(response).not_to be_successful


### PR DESCRIPTION
Spotlight 5 does not support Blacklight 7 so we can remove conditionals that were added to maintain backwards compatibility.
