### PR TITLE
Add multi_json dependency

### DIFF
--- a/blacklight-spotlight.gemspec
+++ b/blacklight-spotlight.gemspec
@@ -39,6 +39,7 @@ these collections.)
   s.add_dependency 'iiif_manifest'
   s.add_dependency 'iiif-presentation', '>=1.4.1'
   s.add_dependency 'mini_magick'
+  s.add_dependency 'multi_json' # Peer dependency of Roar
   s.add_dependency 'nokogiri'
   s.add_dependency 'oauth2'
   s.add_dependency 'openseadragon', '>= 0.8.0'


### PR DESCRIPTION
Prevents this error:

```
Failure/Error: require 'roar/json'

Gem::LoadError:
  multi_json is not part of the bundle. Add it to your Gemfile.
# ./app/services/spotlight/exhibit_import_export_service.rb:4:in '<top (required)>'
# ./.internal_test_app/config/environment.rb:5:in '<top (required)>'
# ./spec/spec_helper.rb:7:in '<top (required)>'

```