### PR TITLE
Set object-fit to contain so carousel images maintain aspect ratio at smaller screen widths

### DIFF
--- a/app/assets/stylesheets/spotlight/_slideshow_block.scss
+++ b/app/assets/stylesheets/spotlight/_slideshow_block.scss
@@ -5,6 +5,7 @@
     margin-left: auto;
     margin-right: auto;
     max-width: 100%;
+    object-fit: contain;
   }
 
   .carousel-caption {


### PR DESCRIPTION
Fixes #3635 

Before:
<img width="491" height="572" alt="Screenshot 2026-03-10 at 1 35 41 PM" src="https://github.com/user-attachments/assets/04ffe301-fa6b-494a-8ad3-408b641dd3b2" />

After:
<img width="485" height="502" alt="Screenshot 2026-03-10 at 4 20 03 PM" src="https://github.com/user-attachments/assets/5a8229fe-f3e7-4e1b-ae26-591e56e5756c" />
