### PR TITLE
Separate specs so they pass more reliably

### DIFF
--- a/spec/features/javascript/blocks/featured_browse_categories_block_spec.rb
+++ b/spec/features/javascript/blocks/featured_browse_categories_block_spec.rb
@@ -18,22 +18,25 @@ RSpec.describe 'Featured Browse Category Block', js: true, type: :feature do
   it 'allows a curator to select from existing browse categories' do
     check 'Include item counts?'
 
+    fill_in_typeahead_field with: 'Title2'
+
+    save_page_changes
+
+    expect(page).to have_css('.category-title', text: search2.title)
+    expect(page).to have_css('.item-count', text: /\d+ items/i)
+
+    expect(page).to be_axe_clean.within '#content'
+  end
+
+  it 'toggles visibility of individual categories' do
     fill_in_typeahead_field with: 'Title1'
 
     within(:css, '.card') do
       uncheck 'Display?'
     end
-
-    fill_in_typeahead_field with: 'Title2'
-
     save_page_changes
 
-    # Documents should exist
     expect(page).to have_no_css('.category-title', text: search1.title)
-    expect(page).to have_css('.category-title', text: search2.title)
-    expect(page).to have_css('.item-count', text: /\d+ items/i)
-
-    expect(page).to be_axe_clean.within '#content'
   end
 
   it 'allows the curator to omit document counts' do

--- a/spec/features/javascript/blocks/link_to_search_block_spec.rb
+++ b/spec/features/javascript/blocks/link_to_search_block_spec.rb
@@ -18,22 +18,25 @@ RSpec.describe 'Link to Search Block', js: true, type: :feature do
   it 'allows a curator to select from existing browse categories' do
     check 'Include item counts?'
 
+    fill_in_typeahead_field with: 'Title2'
+
+    save_page_changes
+
+    expect(page).to have_css('.category-title', text: search2.title)
+    expect(page).to have_css('.item-count', text: /\d+ items/i)
+
+    expect(page).to be_axe_clean.within '#content'
+  end
+
+  it 'toggles visibility of individual categories' do
     fill_in_typeahead_field with: 'Title1'
 
     within(:css, '.card') do
       uncheck 'Display?'
     end
-
-    fill_in_typeahead_field with: 'Title2'
-
     save_page_changes
 
-    # Documents should exist
     expect(page).to have_no_css('.category-title', text: search1.title)
-    expect(page).to have_css('.category-title', text: search2.title)
-    expect(page).to have_css('.item-count', text: /\d+ items/i)
-
-    expect(page).to be_axe_clean.within '#content'
   end
 
   it 'allows the curator to omit document counts' do


### PR DESCRIPTION
These specs were failing for me locally. Separating the behavior/expectations makes them more reliable.