### PR TITLE
Switch fixtures to not be on Stanfords VPN only access

### DIFF
--- a/spec/factories/contact_images.rb
+++ b/spec/factories/contact_images.rb
@@ -3,6 +3,6 @@
 FactoryBot.define do
   factory :contact_image, class: 'Spotlight::ContactImage' do
     image { Rack::Test::UploadedFile.new(File.expand_path(File.join('..', 'fixtures', 'avatar.png'), __dir__)) }
-    iiif_tilesource { 'https://exhibits-stage.stanford.edu/images/78' }
+    iiif_tilesource { 'http://127.0.0.1:9999/images/78' }
   end
 end

--- a/spec/factories/exhibit_thumbnails.rb
+++ b/spec/factories/exhibit_thumbnails.rb
@@ -3,6 +3,6 @@
 FactoryBot.define do
   factory :exhibit_thumbnail, class: 'Spotlight::ExhibitThumbnail' do
     image { Rack::Test::UploadedFile.new(File.expand_path(File.join('..', 'fixtures', 'avatar.png'), __dir__)) }
-    iiif_tilesource { 'https://exhibits-stage.stanford.edu/images/78' }
+    iiif_tilesource { 'http://127.0.0.1:9999/images/78' }
   end
 end

--- a/spec/factories/featured_images.rb
+++ b/spec/factories/featured_images.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :featured_image, class: 'Spotlight::FeaturedImage' do
     image { Rack::Test::UploadedFile.new(File.expand_path(File.join('..', 'fixtures', 'avatar.png'), __dir__)) }
-    iiif_tilesource { 'https://exhibits-stage.stanford.edu/images/78' }
+    iiif_tilesource { 'http://127.0.0.1:9999/images/78' }
   end
 
   factory :temporary_image, class: 'Spotlight::TemporaryImage' do


### PR DESCRIPTION
These sources are doomed to fail, but we can have them fail faster when they look at localhost. On the VPN only networks it waits until a connection timeout is reached.