### PR TITLE
Add configuration for RTL (right-to-left) HTML 'dir' attribute

### DIFF
--- a/app/helpers/spotlight/main_app_helpers.rb
+++ b/app/helpers/spotlight/main_app_helpers.rb
@@ -8,6 +8,20 @@ module Spotlight
     include Spotlight::NavbarHelper
     include Spotlight::MastheadHelper
 
+    def html_tag_attributes
+      return {} unless rtl_enabled?
+
+      rtl_locale? ? { dir: 'rtl' } : {}
+    end
+
+    def rtl_enabled?
+      Spotlight::Engine.config.rtl_enabled || false
+    end
+
+    def rtl_locale?
+      Spotlight::Engine.config.rtl_locales.include?(I18n.locale.to_sym)
+    end
+
     def on_browse_page?
       params[:controller] == 'spotlight/browse'
     end

--- a/lib/generators/spotlight/templates/config/initializers/spotlight_initializer.rb
+++ b/lib/generators/spotlight/templates/config/initializers/spotlight_initializer.rb
@@ -103,3 +103,8 @@
 # Spotlight::Engine.config.page_configurations = {
 #   'my-local-config': ->(context) { context.my_custom_data_path(context.current_exhibit) }
 # }
+#
+# ==> RTL (right-to-left) configuration
+# When enabled, adds dir="rtl" to html_tag_attributes for locales listed in rtl_locales.
+# Spotlight::Engine.config.rtl_enabled = true
+# Spotlight::Engine.config.rtl_locales = %i[ar]

--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -230,6 +230,10 @@ module Spotlight
     # add could add an available locale which could break things if unexpected.
     config.i18n.available_locales = config.i18n_locales.keys
 
+    # When enabled, adds dir="rtl" to html_tag_attributes for locales listed in rtl_locales.
+    config.rtl_enabled = false
+    config.rtl_locales = %i[ar]
+
     # Copy of JbuilderHandler tweaked to spit out YAML for translation exports
     class TranslationYamlHandler
       cattr_accessor :default_format

--- a/spec/helpers/spotlight/main_app_helpers_spec.rb
+++ b/spec/helpers/spotlight/main_app_helpers_spec.rb
@@ -99,4 +99,86 @@ RSpec.describe Spotlight::MainAppHelpers, type: :helper do
       end
     end
   end
+
+  describe '#html_tag_attributes' do
+    subject { helper.html_tag_attributes }
+
+    context 'when rtl_enabled? is false' do
+      before { allow(helper).to receive(:rtl_enabled?).and_return(false) }
+
+      it 'does not set dir' do
+        expect(subject).not_to have_key(:dir)
+      end
+    end
+
+    context 'when rtl_enabled? is true' do
+      before { allow(helper).to receive(:rtl_enabled?).and_return(true) }
+
+      context 'with an RTL locale' do
+        before { allow(helper).to receive(:rtl_locale?).and_return(true) }
+
+        it 'sets dir to rtl' do
+          expect(subject[:dir]).to eq 'rtl'
+        end
+      end
+
+      context 'with an LTR locale' do
+        before { allow(helper).to receive(:rtl_locale?).and_return(false) }
+
+        it 'does not set dir' do
+          expect(subject).not_to have_key(:dir)
+        end
+      end
+    end
+  end
+
+  describe '#rtl_enabled?' do
+    subject { helper.rtl_enabled? }
+
+    context 'when rtl_enabled is false' do
+      before { allow(Spotlight::Engine.config).to receive_messages(rtl_enabled: false) }
+
+      it 'returns false' do
+        expect(subject).to be false
+      end
+    end
+
+    context 'when rtl_enabled is true' do
+      before { allow(Spotlight::Engine.config).to receive_messages(rtl_enabled: true) }
+
+      it 'returns true' do
+        expect(subject).to be true
+      end
+    end
+
+    context 'when rtl_enabled is unset' do
+      before { allow(Spotlight::Engine.config).to receive_messages(rtl_enabled: nil) }
+
+      it 'returns false' do
+        expect(subject).to be false
+      end
+    end
+  end
+
+  describe '#rtl_locale?' do
+    subject { helper.rtl_locale? }
+
+    before { allow(Spotlight::Engine.config).to receive_messages(rtl_locales: %i[ar]) }
+
+    context 'when the locale is in the rtl_locales list' do
+      before { allow(I18n).to receive(:locale).and_return(:ar) }
+
+      it 'returns true' do
+        expect(subject).to be true
+      end
+    end
+
+    context 'when the locale is not in the rtl_locales list' do
+      before { allow(I18n).to receive(:locale).and_return(:en) }
+
+      it 'returns false' do
+        expect(subject).to be false
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Description
Adds a configuration option to enable/disable RTL (right-to-left) as well as a list of locales that should be used for RTL when enabled.

Ref https://github.com/projectblacklight/spotlight/issues/3526, https://github.com/projectblacklight/spotlight/issues/3506
