### PR TITLE
Remove unused multi up item grid styles

### DIFF
--- a/app/assets/stylesheets/spotlight/_multi_up_item_grid.scss
+++ b/app/assets/stylesheets/spotlight/_multi_up_item_grid.scss
@@ -1,33 +1,3 @@
-.item-grid-admin {
-  .field {
-    input[type='text'] {
-      width: 89%;
-    }
-
-    .twitter-typeahead {  
-      margin-bottom: 2*$spacer;
-    }
-  }
-  .field-select {
-    margin-top: 2*$spacer;
-    select {
-      display: inline;
-      width: auto;
-    }
-  }
-  .dd3-item {
-    margin-bottom: 2*$spacer;
-  }
-}
-// Hide the secondary caption field
-// for the Features block so we can
-// re-use the rest from the generic
-// multi-up item grid.
-[data-type='item-features'] {
-  .secondary-caption {
-    display: none;
-  }
-}
 .spotlight-flexbox {
   display: -webkit-box;
   display: -moz-box;


### PR DESCRIPTION
This block type was added in https://github.com/projectblacklight/spotlight/pull/281 and no longer exists. Unfortunately the remaining `spotlight-flexbox` styles in that file are spilling over into other block types.