### PR TITLE
Switch to using Ruby 3.3 syntax

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ AllCops:
     - "spec/internal/**/*"
     - "vendor/**/*"
     - "node_modules/**/*"
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.3
   DisplayCopNames: true
   SuggestExtensions: false
 

--- a/app/components/spotlight/solr_document_legacy_embed_component.rb
+++ b/app/components/spotlight/solr_document_legacy_embed_component.rb
@@ -5,8 +5,8 @@ module Spotlight
   class SolrDocumentLegacyEmbedComponent < Blacklight::DocumentComponent
     attr_reader :block_context
 
-    def initialize(*args, block: nil, **kwargs)
-      super(*args, **kwargs)
+    def initialize(*, block: nil, **)
+      super(*, **)
 
       @block_context = block
     end

--- a/app/controllers/concerns/spotlight/controller.rb
+++ b/app/controllers/concerns/spotlight/controller.rb
@@ -85,19 +85,19 @@ module Spotlight
       end
     end
 
-    def search_action_url(*args, **kwargs)
+    def search_action_url(*, **)
       if current_exhibit
-        exhibit_search_action_url(*args, **kwargs)
+        exhibit_search_action_url(*, **)
       else
-        main_app.search_catalog_url(*args, **kwargs)
+        main_app.search_catalog_url(*, **)
       end
     end
 
-    def search_facet_path(*args, **kwargs)
+    def search_facet_path(*, **)
       if current_exhibit
-        exhibit_search_facet_path(*args, **kwargs)
+        exhibit_search_facet_path(*, **)
       else
-        main_app.facet_catalog_url(*args, **kwargs)
+        main_app.facet_catalog_url(*, **)
       end
     end
 

--- a/app/controllers/spotlight/concerns/application_controller.rb
+++ b/app/controllers/spotlight/concerns/application_controller.rb
@@ -29,8 +29,8 @@ module Spotlight
         end
       end
 
-      def enabled_in_spotlight_view_type_configuration?(config, *args)
-        if config.respond_to?(:original) && !blacklight_configuration_context.evaluate_if_unless_configuration(config.original, *args)
+      def enabled_in_spotlight_view_type_configuration?(config, *)
+        if config.respond_to?(:original) && !blacklight_configuration_context.evaluate_if_unless_configuration(config.original, *)
           false
         elsif current_exhibit.nil? || is_a?(Spotlight::PagesController)
           true
@@ -39,10 +39,10 @@ module Spotlight
         end
       end
 
-      def field_enabled?(field, *args)
+      def field_enabled?(field, *)
         if !field.enabled
           false
-        elsif field.respond_to?(:original) && !blacklight_configuration_context.evaluate_if_unless_configuration(field.original, *args)
+        elsif field.respond_to?(:original) && !blacklight_configuration_context.evaluate_if_unless_configuration(field.original, *)
           false
         elsif field.is_a?(Blacklight::Configuration::SortField) || field.is_a?(Blacklight::Configuration::SearchField)
           field.enabled

--- a/app/helpers/spotlight/application_helper.rb
+++ b/app/helpers/spotlight/application_helper.rb
@@ -59,9 +59,9 @@ module Spotlight
 
     # Can search for named routes directly in the main app, omitting
     # the "main_app." prefix
-    def method_missing(method, *args, &)
+    def method_missing(method, *, &)
       if main_app_url_helper?(method)
-        main_app.send(method, *args)
+        main_app.send(method, *)
       else
         super
       end

--- a/app/helpers/spotlight/main_app_helpers.rb
+++ b/app/helpers/spotlight/main_app_helpers.rb
@@ -27,8 +27,8 @@ module Spotlight
     end
 
     # Expecting to upstream this override in https://github.com/projectblacklight/blacklight/pull/3343/files
-    def document_presenter(document, view_config: nil, **kwargs)
-      (view_config&.document_presenter_class || document_presenter_class(document)).new(document, self, view_config:, **kwargs)
+    def document_presenter(document, view_config: nil, **)
+      (view_config&.document_presenter_class || document_presenter_class(document)).new(document, self, view_config:, **)
     end
 
     def document_presenter_class(_document)

--- a/app/models/spotlight/contact_email.rb
+++ b/app/models/spotlight/contact_email.rb
@@ -33,8 +33,8 @@ module Spotlight
       errors.add :email, 'is not valid' if parsed.nil? || parsed.address != email || parsed.local == email
     end
 
-    def send_devise_notification(notification, *args)
-      notice = notification_mailer.send(notification, self, *args, exhibit:)
+    def send_devise_notification(notification, *)
+      notice = notification_mailer.send(notification, self, *, exhibit:)
       if notice.respond_to? :deliver_now
         notice.deliver_now
       else

--- a/app/models/spotlight/job_tracker.rb
+++ b/app/models/spotlight/job_tracker.rb
@@ -107,8 +107,8 @@ module Spotlight
 
     private
 
-    def number_with_delimiter(*args)
-      ActiveSupport::NumberHelper.number_to_delimited(*args)
+    def number_with_delimiter(*)
+      ActiveSupport::NumberHelper.number_to_delimited(*)
     end
   end
 end

--- a/app/models/spotlight/main_navigation.rb
+++ b/app/models/spotlight/main_navigation.rb
@@ -22,8 +22,8 @@ module Spotlight
       label.presence || default_label
     end
 
-    def default_label(**options)
-      I18n.t(:"spotlight.main_navigation.#{nav_type}", **options)
+    def default_label(**)
+      I18n.t(:"spotlight.main_navigation.#{nav_type}", **)
     end
 
     private

--- a/app/services/spotlight/etl/pipeline.rb
+++ b/app/services/spotlight/etl/pipeline.rb
@@ -58,8 +58,8 @@ module Spotlight
       # @param [Hash] data the initial data structure to pass through to the transform steps
       # @yield (optioanlly..) each transformed document after it is transformed but before
       #        it is sent to the loaders
-      def call(context, data: {}, cache: nil, &block)
-        executor(context, cache:).call(data:, &block)
+      def call(context, data: {}, cache: nil, &)
+        executor(context, cache:).call(data:, &)
       end
 
       ##

--- a/app/services/spotlight/etl/step.rb
+++ b/app/services/spotlight/etl/step.rb
@@ -37,8 +37,8 @@ module Spotlight
       end
       # rubocop:enable Metrics/MethodLength
 
-      def finalize(*args)
-        action.finalize(*args) if action.respond_to? :finalize
+      def finalize(*)
+        action.finalize(*) if action.respond_to? :finalize
       end
 
       private

--- a/blacklight-spotlight.gemspec
+++ b/blacklight-spotlight.gemspec
@@ -18,7 +18,7 @@ these collections.)
 
   s.files = Dir['{app,config,db,lib,vendor}/**/*', 'Rakefile', 'README.md', 'LICENSE', 'spec/{factories,fixtures}/*', 'spec/support/**/*']
 
-  s.required_ruby_version = '>= 3.1'
+  s.required_ruby_version = '>= 3.3'
 
   s.add_dependency 'activejob-status'
   s.add_dependency 'acts-as-taggable-on', '>= 5.0', '< 14'


### PR DESCRIPTION
### Description
Ruby versions below 3.3 are past EOL, so we can switch to using modern Ruby language conventions.