### PR TITLE
Return error on exhibit creation failure to satisfy downstream Turbo

### DIFF
--- a/app/controllers/spotlight/exhibits_controller.rb
+++ b/app/controllers/spotlight/exhibits_controller.rb
@@ -54,6 +54,7 @@ module Spotlight
       build_initial_exhibit_contact_emails
     end
 
+    # rubocop:disable Metrics/AbcSize
     def create
       @exhibit.attributes = exhibit_params
 
@@ -61,9 +62,12 @@ module Spotlight
         @exhibit.roles.create user: current_user, role: 'admin' if current_user
         redirect_to spotlight.exhibit_dashboard_path(@exhibit), notice: t(:'helpers.submit.exhibit.created', model: @exhibit.class.model_name.human.downcase)
       else
-        render action: :new
+        flash.now[:alert] = t('spotlight.exhibits.new_exhibit_form.errors.slug_taken') if @exhibit.errors[:slug].present?
+
+        render :new, status: :unprocessable_entity
       end
     end
+    # rubocop:enable Metrics/AbcSize
 
     def update
       if @exhibit.update(exhibit_params)

--- a/app/models/spotlight/exhibit.rb
+++ b/app/models/spotlight/exhibit.rb
@@ -28,7 +28,7 @@ module Spotlight
     end
 
     validates :title, presence: true, if: -> { I18n.locale == I18n.default_locale }
-    validates :slug, uniqueness: true
+    validates :slug, uniqueness: { message: I18n.t('spotlight.exhibits.new_exhibit_form.errors.slug_taken') }
     validates :theme, inclusion: { in: Spotlight::Engine.config.exhibit_themes }, allow_blank: true
 
     after_validation :move_friendly_id_error_to_slug

--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -23,6 +23,12 @@ en:
       spotlight/page:
         display_sidebar?: Show sidebar
         display_title: Show title
+    errors:
+      models:
+        spotlight/exhibit:
+          attributes:
+            slug:
+              taken: Slug is already taken.
     help:
       spotlight/exhibit:
         tag_list: Enter tags separated by commas.
@@ -616,6 +622,8 @@ en:
       new:
         page_title: Create a new exhibit
       new_exhibit_form:
+        errors:
+          slug_taken: Slug is already taken. Please choose another.
         fields:
           slug:
             help_block: A hyphenated name to be displayed in the URL for the exhibit (e.g., "maps-of-africa").

--- a/spec/features/create_exhibit_spec.rb
+++ b/spec/features/create_exhibit_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe 'Create a new exhibit', type: :feature do
 
     find('input[name="commit"]').click
 
-    expect(page).to have_content 'has already been taken'
+    expect(page).to have_content 'Slug is already taken'
   end
 
   it 'suggests a slug based on the title', js: true do

--- a/spec/features/feature_page_spec.rb
+++ b/spec/features/feature_page_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe 'Feature page', type: :feature, versioning: true do
       end
     end
 
-    it 'releases the lock when the lock holder cancels edits', js: true do
+    it 'releases the lock when the lock holder cancels edits', :js do
       # open the edit page
       visit spotlight.edit_exhibit_feature_page_path(feature_page.exhibit, feature_page)
 


### PR DESCRIPTION
This is related to an issue downstream in Stanford's Spotlight instance https://github.com/sul-dlss/exhibits/issues/2988

Our application is Turbo-enabled, so the return value in the case of an error/duplicate slug on exhibit creation was not handled well. This adds a response type that can be handled by Turbo, and also adds an error message.

<img width="1376" height="719" alt="Screenshot 2025-12-05 at 10 59 34 AM" src="https://github.com/user-attachments/assets/15e416b0-87c3-4e08-861c-232140794074" />


I followed the Rubocop rule and moved the message into locales. I don't know your policy on adding it to other languages before merging.