### PR TITLE
Add Japanese (ja) locale

### DIFF
--- a/config/locales/spotlight.en.yml
+++ b/config/locales/spotlight.en.yml
@@ -180,6 +180,7 @@ en:
     fr: French
     hu: Hungarian
     it: Italian
+    ja: Japanese
     nl: Dutch
     pt-BR: Portuguese - Brazil
     sq: Albanian

--- a/config/locales/spotlight.ja.yml
+++ b/config/locales/spotlight.ja.yml
@@ -1,0 +1,40 @@
+ja:
+  activemodel:
+    attributes:
+      spotlight/contact_form:
+        email: メールアドレス
+        message: お問い合わせ内容
+        name: お名前
+  helpers:
+    action:
+      cancel: キャンセル
+    submit:
+      contact_form:
+        create: 送信
+        created: 送信しました。ご意見ありがとうございます。
+  spotlight:
+    about_pages:
+      contacts:
+        header: 連絡先
+    browse:
+      search:
+        item_count:
+          one: "%{count} 件"
+          other: "%{count} 件"
+      search_box:
+        label: このカテゴリ内を検索
+        placeholder: 検索…
+        reset: 検索ボックスをクリア
+        submit: このカテゴリ内を検索
+        success:
+          expand_html: <a href="%{expand_search_url}">「%{browse_query}」で展示全体を検索</a>することもできます。
+          result_number_html: このカテゴリ内の <strong>%{parent_search_count} 件中 %{search_size} 件</strong>が検索条件に一致しました。
+        zero_results:
+          expand_html: <a href="%{clear_search_url}">検索条件をクリア</a>するか、<a href="%{expand_search_url}">「%{browse_query}」で展示全体を検索</a>してみてください。
+          result_number: このカテゴリ内に検索条件と一致する資料はありませんでした。
+    header_links:
+      contact: ご意見・お問い合わせ
+    shared:
+      report_a_problem:
+        honeypot_field_explanation: この入力欄は無視してください。スパム判定のために使用しています。ここに入力するとメッセージは送信されません。
+        title: お問い合わせ

--- a/lib/spotlight/engine.rb
+++ b/lib/spotlight/engine.rb
@@ -223,7 +223,8 @@ module Spotlight
       nl: 'Nederlands',
       'pt-BR': 'Português brasileiro',
       sq: 'Shqip',
-      zh: '中文'
+      zh: '中文',
+      ja: '日本語'
     }
 
     # Whitelisting the available_locales is necessary here, as any dependency we

--- a/spec/helpers/spotlight/languages_helper_spec.rb
+++ b/spec/helpers/spotlight/languages_helper_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Spotlight::LanguagesHelper, type: :helper do
         ['German', :de],
         ['Hungarian', :hu],
         ['Italian', :it],
+        ['Japanese', :ja],
         ['Portuguese - Brazil', :'pt-BR'],
         ['Spanish', :es]
       )


### PR DESCRIPTION
Adds a Japanese locale.

### What this changes

- `config/locales/spotlight.ja.yml` (new) — translates the same **20 keys** that the existing `de` / `es` / `fr` / `it` / `zh` locales cover: the contact form, the browse search box, the feedback link, and the honeypot explanation.
- `lib/spotlight/engine.rb` — registers `ja: '日本語'` in `config.i18n_locales`. Without this the locale file has no effect, because `config.i18n.available_locales` is set from that hash.

### Checks

- **Key parity**: compared against `spotlight.de.yml` — same 20 keys, nothing added or omitted.
- **Interpolations preserved**: `%{count}`, `%{browse_query}`, `%{expand_search_url}`, `%{search_size}`, `%{parent_search_count}`, `%{clear_search_url}`, and the markup inside the `_html` keys.
- **Pluralization**: Japanese has no grammatical plural, so `item_count.one` and `item_count.other` carry the same string — the same approach `spotlight.zh.yml` takes.
- **Ordering**: the new entry is placed after `zh: '中文'`, following the existing ordering of `i18n_locales` by display name.
- `bundle exec rubocop lib/spotlight/engine.rb` — no offenses.

### Scope

Deliberately limited to the public-facing subset the other non-English locales use; the admin UI is left in English, consistent with them. Happy to extend it if you would rather have fuller coverage.

The strings were checked against a running Spotlight instance with a Japanese-language exhibit.