### PR TITLE
Fix Blacklight version check

### DIFF
--- a/app/views/spotlight/sir_trevor/blocks/_embedded_document.html.erb
+++ b/app/views/spotlight/sir_trevor/blocks/_embedded_document.html.erb
@@ -3,6 +3,6 @@
   <%= render (view_config.document_component || Spotlight::SolrDocumentLegacyEmbedComponent).new(document: document_presenter(document, view_config: view_config), counter: nil, block: local_assigns[:block]) do |component| %>
     <% component.with_partial do %>
       <%= render_document_partials document, view_config.partials, component: component, document_counter: nil, view_config: view_config, block: local_assigns[:block], **(view_config.locals) %>
-    <% end if Blacklight.version < '9.0' && view_config&.partials&.any? %>
+    <% end if Blacklight::VERSION < '9.0' && view_config&.partials&.any? %>
   <% end %>
 </div>


### PR DESCRIPTION
`Blacklight.version` no longer works.

<img width="2758" height="1210" alt="Screenshot 2025-10-03 at 11 42 50 AM" src="https://github.com/user-attachments/assets/fac9e05a-3d23-44bc-a21e-a348ccf66021" />
