### PR TITLE
Update ImageMagick info under Requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ If you have questions or are interested in contributing, please reach out to the
 - [Ruby](https://www.ruby-lang.org/) 3.2+
 - [Ruby on Rails](https://rubyonrails.org/) 7.1+
 - Java (11 or greater) *for Solr*
-- [ImageMagick](http://www.imagemagick.org/script/index.php) if using [riiif](https://github.com/sul-dlss/riiif) (current default for `config.iiif_service`)
-  - See [riiif] configuration instructions for alternatives to ImageMagick (ex. libvips)
+- [ImageMagick](http://www.imagemagick.org/script/index.php) if using riiif (current default for `config.iiif_service`)
+  - See [riiif](https://github.com/sul-dlss/riiif) configuration instructions for alternatives to ImageMagick (ex. libvips)
   - May also be needed if adding custom [carrierwave](https://github.com/carrierwaveuploader/carrierwave) uploaders to Spotlight
 
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,13 @@ If you have questions or are interested in contributing, please reach out to the
 
 ## Requirements
 
-1. [Ruby](https://www.ruby-lang.org/) 3.2+
-2. [Ruby on Rails](https://rubyonrails.org/) 7.1+
-3. Java (11 or greater) *for Solr*
-4. ImageMagick (http://www.imagemagick.org/script/index.php) due to [carrierwave](https://github.com/carrierwaveuploader/carrierwave#adding-versions)
+- [Ruby](https://www.ruby-lang.org/) 3.2+
+- [Ruby on Rails](https://rubyonrails.org/) 7.1+
+- Java (11 or greater) *for Solr*
+- [ImageMagick](http://www.imagemagick.org/script/index.php) if using [riiif](https://github.com/sul-dlss/riiif) (current default for `config.iiif_service`)
+  - See [riiif] configuration instructions for alternatives to ImageMagick (ex. libvips)
+  - May also be needed if adding custom [carrierwave](https://github.com/carrierwaveuploader/carrierwave) uploaders to Spotlight
+
 
 ## Installation
 


### PR DESCRIPTION
### Description

This updates the information about ImageMagick as a requirement. ImageMagick is not actually needed for carrierwave based on how Spotlight's uploaders are configured. It only required when further [manipulating images](https://github.com/carrierwaveuploader/carrierwave#manipulating-images), which we don't do by default.

ImageMagick, however, is needed for riiif. For that, though, there are also alternative configuration options available. 