### PR TITLE
Preconfigure the test app to use Solid Queue/Mission Control - Jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ The `spec:prepare` task generates css assets for use by the tests. You can delet
 
 Once you are set up, you can also run `rubocop` to enforce consistent coding style.
 
+The test app comes with [Solid Queue](https://github.com/rails/solid_queue) configured as the backend for [Active Job](https://edgeguides.rubyonrails.org/active_job_basics.html). [Mission Control - Jobs](https://github.com/rails/mission_control-jobs), the jobs dashboard, is available at http://localhost:3000/jobs.
 
 ### Individual commands
 


### PR DESCRIPTION
### Description
This pre-configures Solid Queue/Mission Control - Jobs for the test app. This could be a potential quality of life improvement for developers. It's been brought up in the past that the behavior of jobs (e.g., indexing & indexing progress) can be confusing when using the test app for development without an Active Job backend installed & configured.

This is only for the test app in the development environment. It does not impact [template installs](https://github.com/projectblacklight/spotlight?tab=readme-ov-file#installation).