### PR TITLE
Remove after_save from featured image

### DIFF
--- a/app/models/spotlight/featured_image.rb
+++ b/app/models/spotlight/featured_image.rb
@@ -24,13 +24,6 @@ module Spotlight
       Spotlight::TemporaryImage.find(upload_id).delete if upload_id.present?
     end
 
-    after_save do
-      if image.present?
-        image.cache! unless image.cached?
-        image.store!
-      end
-    end
-
     after_save :bust_containing_resource_caches
 
     attr_accessor :upload_id


### PR DESCRIPTION
Ref https://github.com/sul-dlss/exhibits/issues/3006, where we noticed that featured images that were created prior to the addition of CarrierWave validations were having the new validations applied every time the page was saved, even with no change to the image. This is because pages [accept nested attributes for the thumb](https://github.com/projectblacklight/spotlight/blob/1ac2eca27f7443bced31e4548dbe82ebf14d395f/app/models/spotlight/page.rb#L41C97-L41C112) and `iiif_tilesource` will be present.

This `after_save` was added in https://github.com/projectblacklight/spotlight/pull/1053, ostensibly to handle some issue with versions. 

That version handling was removed in https://github.com/projectblacklight/spotlight/pull/1498 when switching to the IIIF cropper setup we use today.

Triggering `cache!`/`store!` in `after_save` is another source of uncaught CarrierWave `UploadError` errors for sites using CarrierWave validations. I don't see a need this behavior any more, we can let CarrierWave handle the storage in the assignment.