### PR TITLE
Update search_service to use Blacklight 9's search_state (no user_params)

### DIFF
--- a/app/controllers/concerns/spotlight/search_helper.rb
+++ b/app/controllers/concerns/spotlight/search_helper.rb
@@ -3,10 +3,16 @@
 module Spotlight
   # ...
   module SearchHelper
-    def search_service(user_params = respond_to?(:search_state, true) ? search_state.to_h : {})
+    # @param [Blacklight::SearchState] state the search state to use. If not provided, builds one
+    #   from the search_state available in context (controller or model), or an empty state if
+    #   neither is available. Note: Spotlight::SearchState cannot be passed directly because it is
+    #   a SimpleDelegator (not a Blacklight::SearchState subclass), and Blacklight's
+    #   SearchBuilder#with performs an is_a? check.
+    # @return [Object] An instance of the configured search service
+    def search_service(state = Blacklight::SearchState.new(respond_to?(:search_state, true) ? search_state.to_h : {}, blacklight_config))
       klass = respond_to?(:search_service_class) ? search_service_class : Blacklight::SearchService
 
-      klass.new(config: blacklight_config, user_params:, **search_service_context)
+      klass.new(config: blacklight_config, search_state: state, **search_service_context)
     end
 
     # @return [Hash] a hash of context information to pass through to the search service

--- a/app/controllers/spotlight/pages_controller.rb
+++ b/app/controllers/spotlight/pages_controller.rb
@@ -118,10 +118,11 @@ module Spotlight
 
     # Add a Page specific search_results method that takes user params as
     # an option and passes that off to the search service to get results
-    # @param [Hash] the query parameters
+    # @param [Hash] user_params the query parameters
     # @return [Object] the search results object from the configured search service
     def search_results(user_params)
-      search_service(user_params).search_results
+      state = Blacklight::SearchState.new(user_params, blacklight_config)
+      search_service(state).search_results
     end
 
     def undo_link

--- a/app/models/spotlight/search.rb
+++ b/app/models/spotlight/search.rb
@@ -80,15 +80,15 @@ module Spotlight
     end
 
     def search_params
-      search_service.search_builder.with(base_search_state).merge(facet: false)
+      search_service.search_builder.with(search_state).merge(facet: false)
     end
 
     def merge_params_for_search(params, blacklight_config)
       user_query = Blacklight::SearchState.new(params, blacklight_config, nil).to_h
-      base_search_state.params_for_search(user_query).merge(user_query.slice(:page))
+      search_state.params_for_search(user_query).merge(user_query.slice(:page))
     end
 
-    def base_search_state
+    def search_state
       Blacklight::SearchState.new((query_params || {}).with_indifferent_access, blacklight_config, nil)
     end
 

--- a/spec/controllers/concerns/spotlight/search_helper_spec.rb
+++ b/spec/controllers/concerns/spotlight/search_helper_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+RSpec.describe Spotlight::SearchHelper do
+  # Spotlight::Search includes SearchHelper and provides a model-context includer with
+  # its own search_state method, making it a convenient vehicle for testing the concern.
+  let(:exhibit) { FactoryBot.create(:exhibit) }
+  let(:query_params) { { 'q' => 'cats' } }
+  let(:search) { exhibit.searches.build(title: 'Test', query_params:) }
+  let(:blacklight_config) { exhibit.blacklight_config }
+
+  describe '#search_service' do
+    let(:service) { search.search_service }
+
+    it 'returns an instance of the search service' do
+      expect(service).to be_a(Blacklight::SearchService)
+    end
+
+    it 'builds the service with a Blacklight::SearchState derived from context' do
+      expect(service.send(:search_state)).to be_a(Blacklight::SearchState)
+      expect(service.send(:search_state).to_h).to include('q' => 'cats')
+    end
+
+    context 'when given an explicit Blacklight::SearchState' do
+      let(:explicit_state) { Blacklight::SearchState.new({ 'q' => 'dogs' }, blacklight_config) }
+      let(:service) { search.search_service(explicit_state) }
+
+      it 'passes it through to the service unchanged' do
+        expect(service.send(:search_state)).to be explicit_state
+      end
+    end
+  end
+end

--- a/spec/models/spotlight/search_spec.rb
+++ b/spec/models/spotlight/search_spec.rb
@@ -65,6 +65,16 @@ RSpec.describe Spotlight::Search, type: :model do
     end
   end
 
+  describe '#search_state' do
+    it 'returns a Blacklight::SearchState' do
+      expect(subject.search_state).to be_a(Blacklight::SearchState)
+    end
+
+    it 'reflects the saved query_params' do
+      expect(subject.search_state.to_h).to include('f' => hash_including('genre_ssim' => ['map']))
+    end
+  end
+
   describe '#search_params' do
     it 'maps the search to the appropriate facet values' do
       expect(subject.search_params.to_hash).to include 'fq' => array_including('{!term f=genre_ssim}map')


### PR DESCRIPTION
Fixes #3590 

Possibly better fix for #3590 over #3591 

Blacklight 9 removed `user_params` from `SearchService#initialize` and now relies on `search_state`. This PR updates `SearchHelper#search_service` to accept a `Blacklight::SearchState` and builds the default from the view context.

`PagesController#search_results` is the only place that passed a hash and it now wraps it in a Blacklight::SearchState first.

Note: `Spotlight::SearchState` is a `SimpleDelegator`, not a `Blacklight::SearchState` subclass, so it fails `is_a?` checks in `SearchBuilder#with` so the `.to_h` conversion in the default value is intentional.